### PR TITLE
Integrate the Launch form

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
@@ -1,6 +1,7 @@
 import {
     Button,
     DialogActions,
+    DialogContent,
     FormHelperText,
     Typography
 } from '@material-ui/core';
@@ -9,7 +10,12 @@ import { WaitForData } from 'components/common';
 import { ButtonCircularProgress } from 'components/common/ButtonCircularProgress';
 import { APIContextValue, useAPIContext } from 'components/data/apiContext';
 import { smallFontSize } from 'components/Theme';
-import { FilterOperationName, WorkflowId } from 'models';
+import {
+    FilterOperationName,
+    NamedEntityIdentifier,
+    SortDirection,
+    workflowSortFields
+} from 'models';
 import * as React from 'react';
 import { SearchableSelector } from './SearchableSelector';
 import { SimpleInput } from './SimpleInput';
@@ -20,18 +26,17 @@ import { workflowsToSearchableSelectorOptions } from './utils';
 
 const useStyles = makeStyles((theme: Theme) => ({
     footer: {
-        borderTop: `1px solid ${theme.palette.divider}`,
         padding: theme.spacing(2)
     },
     formControl: {
         padding: `${theme.spacing(1.5)}px 0`
     },
     header: {
-        borderBottom: `1px solid ${theme.palette.divider}`,
         padding: theme.spacing(2),
         width: '100%'
     },
     inputsSection: {
+        minHeight: theme.spacing(75),
         padding: theme.spacing(2)
     },
     inputLabel: {
@@ -60,7 +65,7 @@ function getComponentForInput(input: InputProps) {
 
 function generateFetchSearchResults(
     { listWorkflows }: APIContextValue,
-    workflowId: WorkflowId
+    workflowId: NamedEntityIdentifier
 ) {
     return async (query: string) => {
         const { entities: workflows } = await listWorkflows(workflowId, {
@@ -70,13 +75,13 @@ function generateFetchSearchResults(
                     operation: FilterOperationName.CONTAINS,
                     value: query
                 }
-            ]
+            ],
+            sort: {
+                key: workflowSortFields.createdAt,
+                direction: SortDirection.DESCENDING
+            }
         });
-        const options = workflowsToSearchableSelectorOptions(workflows);
-        if (options.length > 0) {
-            options[0].description = 'latest';
-        }
-        return options;
+        return workflowsToSearchableSelectorOptions(workflows);
     };
 }
 
@@ -102,7 +107,7 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                 <div className={styles.inputLabel}>Launch Workflow</div>
                 <Typography variant="h6">{state.workflowName}</Typography>
             </header>
-            <section className={styles.inputsSection}>
+            <DialogContent dividers={true} className={styles.inputsSection}>
                 <WaitForData
                     spinnerVariant="medium"
                     {...state.workflowOptionsLoadingState}
@@ -145,7 +150,7 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                         </WaitForData>
                     ) : null}
                 </WaitForData>
-            </section>
+            </DialogContent>
             <div className={styles.footer}>
                 {!!submissionState.lastError && (
                     <FormHelperText error={true}>

--- a/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
@@ -2,6 +2,7 @@ import {
     Button,
     DialogActions,
     DialogContent,
+    DialogTitle,
     FormHelperText,
     Typography
 } from '@material-ui/core';
@@ -102,11 +103,11 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
     };
 
     return (
-        <form className={styles.root}>
-            <header className={styles.header}>
+        <>
+            <DialogTitle disableTypography={true} className={styles.header}>
                 <div className={styles.inputLabel}>Launch Workflow</div>
                 <Typography variant="h6">{state.workflowName}</Typography>
-            </header>
+            </DialogTitle>
             <DialogContent dividers={true} className={styles.inputsSection}>
                 <WaitForData
                     spinnerVariant="medium"
@@ -183,6 +184,6 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                     </Button>
                 </DialogActions>
             </div>
-        </form>
+        </>
     );
 };

--- a/src/components/Launch/LaunchWorkflowForm/SearchableSelector.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/SearchableSelector.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         marginTop: theme.spacing(0.5),
         position: 'absolute',
         right: 0,
-        zIndex: 2
+        zIndex: theme.zIndex.tooltip
     },
     selectedItem: {
         fontWeight: 'bold'

--- a/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
@@ -41,6 +41,8 @@ const mockApi = mockAPIContextValue({
     listLaunchPlans: () => resolveAfter(500, { entities: [mockLaunchPlan] })
 });
 
+const onClose = () => console.log('Close');
+
 const stories = storiesOf('Launch/LaunchWorkflowForm', module);
 stories.addDecorator(story => (
     <APIContext.Provider value={mockApi}>
@@ -48,4 +50,6 @@ stories.addDecorator(story => (
     </APIContext.Provider>
 ));
 
-stories.add('Basic', () => <LaunchWorkflowForm workflowId={mockWorkflow.id} />);
+stories.add('Basic', () => (
+    <LaunchWorkflowForm onClose={onClose} workflowId={mockWorkflow.id} />
+));

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -1,9 +1,15 @@
 import { FetchableData, MultiFetchableState } from 'components/hooks';
-import { LaunchPlan, WorkflowExecutionIdentifier, WorkflowId } from 'models';
+import {
+    LaunchPlan,
+    NamedEntityIdentifier,
+    WorkflowExecutionIdentifier,
+    WorkflowId
+} from 'models';
 import { SearchableSelectorOption } from './SearchableSelector';
 
 export interface LaunchWorkflowFormProps {
-    workflowId: WorkflowId;
+    workflowId: NamedEntityIdentifier;
+    onClose(): void;
 }
 
 export interface LaunchWorkflowFormState {

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -215,6 +215,9 @@ export function useLaunchWorkflowFormState({
     const [selectedLaunchPlan, setLaunchPlan] = useState<
         SearchableSelectorOption<LaunchPlan>
     >();
+    const launchPlanData = selectedLaunchPlan
+        ? selectedLaunchPlan.data
+        : undefined;
 
     const workflowOptionsLoadingState = waitForAllFetchables([workflows]);
     const launchPlanOptionsLoadingState = waitForAllFetchables([launchPlans]);
@@ -233,10 +236,10 @@ export function useLaunchWorkflowFormState({
     };
 
     const launchWorkflow = async () => {
-        if (!selectedLaunchPlan) {
+        if (!launchPlanData) {
             throw new Error('Attempting to launch with no LaunchPlan');
         }
-        const launchPlanId = selectedLaunchPlan.data.id;
+        const launchPlanId = launchPlanData.id;
         const { domain, project } = workflowId;
         const response = await createWorkflowExecution({
             domain,
@@ -267,12 +270,12 @@ export function useLaunchWorkflowFormState({
     useEffect(
         () => {
             const parsedInputs =
-                selectedLaunchPlan && workflow.hasLoaded
-                    ? getInputs(workflow.value, selectedLaunchPlan.data)
+                launchPlanData && workflow.hasLoaded
+                    ? getInputs(workflow.value, launchPlanData)
                     : [];
             setParsedInputs(parsedInputs);
         },
-        [workflow.hasLoaded, workflow.value, selectedLaunchPlan]
+        [workflow.hasLoaded, workflow.value, launchPlanData]
     );
 
     // Once launch plans have been loaded, attempt to select the default

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -292,6 +292,16 @@ export function useLaunchWorkflowFormState({
         [workflow.hasLoaded, workflow.value, launchPlanData]
     );
 
+    // Once workflows have loaded, attempt to select the first option
+    useEffect(
+        () => {
+            if (workflowSelectorOptions.length > 0 && !selectedWorkflow) {
+                setWorkflow(workflowSelectorOptions[0]);
+            }
+        },
+        [workflows.value]
+    );
+
     // Once launch plans have been loaded, attempt to select the default
     // launch plan
     useEffect(

--- a/src/components/Workflow/WorkflowDetails/WorkflowDetails.tsx
+++ b/src/components/Workflow/WorkflowDetails/WorkflowDetails.tsx
@@ -78,7 +78,7 @@ export const WorkflowDetailsContainer: React.FC<WorkflowDetailsRouteParams> = ({
                     <WorkflowExecutions workflowId={workflowId} />
                 </div>
                 <Dialog
-                    scroll="body"
+                    scroll="paper"
                     maxWidth="sm"
                     fullWidth={true}
                     open={showLaunchForm}

--- a/src/components/Workflow/WorkflowDetails/WorkflowDetails.tsx
+++ b/src/components/Workflow/WorkflowDetails/WorkflowDetails.tsx
@@ -1,7 +1,9 @@
+import { Dialog } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { contentMarginGridUnits } from 'common/layout';
 import { WaitForData, withRouteParams } from 'components/common';
 import { useProject } from 'components/hooks';
+import { LaunchWorkflowForm } from 'components/Launch/LaunchWorkflowForm/LaunchWorkflowForm';
 import * as React from 'react';
 import { WorkflowDescription } from './WorkflowDescription';
 import { WorkflowDetailsHeader } from './WorkflowDetailsHeader';
@@ -46,6 +48,10 @@ export const WorkflowDetailsContainer: React.FC<WorkflowDetailsRouteParams> = ({
 }) => {
     const project = useProject(projectId);
     const styles = useStyles();
+    const [showLaunchForm, setShowLaunchForm] = React.useState(false);
+    const onLaunch = () => setShowLaunchForm(true);
+    const onCancelLaunch = () => setShowLaunchForm(false);
+
     const workflowId = {
         project: projectId,
         domain: domainId,
@@ -58,6 +64,7 @@ export const WorkflowDetailsContainer: React.FC<WorkflowDetailsRouteParams> = ({
                     project={project.value}
                     domainId={domainId}
                     workflowName={workflowName}
+                    onClickLaunch={onLaunch}
                 />
                 <div className={styles.metadataContainer}>
                     <div className={styles.descriptionContainer}>
@@ -70,6 +77,12 @@ export const WorkflowDetailsContainer: React.FC<WorkflowDetailsRouteParams> = ({
                 <div className={styles.executionsContainer}>
                     <WorkflowExecutions workflowId={workflowId} />
                 </div>
+                <Dialog maxWidth="sm" fullWidth={true} open={showLaunchForm}>
+                    <LaunchWorkflowForm
+                        onClose={onCancelLaunch}
+                        workflowId={workflowId}
+                    />
+                </Dialog>
             </WaitForData>
         </>
     );

--- a/src/components/Workflow/WorkflowDetails/WorkflowDetails.tsx
+++ b/src/components/Workflow/WorkflowDetails/WorkflowDetails.tsx
@@ -77,7 +77,12 @@ export const WorkflowDetailsContainer: React.FC<WorkflowDetailsRouteParams> = ({
                 <div className={styles.executionsContainer}>
                     <WorkflowExecutions workflowId={workflowId} />
                 </div>
-                <Dialog maxWidth="sm" fullWidth={true} open={showLaunchForm}>
+                <Dialog
+                    scroll="body"
+                    maxWidth="sm"
+                    fullWidth={true}
+                    open={showLaunchForm}
+                >
                     <LaunchWorkflowForm
                         onClose={onCancelLaunch}
                         workflowId={workflowId}

--- a/src/components/Workflow/WorkflowDetails/WorkflowDetailsHeader.tsx
+++ b/src/components/Workflow/WorkflowDetails/WorkflowDetailsHeader.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import * as classnames from 'classnames';
@@ -9,10 +10,12 @@ import { Link } from 'react-router-dom';
 import { Routes } from 'routes';
 
 const useStyles = makeStyles((theme: Theme) => ({
+    actionsContainer: {},
     headerContainer: {
         alignItems: 'center',
         display: 'flex',
         height: theme.spacing(5),
+        justifyContent: 'space-between',
         marginTop: theme.spacing(2),
         width: '100%'
     },
@@ -36,11 +39,13 @@ interface WorkflowDetailsHeaderProps {
     domainId: string;
     project: Project;
     workflowName: string;
+    onClickLaunch(): void;
 }
 
 /** Renders the workflow name and actions shown on the workflow details page */
 export const WorkflowDetailsHeader: React.FC<WorkflowDetailsHeaderProps> = ({
     domainId,
+    onClickLaunch,
     project,
     workflowName
 }) => {
@@ -66,6 +71,16 @@ export const WorkflowDetailsHeader: React.FC<WorkflowDetailsHeaderProps> = ({
                     <ArrowBack color="inherit" />
                 </Link>
                 <span className={styles.headerText}>{headerText}</span>
+            </div>
+            <div className={styles.actionsContainer}>
+                <Button
+                    color="primary"
+                    id="launch-workflow"
+                    onClick={onClickLaunch}
+                    variant="contained"
+                >
+                    Launch Workflow
+                </Button>
             </div>
         </div>
     );

--- a/src/models/Execution/api.ts
+++ b/src/models/Execution/api.ts
@@ -1,4 +1,4 @@
-import { Admin } from 'flyteidl';
+import { Admin, Core } from 'flyteidl';
 import {
     defaultPaginationConfig,
     getAdminEntity,
@@ -7,6 +7,7 @@ import {
 } from 'models/AdminEntity';
 import {
     endpointPrefixes,
+    Identifier,
     IdentifierScope,
     makeIdentifierPath,
     NameIdentifierScope
@@ -72,6 +73,37 @@ export const getExecutionData = (
         {
             path: `/data${makeExecutionPath(id)}`,
             messageType: Admin.WorkflowExecutionGetDataResponse
+        },
+        config
+    );
+
+interface CreateWorkflowExecutionArguments {
+    domain: string;
+    inputs: Core.ILiteralMap;
+    launchPlanId: Identifier;
+    project: string;
+}
+/** Submits a request to create a new `WorkflowExecution` using the provided
+ * LaunchPlan and input values.
+ */
+export const createWorkflowExecution = (
+    {
+        domain,
+        inputs,
+        launchPlanId: launchPlan,
+        project
+    }: CreateWorkflowExecutionArguments,
+    config?: RequestConfig
+) =>
+    postAdminEntity<
+        Admin.IExecutionCreateRequest,
+        Admin.ExecutionCreateResponse
+    >(
+        {
+            data: { project, domain, spec: { inputs, launchPlan } },
+            path: endpointPrefixes.execution,
+            requestMessageType: Admin.ExecutionCreateRequest,
+            responseMessageType: Admin.ExecutionCreateResponse
         },
         config
     );

--- a/src/models/Execution/api.ts
+++ b/src/models/Execution/api.ts
@@ -12,7 +12,7 @@ import {
     makeIdentifierPath,
     NameIdentifierScope
 } from 'models/Common';
-
+import { defaultExecutionPrincipal } from './constants';
 import {
     Execution,
     ExecutionData,
@@ -22,7 +22,6 @@ import {
     TaskExecutionIdentifier,
     WorkflowExecutionIdentifier
 } from './types';
-
 import {
     executionListTransformer,
     makeExecutionPath,
@@ -100,7 +99,15 @@ export const createWorkflowExecution = (
         Admin.ExecutionCreateResponse
     >(
         {
-            data: { project, domain, spec: { inputs, launchPlan } },
+            data: {
+                project,
+                domain,
+                spec: {
+                    inputs,
+                    launchPlan,
+                    metadata: { principal: defaultExecutionPrincipal }
+                }
+            },
             path: endpointPrefixes.execution,
             requestMessageType: Admin.ExecutionCreateRequest,
             responseMessageType: Admin.ExecutionCreateResponse

--- a/src/models/Execution/constants.ts
+++ b/src/models/Execution/constants.ts
@@ -29,3 +29,5 @@ export const executionSortFields = {
     createdAt: 'created_at',
     startedAt: 'started_at'
 };
+
+export const defaultExecutionPrincipal = 'flyteconsole';


### PR DESCRIPTION
* Added a button to the WorkflowDetailsHeader to initiate launch
* Added some state to WorkflowDetails to handle showing a MUI Dialog with our form inside it
* Changed some of the launch form components to use MUI Dialog* components instead.
* Updated props for the form so that a partial workflow id can be passed, as well as a close handler
* Updated styling of the form to make sure we have enough room to show the versions list.
* Implemented the API call for creating an execution
* Implemented logic in the form's submission handler
* Added sort queries for search results and the pre-populated workflow version list
* Moved my 'latest' tagging logic to the pre-populated list, where it belongs. 😅 
* Added an effect to select the latest version of the workflow by default so that the form should be able to load straight to inputs without any user action. They can always change the workflow version if desired.
![IntegratedLaunchForm](https://user-images.githubusercontent.com/1815175/64214672-402a2280-ce66-11e9-95b4-82fe69ad6f73.gif)
