### PR TITLE
Set a more reasonable minHeight on launch form contents

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         width: '100%'
     },
     inputsSection: {
-        minHeight: theme.spacing(75),
+        minHeight: theme.spacing(59),
         padding: theme.spacing(2)
     },
     inputLabel: {


### PR DESCRIPTION
On a laptop screen, the minimum height for the contents of the launch form cause some ugly scrolling behavior. Given the space used by the other elements, I chose a smaller minHeight to keep the dialog+padding inside of 900px.