### PR TITLE
Updated handling for execution inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.0.0",
         "@date-io/moment": "^1.3.9",
-        "@lyft/flyteidl": "^0.1.0",
+        "@lyft/flyteidl": "^0.16.0",
         "@material-ui/core": "^4.0.0",
         "@material-ui/icons": "^4.0.0",
         "@material-ui/pickers": "^3.2.2",

--- a/src/components/Executions/ExecutionInputsOutputsModal.tsx
+++ b/src/components/Executions/ExecutionInputsOutputsModal.tsx
@@ -36,6 +36,17 @@ enum TabId {
     OUTPUTS = 'outputs'
 }
 
+const RemoteExecutionInputs: React.FC<{ execution: Execution }> = ({
+    execution
+}) => {
+    const executionData = useWorkflowExecutionData(execution.id);
+    return (
+        <WaitForData {...executionData} spinnerVariant="none">
+            {() => <RemoteLiteralMapViewer blob={executionData.value.inputs} />}
+        </WaitForData>
+    );
+};
+
 const RemoteExecutionOutputs: React.FC<{ execution: Execution }> = ({
     execution
 }) => {
@@ -50,7 +61,13 @@ const RemoteExecutionOutputs: React.FC<{ execution: Execution }> = ({
 };
 
 const RenderInputs: React.FC<{ execution: Execution }> = ({ execution }) => {
-    return <LiteralMapViewer map={execution.closure.computedInputs} />;
+    // computedInputs is deprecated, but older data may still use that field.
+    // For new records, the inputs will always need to be fetched separately
+    return execution.closure.computedInputs ? (
+        <LiteralMapViewer map={execution.closure.computedInputs} />
+    ) : (
+        <RemoteExecutionInputs execution={execution} />
+    );
 };
 
 const RenderOutputs: React.FC<{ execution: Execution }> = ({ execution }) => {

--- a/src/models/Execution/api.ts
+++ b/src/models/Execution/api.ts
@@ -63,6 +63,10 @@ export const getExecution = (
         config
     );
 
+const emptyExecutionData: ExecutionData = {
+    inputs: {},
+    outputs: {}
+};
 /** Fetches data URLs for an `Execution` record */
 export const getExecutionData = (
     id: WorkflowExecutionIdentifier,
@@ -71,7 +75,11 @@ export const getExecutionData = (
     getAdminEntity<Admin.WorkflowExecutionGetDataResponse, ExecutionData>(
         {
             path: `/data${makeExecutionPath(id)}`,
-            messageType: Admin.WorkflowExecutionGetDataResponse
+            messageType: Admin.WorkflowExecutionGetDataResponse,
+            // Admin isn't guaranteed to populate both inputs and outputs,
+            // so ensure that a safe access is possible for each
+            transform: result =>
+                ({ ...emptyExecutionData, ...result } as ExecutionData)
         },
         config
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,10 +1795,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@lyft/flyteidl@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@lyft/flyteidl/-/flyteidl-0.1.0.tgz#7fd7e882c5448f3eea49dc9b16f2d71cbe5ad46f"
-  integrity sha512-cyOgIrEep7YZ75HiYlsjKXrDX9Xc8RAy4qhABKBpHGzt6cKyEmO7UknvGcq9UtCcPIDSVrjZASQDlOaZ9lsocA==
+"@lyft/flyteidl@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@lyft/flyteidl/-/flyteidl-0.16.0.tgz#60f4f195a847806a57726a5eab78e4cab7f92996"
+  integrity sha512-2Ps6LLv/F0J0IIesv+wY40luvc8f9+kuI1HdD4q1oGa/AZhfXjsKFmk8TvFoLw7cGd5K75L8QeGSSfGwZci7LQ==
 
 "@material-ui/core@^4.0.0":
   version "4.3.1"


### PR DESCRIPTION
lyft/flyteidl#13 deprecates the usage of `computed_inputs` to store the inputs of an execution directly on the record. In the future, the inputs will have to be fetched just like outputs. This is a backwards-compatible implementation that handles both cases.

* Updated the components which display WorkflowExecution inputs/outputs to check for the existence of inputs on the execution closure. If they aren't found, we will attempt to fetch them using the execution data endpoint.
* Updated the model layer for execution data to ensure that inputs/outputs alway have at least an empty object. The interface definition guarantees that those properties will exist, and the components are set up to handle the empty object case (but not the undefined property case)

TODO:
- [ ] Update flyteidl version once it's published