### PR TITLE
Add support for project descriptions

### DIFF
--- a/src/components/SelectProject/ProjectList.tsx
+++ b/src/components/SelectProject/ProjectList.tsx
@@ -1,18 +1,27 @@
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardHeader from '@material-ui/core/CardHeader';
+import {
+    Button,
+    Card,
+    CardActions,
+    CardContent,
+    Typography
+} from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import { ButtonLink } from 'components/common/ButtonLink';
 import { useCommonStyles } from 'components/common/styles';
 import { Project } from 'models/Project';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { Routes } from 'routes/routes';
+import { defaultProjectDescription } from './constants';
 
 const useStyles = makeStyles((theme: Theme) => ({
     projectCard: {
         textAlign: 'left',
         marginBottom: theme.spacing(2),
-        width: theme.spacing(36)
+        minWidth: theme.spacing(36),
+        maxWidth: theme.spacing(48),
+        '&:first-of-type': {
+            marginTop: theme.spacing(1)
+        }
     },
     projectTitle: {
         paddingBottom: 0
@@ -24,38 +33,42 @@ export interface ProjectListProps {
     projects: Project[];
 }
 
-const DomainLinks: React.FC<{ project: Project }> = ({ project }) => {
+const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
+    const styles = useStyles();
+    const commonStyles = useCommonStyles();
+    const description = !!project.description
+        ? project.description
+        : defaultProjectDescription;
     return (
-        <section>
-            {project.domains.map(({ id: domainId, name }, idx) => (
-                <span key={domainId}>
-                    {idx > 0 && <span>&nbsp;|&nbsp;</span>}
-                    <Link
+        <Card className={styles.projectCard} elevation={1}>
+            <CardContent>
+                <Typography variant="h6" component="h2" gutterBottom={true}>
+                    {project.name}
+                </Typography>
+                <Typography
+                    className={commonStyles.textWrapped}
+                    variant="body2"
+                    color="textSecondary"
+                    component="p"
+                >
+                    {description}
+                </Typography>
+            </CardContent>
+            <CardActions>
+                {project.domains.map(({ id: domainId, name }) => (
+                    <Button
+                        color="primary"
+                        key={domainId}
+                        component={ButtonLink}
                         to={Routes.ProjectDetails.sections.workflows.makeUrl(
                             project.id,
                             domainId
                         )}
                     >
                         {name}
-                    </Link>
-                </span>
-            ))}
-        </section>
-    );
-};
-
-const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
-    const styles = useStyles();
-    return (
-        <Card className={styles.projectCard}>
-            <CardHeader
-                className={styles.projectTitle}
-                title={project.name}
-                titleTypographyProps={{ variant: 'body1' }}
-            />
-            <CardContent>
-                <DomainLinks project={project} />
-            </CardContent>
+                    </Button>
+                ))}
+            </CardActions>
         </Card>
     );
 };

--- a/src/components/SelectProject/SelectProject.tsx
+++ b/src/components/SelectProject/SelectProject.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         margin: `${theme.spacing(2)} 0`
     },
     searchContainer: {
-        width: theme.spacing(36)
+        minWidth: theme.spacing(45)
     }
 }));
 

--- a/src/components/SelectProject/constants.ts
+++ b/src/components/SelectProject/constants.ts
@@ -1,0 +1,1 @@
+export const defaultProjectDescription = '(No description provided)';

--- a/src/components/common/ButtonLink.tsx
+++ b/src/components/common/ButtonLink.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import {
+    Link as RouterLink,
+    LinkProps as RouterLinkProps
+} from 'react-router-dom';
+
+export const ButtonLink = React.forwardRef<HTMLAnchorElement, RouterLinkProps>(
+    (props, ref) => <RouterLink innerRef={ref} {...props} />
+);


### PR DESCRIPTION
Project records now have optional description fields. This adds support for displaying the description in the cards shown in the project list. Projects with no description will show "(No description provided.)" as a placeholder.

* Added `ButtonLink` class to support using MUI link-style buttons with ReactRouter links under the hood
* Updated layout of cards in the projects list to look better with descriptions
* Updated the domain links to be Button-style links. This is more consistent with how MUI cards typically do actions

![image](https://user-images.githubusercontent.com/1815175/66616145-73a64e00-eb84-11e9-8d68-d3b4469b89e5.png)
