### PR TITLE
Fix project sorting to be case-insensitive

### DIFF
--- a/src/models/Project/api.ts
+++ b/src/models/Project/api.ts
@@ -13,5 +13,7 @@ export const listProjects = () =>
         // We want the returned list to be sorted ascending by name, but the
         // admin endpoint doesn't support sorting for projects.
         transform: ({ projects }: Admin.Projects) =>
-            sortBy(projects, 'name') as Project[]
+            sortBy(projects, project =>
+                `${project.name}`.toLowerCase()
+            ) as Project[]
     });

--- a/src/models/Project/test/api.test.ts
+++ b/src/models/Project/test/api.test.ts
@@ -1,0 +1,26 @@
+import { Admin } from 'flyteidl';
+import { emptyProject } from 'models/__mocks__/projectData';
+import { getAdminEntity } from '../../AdminEntity/AdminEntity';
+import { listProjects } from '../api';
+jest.mock('../../AdminEntity/AdminEntity.ts');
+
+const mockGetAdminEntity = getAdminEntity as jest.Mock;
+
+describe('Project.api', () => {
+    let projects: Admin.Project[];
+    beforeEach(() => {
+        projects = [
+            { ...emptyProject, id: 'projectb', name: 'B Project' },
+            { ...emptyProject, id: 'projecta', name: 'aproject' }
+        ];
+        mockGetAdminEntity.mockImplementation(({ transform }) =>
+            Promise.resolve(transform({ projects }))
+        );
+    });
+    describe('listProjects', () => {
+        it('sorts projects by case-insensitive name', async () => {
+            const projectsResult = await listProjects();
+            expect(projectsResult).toEqual([projects[1], projects[0]]);
+        });
+    });
+});

--- a/src/models/__mocks__/projectData.ts
+++ b/src/models/__mocks__/projectData.ts
@@ -1,5 +1,11 @@
 import { Domain, Project } from '../Project';
 
+export const emptyProject = {
+    id: 'emptyproject',
+    name: 'emptyproject',
+    domains: [],
+    description: ''
+};
 export const mockDomainIds = ['development', 'production'];
 export const mockProjectIds = Array.from(Array(10).keys()).map(
     idx => `project number ${idx}`


### PR DESCRIPTION
The api function for projects was relying on lodash `sortBy` to pluck the `name` property and sort by those values. This doesn't work quite correctly with mixed-case values ('BProject' would sort before 'aproject' because the ascii code point for 'B' comes before 'a'). To correct this, the iteratee was replaced with a function that returns the names values as lowercase.