### PR TITLE
Tasks view

### DIFF
--- a/src/components/Navigation/ProjectNavigation.tsx
+++ b/src/components/Navigation/ProjectNavigation.tsx
@@ -2,6 +2,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import { SvgIconProps } from '@material-ui/core/SvgIcon';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import DeviceHub from '@material-ui/icons/DeviceHub';
+import LinearScale from '@material-ui/icons/LinearScale';
 import * as classnames from 'classnames';
 import { withRouteParams } from 'components/common';
 import { useCommonStyles } from 'components/common/styles';
@@ -85,6 +86,23 @@ const ProjectNavigationImpl: React.FC<ProjectNavigationRouteParams> = ({
                 domainId
             ),
             text: 'Workflows'
+        },
+        {
+            icon: LinearScale,
+            isActive: (match, location) => {
+                const finalMatch = match
+                    ? match
+                    : matchPath(location.pathname, {
+                          path: Routes.TaskDetails.path,
+                          exact: false
+                      });
+                return !!finalMatch;
+            },
+            path: Routes.ProjectDetails.sections.tasks.makeUrl(
+                project.value.id,
+                domainId
+            ),
+            text: 'Tasks'
         }
     ];
 

--- a/src/components/Project/ProjectDetails.tsx
+++ b/src/components/Project/ProjectDetails.tsx
@@ -6,6 +6,7 @@ import { Project } from 'models';
 import * as React from 'react';
 import { Redirect, Route, Switch } from 'react-router';
 import { Routes } from 'routes';
+import { ProjectTasks } from './ProjectTasks';
 import { ProjectWorkflows } from './ProjectWorkflows';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -23,7 +24,7 @@ export interface ProjectDetailsRouteParams {
 export type ProjectDetailsProps = ProjectDetailsRouteParams;
 
 const entityTypeToComponent = {
-    tasks: ProjectWorkflows,
+    tasks: ProjectTasks,
     workflows: ProjectWorkflows
 };
 

--- a/src/components/Project/ProjectDetails.tsx
+++ b/src/components/Project/ProjectDetails.tsx
@@ -4,6 +4,8 @@ import { WaitForData, withRouteParams } from 'components/common';
 import { useProject, useQueryState } from 'components/hooks';
 import { Project } from 'models';
 import * as React from 'react';
+import { Redirect, Route, Switch } from 'react-router';
+import { Routes } from 'routes';
 import { ProjectWorkflows } from './ProjectWorkflows';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -20,9 +22,15 @@ export interface ProjectDetailsRouteParams {
 }
 export type ProjectDetailsProps = ProjectDetailsRouteParams;
 
-const ProjectWorkflowsByDomain: React.FC<{ project: Project }> = ({
-    project
-}) => {
+const entityTypeToComponent = {
+    tasks: ProjectWorkflows,
+    workflows: ProjectWorkflows
+};
+
+const ProjectEntitiesByDomain: React.FC<{
+    project: Project;
+    entityType: 'tasks' | 'workflows';
+}> = ({ entityType, project }) => {
     const styles = useStyles();
     const { params, setQueryState } = useQueryState<{ domain: string }>();
     if (project.domains.length === 0) {
@@ -33,6 +41,7 @@ const ProjectWorkflowsByDomain: React.FC<{ project: Project }> = ({
         setQueryState({
             domain: tabId
         });
+    const EntityComponent = entityTypeToComponent[entityType];
     return (
         <>
             <Tabs
@@ -49,10 +58,18 @@ const ProjectWorkflowsByDomain: React.FC<{ project: Project }> = ({
                     />
                 ))}
             </Tabs>
-            <ProjectWorkflows projectId={project.id} domainId={domainId} />
+            <EntityComponent projectId={project.id} domainId={domainId} />
         </>
     );
 };
+
+const ProjectWorkflowsByDomain: React.FC<{ project: Project }> = ({
+    project
+}) => <ProjectEntitiesByDomain project={project} entityType="workflows" />;
+
+const ProjectTasksByDomain: React.FC<{ project: Project }> = ({ project }) => (
+    <ProjectEntitiesByDomain project={project} entityType="tasks" />
+);
 
 /** The view component for the Project landing page */
 export const ProjectDetailsContainer: React.FC<ProjectDetailsRouteParams> = ({
@@ -62,7 +79,23 @@ export const ProjectDetailsContainer: React.FC<ProjectDetailsRouteParams> = ({
     return (
         <WaitForData {...project}>
             {() => {
-                return <ProjectWorkflowsByDomain project={project.value} />;
+                return (
+                    <Switch>
+                        <Route
+                            path={Routes.ProjectDetails.sections.workflows.path}
+                        >
+                            <ProjectWorkflowsByDomain project={project.value} />
+                        </Route>
+                        <Route path={Routes.ProjectDetails.sections.tasks.path}>
+                            <ProjectTasksByDomain project={project.value} />
+                        </Route>
+                        <Redirect
+                            to={Routes.ProjectDetails.sections.workflows.makeUrl(
+                                projectId
+                            )}
+                        />
+                    </Switch>
+                );
             }}
         </WaitForData>
     );

--- a/src/components/Project/ProjectTasks.tsx
+++ b/src/components/Project/ProjectTasks.tsx
@@ -1,12 +1,6 @@
-import { Typography } from '@material-ui/core';
-import { SearchResult, WaitForData } from 'components/common';
-import {
-    SearchableNamedEntity,
-    SearchableNamedEntityList,
-    useNamedEntityListStyles
-} from 'components/common/SearchableNamedEntityList';
-import { useCommonStyles } from 'components/common/styles';
+import { WaitForData } from 'components/common';
 import { useTaskNameList } from 'components/hooks/useNamedEntity';
+import { SearchableTaskNameList } from 'components/Task/SearchableTaskNameList';
 import { limits, SortDirection, workflowSortFields } from 'models';
 import * as React from 'react';
 
@@ -20,29 +14,6 @@ export const ProjectTasks: React.FC<ProjectTasksProps> = ({
     domainId: domain,
     projectId: project
 }) => {
-    const listStyles = useNamedEntityListStyles();
-    const commonStyles = useCommonStyles();
-    const renderItem = ({
-        key,
-        value,
-        content
-    }: SearchResult<SearchableNamedEntity>) => (
-        <li key={key}>
-            <div className={listStyles.searchResult}>
-                <div className={listStyles.itemName}>
-                    <div>{content}</div>
-                    {!!value.metadata.description && (
-                        <Typography
-                            variant="body2"
-                            className={commonStyles.hintText}
-                        >
-                            {value.metadata.description}
-                        </Typography>
-                    )}
-                </div>
-            </div>
-        </li>
-    );
     const taskNames = useTaskNameList(
         { domain, project },
         {
@@ -56,10 +27,7 @@ export const ProjectTasks: React.FC<ProjectTasksProps> = ({
 
     return (
         <WaitForData {...taskNames}>
-            <SearchableNamedEntityList
-                names={taskNames.value}
-                renderItem={renderItem}
-            />
+            <SearchableTaskNameList names={taskNames.value} />
         </WaitForData>
     );
 };

--- a/src/components/Project/ProjectTasks.tsx
+++ b/src/components/Project/ProjectTasks.tsx
@@ -1,5 +1,4 @@
 import { Typography } from '@material-ui/core';
-import ChevronRight from '@material-ui/icons/ChevronRight';
 import { SearchResult, WaitForData } from 'components/common';
 import {
     SearchableNamedEntity,
@@ -41,7 +40,6 @@ export const ProjectTasks: React.FC<ProjectTasksProps> = ({
                         </Typography>
                     )}
                 </div>
-                {/* <ChevronRight className={listStyles.itemChevron} /> */}
             </div>
         </li>
     );

--- a/src/components/Project/ProjectTasks.tsx
+++ b/src/components/Project/ProjectTasks.tsx
@@ -1,13 +1,13 @@
 import { Typography } from '@material-ui/core';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import { SearchResult, WaitForData } from 'components/common';
-import { useCommonStyles } from 'components/common/styles';
-import { useTaskNameList } from 'components/hooks/useNamedEntity';
 import {
     SearchableNamedEntity,
     SearchableNamedEntityList,
     useNamedEntityListStyles
-} from 'components/Workflow/SearchableNamedEntityList';
+} from 'components/common/SearchableNamedEntityList';
+import { useCommonStyles } from 'components/common/styles';
+import { useTaskNameList } from 'components/hooks/useNamedEntity';
 import { limits, SortDirection, workflowSortFields } from 'models';
 import * as React from 'react';
 

--- a/src/components/Project/ProjectTasks.tsx
+++ b/src/components/Project/ProjectTasks.tsx
@@ -1,0 +1,33 @@
+import { WaitForData } from 'components/common';
+import { useWorkflowNameList } from 'components/hooks/useNamedEntity';
+import { SearchableWorkflowNameList } from 'components/Workflow/SearchableWorkflowNameList';
+import { limits, SortDirection, workflowSortFields } from 'models';
+import * as React from 'react';
+
+export interface ProjectWorkflowsProps {
+    projectId: string;
+    domainId: string;
+}
+
+/** A listing of the Workflows registered for a project */
+export const ProjectWorkflows: React.FC<ProjectWorkflowsProps> = ({
+    domainId: domain,
+    projectId: project
+}) => {
+    const workflowNames = useWorkflowNameList(
+        { domain, project },
+        {
+            limit: limits.NONE,
+            sort: {
+                direction: SortDirection.ASCENDING,
+                key: workflowSortFields.name
+            }
+        }
+    );
+
+    return (
+        <WaitForData {...workflowNames}>
+            <SearchableWorkflowNameList workflowNames={workflowNames.value} />
+        </WaitForData>
+    );
+};

--- a/src/components/Project/ProjectTasks.tsx
+++ b/src/components/Project/ProjectTasks.tsx
@@ -1,20 +1,51 @@
-import { WaitForData } from 'components/common';
-import { useWorkflowNameList } from 'components/hooks/useNamedEntity';
-import { SearchableWorkflowNameList } from 'components/Workflow/SearchableWorkflowNameList';
+import { Typography } from '@material-ui/core';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import { SearchResult, WaitForData } from 'components/common';
+import { useCommonStyles } from 'components/common/styles';
+import { useTaskNameList } from 'components/hooks/useNamedEntity';
+import {
+    SearchableNamedEntity,
+    SearchableNamedEntityList,
+    useNamedEntityListStyles
+} from 'components/Workflow/SearchableNamedEntityList';
 import { limits, SortDirection, workflowSortFields } from 'models';
 import * as React from 'react';
 
-export interface ProjectWorkflowsProps {
+export interface ProjectTasksProps {
     projectId: string;
     domainId: string;
 }
 
-/** A listing of the Workflows registered for a project */
-export const ProjectWorkflows: React.FC<ProjectWorkflowsProps> = ({
+/** A listing of the Tasks registered for a project */
+export const ProjectTasks: React.FC<ProjectTasksProps> = ({
     domainId: domain,
     projectId: project
 }) => {
-    const workflowNames = useWorkflowNameList(
+    const listStyles = useNamedEntityListStyles();
+    const commonStyles = useCommonStyles();
+    const renderItem = ({
+        key,
+        value,
+        content
+    }: SearchResult<SearchableNamedEntity>) => (
+        <li key={key}>
+            <div className={listStyles.searchResult}>
+                <div className={listStyles.itemName}>
+                    <div>{content}</div>
+                    {!!value.metadata.description && (
+                        <Typography
+                            variant="body2"
+                            className={commonStyles.hintText}
+                        >
+                            {value.metadata.description}
+                        </Typography>
+                    )}
+                </div>
+                {/* <ChevronRight className={listStyles.itemChevron} /> */}
+            </div>
+        </li>
+    );
+    const taskNames = useTaskNameList(
         { domain, project },
         {
             limit: limits.NONE,
@@ -26,8 +57,11 @@ export const ProjectWorkflows: React.FC<ProjectWorkflowsProps> = ({
     );
 
     return (
-        <WaitForData {...workflowNames}>
-            <SearchableWorkflowNameList workflowNames={workflowNames.value} />
+        <WaitForData {...taskNames}>
+            <SearchableNamedEntityList
+                names={taskNames.value}
+                renderItem={renderItem}
+            />
         </WaitForData>
     );
 };

--- a/src/components/Project/ProjectWorkflows.tsx
+++ b/src/components/Project/ProjectWorkflows.tsx
@@ -1,8 +1,18 @@
-import { WaitForData } from 'components/common';
+import { Typography } from '@material-ui/core';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import { SearchResult, WaitForData } from 'components/common';
+import { useCommonStyles } from 'components/common/styles';
 import { useWorkflowNameList } from 'components/hooks/useNamedEntity';
+import {
+    SearchableNamedEntity,
+    SearchableNamedEntityList,
+    useNamedEntityListStyles
+} from 'components/Workflow/SearchableNamedEntityList';
 import { SearchableWorkflowNameList } from 'components/Workflow/SearchableWorkflowNameList';
 import { limits, SortDirection, workflowSortFields } from 'models';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Routes } from 'routes';
 
 export interface ProjectWorkflowsProps {
     projectId: string;
@@ -27,7 +37,7 @@ export const ProjectWorkflows: React.FC<ProjectWorkflowsProps> = ({
 
     return (
         <WaitForData {...workflowNames}>
-            <SearchableWorkflowNameList workflowNames={workflowNames.value} />
+            <SearchableWorkflowNameList names={workflowNames.value} />
         </WaitForData>
     );
 };

--- a/src/components/Project/ProjectWorkflows.tsx
+++ b/src/components/Project/ProjectWorkflows.tsx
@@ -1,13 +1,13 @@
 import { Typography } from '@material-ui/core';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import { SearchResult, WaitForData } from 'components/common';
-import { useCommonStyles } from 'components/common/styles';
-import { useWorkflowNameList } from 'components/hooks/useNamedEntity';
 import {
     SearchableNamedEntity,
     SearchableNamedEntityList,
     useNamedEntityListStyles
-} from 'components/Workflow/SearchableNamedEntityList';
+} from 'components/common/SearchableNamedEntityList';
+import { useCommonStyles } from 'components/common/styles';
+import { useWorkflowNameList } from 'components/hooks/useNamedEntity';
 import { SearchableWorkflowNameList } from 'components/Workflow/SearchableWorkflowNameList';
 import { limits, SortDirection, workflowSortFields } from 'models';
 import * as React from 'react';

--- a/src/components/Task/SearchableTaskNameList.tsx
+++ b/src/components/Task/SearchableTaskNameList.tsx
@@ -1,15 +1,16 @@
 import { Typography } from '@material-ui/core';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import { SearchResult } from 'components/common';
-import { useCommonStyles } from 'components/common/styles';
 import {
     SearchableNamedEntity,
     SearchableNamedEntityList,
     SearchableNamedEntityListProps,
     useNamedEntityListStyles
-} from 'components/Workflow/SearchableNamedEntityList';
+} from 'components/common/SearchableNamedEntityList';
+import { useCommonStyles } from 'components/common/styles';
 import * as React from 'react';
 
+/** Renders a searchable list of Task names, with associated metadata */
 export const SearchableTaskNameList: React.FC<
     Omit<SearchableNamedEntityListProps, 'renderItem'>
 > = props => {

--- a/src/components/Task/SearchableTaskNameList.tsx
+++ b/src/components/Task/SearchableTaskNameList.tsx
@@ -9,10 +9,8 @@ import {
     useNamedEntityListStyles
 } from 'components/Workflow/SearchableNamedEntityList';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
-import { Routes } from 'routes';
 
-export const SearchableWorkflowNameList: React.FC<
+export const SearchableTaskNameList: React.FC<
     Omit<SearchableNamedEntityListProps, 'renderItem'>
 > = props => {
     const commonStyles = useCommonStyles();
@@ -23,15 +21,7 @@ export const SearchableWorkflowNameList: React.FC<
         value,
         content
     }: SearchResult<SearchableNamedEntity>) => (
-        <Link
-            key={key}
-            className={commonStyles.linkUnstyled}
-            to={Routes.WorkflowDetails.makeUrl(
-                value.id.project,
-                value.id.domain,
-                value.id.name
-            )}
-        >
+        <li key={key}>
             <div className={listStyles.searchResult}>
                 <div className={listStyles.itemName}>
                     <div>{content}</div>
@@ -44,9 +34,9 @@ export const SearchableWorkflowNameList: React.FC<
                         </Typography>
                     )}
                 </div>
-                <ChevronRight className={listStyles.itemChevron} />
+                {/* <ChevronRight className={listStyles.itemChevron} /> */}
             </div>
-        </Link>
+        </li>
     );
     return <SearchableNamedEntityList {...props} renderItem={renderItem} />;
 };

--- a/src/components/Task/__stories__/SearchableTaskNameList.stories.tsx
+++ b/src/components/Task/__stories__/SearchableTaskNameList.stories.tsx
@@ -1,0 +1,10 @@
+import { storiesOf } from '@storybook/react';
+import { sampleTaskNames } from 'models/__mocks__/sampleTaskNames';
+import * as React from 'react';
+import { SearchableTaskNameList } from '../SearchableTaskNameList';
+
+const baseProps = { names: [...sampleTaskNames] };
+
+const stories = storiesOf('Task/SearchableTaskNameList', module);
+stories.addDecorator(story => <div style={{ width: '650px' }}>{story()}</div>);
+stories.add('basic', () => <SearchableTaskNameList {...baseProps} />);

--- a/src/components/Workflow/SearchableNamedEntityList.tsx
+++ b/src/components/Workflow/SearchableNamedEntityList.tsx
@@ -1,0 +1,116 @@
+import { Typography } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import { SearchableList, SearchResult } from 'components/common/SearchableList';
+import { useCommonStyles } from 'components/common/styles';
+import { listhoverColor, separatorColor } from 'components/Theme';
+import { NamedEntity } from 'models';
+import * as React from 'react';
+
+export const useNamedEntityListStyles = makeStyles((theme: Theme) => ({
+    container: {
+        marginBottom: theme.spacing(2),
+        width: '100%'
+    },
+    itemName: {
+        flex: '1 0 auto',
+        padding: `${theme.spacing(2)}px 0`
+    },
+    itemChevron: {
+        color: theme.palette.grey[500],
+        flex: '0 0 auto'
+    },
+    noResults: {
+        color: theme.palette.text.disabled,
+        display: 'flex',
+        justifyContent: 'center',
+        marginTop: theme.spacing(6)
+    },
+    searchResult: {
+        alignItems: 'center',
+        borderBottom: `1px solid ${separatorColor}`,
+        display: 'flex',
+        flexDirection: 'row',
+        padding: `0 ${theme.spacing(3)}px`,
+        '&:first-of-type': {
+            borderTop: `1px solid ${separatorColor}`
+        },
+        '&:hover': {
+            backgroundColor: listhoverColor
+        },
+        '& mark': {
+            backgroundColor: 'unset',
+            color: theme.palette.primary.main,
+            fontWeight: 'bold'
+        }
+    }
+}));
+
+export interface SearchableNamedEntity extends NamedEntity {
+    key: string;
+}
+
+const nameKey = ({ id: { domain, name, project } }: NamedEntity) =>
+    `${domain}/${name}/${project}`;
+
+const NoResults: React.FC = () => (
+    <Typography
+        className={useNamedEntityListStyles().noResults}
+        variant="h6"
+        component="div"
+    >
+        No matching results
+    </Typography>
+);
+
+type ItemRenderer = (
+    item: SearchResult<SearchableNamedEntity>
+) => React.ReactNode;
+
+interface SearchResultsProps {
+    results: SearchResult<SearchableNamedEntity>[];
+    renderItem: ItemRenderer;
+}
+const SearchResults: React.FC<SearchResultsProps> = ({
+    renderItem,
+    results
+}) => {
+    const commonStyles = useCommonStyles();
+    return results.length === 0 ? (
+        <NoResults />
+    ) : (
+        <ul className={commonStyles.listUnstyled}>{results.map(renderItem)}</ul>
+    );
+};
+
+export interface SearchableNamedEntityListProps {
+    names: NamedEntity[];
+    renderItem: ItemRenderer;
+}
+
+const nameSearchPropertyGetter = ({ id }: SearchableNamedEntity) => id.name;
+/** Given a list of WorkflowIds, renders a searchable list of items which
+ * navigate to the WorkflowDetails page on click
+ */
+export const SearchableNamedEntityList: React.FC<
+    SearchableNamedEntityListProps
+> = ({ names, renderItem }) => {
+    const styles = useNamedEntityListStyles();
+    const searchValues = names.map(name => ({
+        ...name,
+        key: nameKey(name)
+    }));
+
+    const renderItems = (results: SearchResult<SearchableNamedEntity>[]) => (
+        <SearchResults results={results} renderItem={renderItem} />
+    );
+
+    return (
+        <div className={styles.container}>
+            <SearchableList
+                items={searchValues}
+                propertyGetter={nameSearchPropertyGetter}
+                renderContent={renderItems}
+            />
+        </div>
+    );
+};

--- a/src/components/Workflow/SearchableWorkflowNameList.tsx
+++ b/src/components/Workflow/SearchableWorkflowNameList.tsx
@@ -1,17 +1,18 @@
 import { Typography } from '@material-ui/core';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import { SearchResult } from 'components/common';
-import { useCommonStyles } from 'components/common/styles';
 import {
     SearchableNamedEntity,
     SearchableNamedEntityList,
     SearchableNamedEntityListProps,
     useNamedEntityListStyles
-} from 'components/Workflow/SearchableNamedEntityList';
+} from 'components/common/SearchableNamedEntityList';
+import { useCommonStyles } from 'components/common/styles';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Routes } from 'routes';
 
+/** Renders a searchable list of Workflow names, with associated descriptions */
 export const SearchableWorkflowNameList: React.FC<
     Omit<SearchableNamedEntityListProps, 'renderItem'>
 > = props => {

--- a/src/components/Workflow/__stories__/SearchableWorkflowNameList.stories.tsx
+++ b/src/components/Workflow/__stories__/SearchableWorkflowNameList.stories.tsx
@@ -3,7 +3,7 @@ import { sampleWorkflowNames } from 'models/__mocks__/sampleWorkflowNames';
 import * as React from 'react';
 import { SearchableWorkflowNameList } from '../SearchableWorkflowNameList';
 
-const baseProps = { workflowNames: [...sampleWorkflowNames] };
+const baseProps = { names: [...sampleWorkflowNames] };
 
 const stories = storiesOf('Workflow/SearchableWorkflowNameList', module);
 stories.addDecorator(story => <div style={{ width: '650px' }}>{story()}</div>);

--- a/src/components/common/SearchableNamedEntityList.tsx
+++ b/src/components/common/SearchableNamedEntityList.tsx
@@ -1,10 +1,10 @@
 import { Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { SearchableList, SearchResult } from 'components/common/SearchableList';
-import { useCommonStyles } from 'components/common/styles';
 import { listhoverColor, separatorColor } from 'components/Theme';
 import { NamedEntity } from 'models';
 import * as React from 'react';
+import { SearchableList, SearchResult } from './SearchableList';
+import { useCommonStyles } from './styles';
 
 export const useNamedEntityListStyles = makeStyles((theme: Theme) => ({
     container: {
@@ -88,9 +88,7 @@ export interface SearchableNamedEntityListProps {
 }
 
 const nameSearchPropertyGetter = ({ id }: SearchableNamedEntity) => id.name;
-/** Given a list of WorkflowIds, renders a searchable list of items which
- * navigate to the WorkflowDetails page on click
- */
+/** Base component functionalityfor rendering NamedEntities (Workflow/Task/LaunchPlan) */
 export const SearchableNamedEntityList: React.FC<
     SearchableNamedEntityListProps
 > = ({ names, renderItem }) => {

--- a/src/components/hooks/useNamedEntity.ts
+++ b/src/components/hooks/useNamedEntity.ts
@@ -59,7 +59,7 @@ export function useWorkflowNamedEntity(
     });
 }
 
-/** A hook for fetching a paginated list of workflow names */
+/** A hook for fetching a paginated list of task names */
 export function useTaskNameList(
     scope: DomainIdentifierScope,
     config: RequestConfig

--- a/src/components/hooks/useNamedEntity.ts
+++ b/src/components/hooks/useNamedEntity.ts
@@ -60,6 +60,22 @@ export function useWorkflowNamedEntity(
 }
 
 /** A hook for fetching a paginated list of workflow names */
+export function useTaskNameList(
+    scope: DomainIdentifierScope,
+    config: RequestConfig
+) {
+    const { listNamedEntities } = useAPIContext();
+    return usePagination<NamedEntity, DomainIdentifierScope>(
+        { ...config, fetchArg: scope },
+        (scope, requestConfig) =>
+            listNamedEntities(
+                { ...scope, resourceType: ResourceType.TASK },
+                requestConfig
+            )
+    );
+}
+
+/** A hook for fetching a paginated list of workflow names */
 export function useWorkflowNameList(
     scope: DomainIdentifierScope,
     config: RequestConfig

--- a/src/models/Task/constants.ts
+++ b/src/models/Task/constants.ts
@@ -12,3 +12,8 @@ export enum TaskType {
     UNKNOWN = 'unknown',
     WAITABLE = 'waitable'
 }
+
+export const taskSortFields = {
+    createdAt: 'created_at',
+    name: 'name'
+};

--- a/src/models/__mocks__/sampleTaskNames.ts
+++ b/src/models/__mocks__/sampleTaskNames.ts
@@ -1,0 +1,57 @@
+import { Core } from 'flyteidl';
+import { NamedEntity, NamedEntityIdentifier } from 'models/Common';
+
+export const sampleTaskIds: NamedEntityIdentifier[] = [
+    'app.complex_workflows.custom_image.task_object',
+    'app.workflows.batch_workflow.int_sub_task',
+    'app.workflows.batch_workflow.print_every_time',
+    'app.workflows.batch_workflow.sample_batch_task_no_inputs',
+    'app.workflows.batch_workflow.sample_batch_task_sq',
+    'app.workflows.batch_workflow.sq_sub_task',
+    'app.workflows.batch_workflow.sub_task',
+    'app.workflows.dynamic_resources.override_cpu_task',
+    'app.workflows.edge.canny_detection',
+    'app.workflows.edge.demo.canny_detection',
+    'app.workflows.failing_workflows.divider',
+    'app.workflows.failing_workflows.oversleeper',
+    'app.workflows.failing_workflows.retryer',
+    'app.workflows.fancy.custom_image_task',
+    'app.workflows.fancy.task_object',
+    'app.workflows.hive_workflow.always_failiing_hive_task',
+    'app.workflows.hive_workflow.dynamic_hive_task_producer',
+    'app.workflows.hive_workflow.generate_queries',
+    'app.workflows.hive_workflow.get_queries_cached',
+    'app.workflows.hive_workflow.get_uncached_query_for_dynamic',
+    'app.workflows.hive_workflow.print_schemas',
+    'app.workflows.rich_workflow.add_one_and_print',
+    'app.workflows.rich_workflow.print_every_time',
+    'app.workflows.rich_workflow.print_int',
+    'app.workflows.rich_workflow.simple_batch_task',
+    'app.workflows.rich_workflow.sum_and_print',
+    'app.workflows.rich_workflow.sum_ints',
+    'app.workflows.rich_workflow.sum_non_none',
+    'app.workflows.sample_tasks.add_one_and_print',
+    'app.workflows.sample_tasks.identity_sub_task',
+    'app.workflows.sample_tasks.print_every_time',
+    'app.workflows.sample_tasks.print_int',
+    'app.workflows.sample_tasks.simple_batch_task',
+    'app.workflows.sample_tasks.sum_and_print',
+    'app.workflows.sample_tasks.sum_ints',
+    'app.workflows.sample_tasks.sum_non_none',
+    'app.workflows.sidecar.a_sidecar_task',
+    'app.workflows.sidecar.a_simple_sidecar_task',
+    'app.workflows.sidecar_workflow.my_task',
+    'app.workflows.sidecar_workflow.primary_sidecar_task',
+    'app.workflows.sidecar_workflow.simulate_hours',
+    'app.workflows.simple.add_one',
+    'app.workflows.work.find_odd_numbers',
+    'app.workflows.work.find_odd_numbers_with_string'
+].map(name => ({ name, project: 'flytekit', domain: 'development' }));
+
+export const sampleTaskNames: NamedEntity[] = sampleTaskIds.map(id => ({
+    id,
+    resourceType: Core.ResourceType.TASK,
+    metadata: {
+        description: `A description for ${id.name}`
+    }
+}));

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -29,7 +29,7 @@ export class Routes {
     static ProjectDetails = {
         makeUrl: (project: string, section?: string) =>
             makeProjectBoundPath(project, section ? `/${section}` : ''),
-        path: `${projectBasePath}/:section?`,
+        path: projectBasePath,
         sections: {
             tasks: {
                 makeUrl: (project: string, domain?: string) =>

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -29,7 +29,7 @@ export class Routes {
     static ProjectDetails = {
         makeUrl: (project: string, section?: string) =>
             makeProjectBoundPath(project, section ? `/${section}` : ''),
-        path: projectBasePath,
+        path: `${projectBasePath}/:section?`,
         sections: {
             tasks: {
                 makeUrl: (project: string, domain?: string) =>

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -31,6 +31,14 @@ export class Routes {
             makeProjectBoundPath(project, section ? `/${section}` : ''),
         path: projectBasePath,
         sections: {
+            tasks: {
+                makeUrl: (project: string, domain?: string) =>
+                    makeProjectBoundPath(
+                        project,
+                        `/tasks${domain ? `?domain=${domain}` : ''}`
+                    ),
+                path: `${projectBasePath}/tasks`
+            },
             workflows: {
                 makeUrl: (project: string, domain?: string) =>
                     makeProjectBoundPath(
@@ -55,6 +63,11 @@ export class Routes {
         makeUrl: (project: string, domain: string) =>
             makeProjectDomainBoundPath(project, domain, '/schedules'),
         path: `${projectDomainBasePath}/schedules`
+    };
+    static ProjectTasks = {
+        makeUrl: (project: string, domain: string) =>
+            makeProjectDomainBoundPath(project, domain, '/tasks'),
+        path: `${projectDomainBasePath}/tasks`
     };
     static ProjectWorkflows = {
         makeUrl: (project: string, domain: string) =>
@@ -130,6 +143,13 @@ export class Routes {
                 `/workflows/${workflowName}/version/${version}`
             ),
         path: `${projectDomainBasePath}/workflows/:workflowName/version/:version`
+    };
+
+    // Tasks
+    static TaskDetails = {
+        makeUrl: (project: string, domain: string, taskName: string) =>
+            makeProjectDomainBoundPath(project, domain, `/tasks/${taskName}`),
+        path: `${projectDomainBasePath}/tasks/:taskName`
     };
 
     // Executions


### PR DESCRIPTION
This creates a view similar to the workflows list view, except for tasks.
For the moment, we just want to list the available tasks with their associated metadata (description). And a follow-up PR will also add the interface description for tasks.

* Added routes, side navigation for tasks list
* Updated `ProjectDetails` to support rendering different content based on the route (either workflows or tasks)
* Made most of `SearchableWorkflowNameList` generic so that it can be shared with the tasks list. The only difference between them is how the rows are rendered.
* Added hook for fetching task names/descriptions
* Added mock data for task ids/names

![image](https://user-images.githubusercontent.com/1815175/68341445-50948e80-009d-11ea-9ea1-9240905acd9f.png)
