### PR TITLE
Fixing wrapping of values in task/workflow lists

### DIFF
--- a/src/components/Project/ProjectTasks.tsx
+++ b/src/components/Project/ProjectTasks.tsx
@@ -1,7 +1,7 @@
 import { WaitForData } from 'components/common';
 import { useTaskNameList } from 'components/hooks/useNamedEntity';
 import { SearchableTaskNameList } from 'components/Task/SearchableTaskNameList';
-import { limits, SortDirection, workflowSortFields } from 'models';
+import { limits, SortDirection, taskSortFields } from 'models';
 import * as React from 'react';
 
 export interface ProjectTasksProps {
@@ -20,7 +20,7 @@ export const ProjectTasks: React.FC<ProjectTasksProps> = ({
             limit: limits.NONE,
             sort: {
                 direction: SortDirection.ASCENDING,
-                key: workflowSortFields.name
+                key: taskSortFields.name
             }
         }
     );

--- a/src/components/common/SearchableNamedEntityList.tsx
+++ b/src/components/common/SearchableNamedEntityList.tsx
@@ -12,7 +12,7 @@ export const useNamedEntityListStyles = makeStyles((theme: Theme) => ({
         width: '100%'
     },
     itemName: {
-        flex: '1 0 auto',
+        flex: '1 1 auto',
         padding: `${theme.spacing(2)}px 0`
     },
     itemChevron: {


### PR DESCRIPTION
Updated a flex property and also fixed a bad usage of a sort key constant (they end up being the same value, so it wasn't causing a bug)

Before:
![image](https://user-images.githubusercontent.com/1815175/68981913-eb861a80-07b9-11ea-900b-4098bfb014f5.png)

After:
![image](https://user-images.githubusercontent.com/1815175/68981945-05276200-07ba-11ea-9c61-fb7bbf0261c3.png)
