### PR TITLE
Fix Docker image build errors due to missing .snyk file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8 as builder
 
 RUN npm install -g yarn@1.9
 WORKDIR /code/flyteconsole
-COPY package*.json yarn.lock ./
+COPY package*.json yarn.lock .snyk ./
 RUN : \
   # install production dependencies
   && yarn install --production \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flyteconsole",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The web UI for the Flyte platform",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`snyk-protect` runs as part of the `yarn` installation process. It requires the presence of the `.snyk` file, which is not part of the minimal files we copy at that stage of the `Dockerfile`. This adds the `.snyk` file at the early stage and bumps the package version.