### PR TITLE
Ensure TaskExecutions are always listed in the correct order.

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,6 +12,7 @@ export const navBarContentId = 'nav-bar-content';
 export const unknownValueString = '(unknown)';
 export const noDescriptionString = '(No description)';
 export const noneString = '(none)';
+export const noExecutionsFoundString = 'No executions found.';
 
 export const externalLinks = {
     // TODO: add flyte docs and feedback links when we have them

--- a/src/components/Executions/ExecutionDetails/ExecutionNodeDetails/TaskExecutionNodeDetails.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionNodeDetails/TaskExecutionNodeDetails.tsx
@@ -2,6 +2,7 @@ import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import * as React from 'react';
 const { useContext } = React;
+import { noExecutionsFoundString } from 'common/constants';
 import { NonIdealState, SectionHeader } from 'components/common';
 import { useCommonStyles } from 'components/common/styles';
 import { TaskExecutionsList } from 'components/Executions';
@@ -35,7 +36,7 @@ const NoTaskDetailsAvailable: React.FC = () => (
 const NoExecutionsAvailable: React.FC = () => (
     <NonIdealState
         description="This node has not been executed"
-        title="No Executions available"
+        title={noExecutionsFoundString}
         size="small"
     />
 );

--- a/src/components/Executions/Tables/NoExecutionsContent.tsx
+++ b/src/components/Executions/Tables/NoExecutionsContent.tsx
@@ -1,4 +1,5 @@
 import { Typography } from '@material-ui/core';
+import { noExecutionsFoundString } from 'common/constants';
 import * as React from 'react';
 import { useExecutionTableStyles } from './styles';
 
@@ -10,7 +11,7 @@ export const NoExecutionsContent: React.FC<{ size?: SizeVariant }> = ({
 }) => (
     <div className={useExecutionTableStyles().noRowsContent}>
         <Typography variant={size === 'large' ? 'h6' : 'body1'}>
-            No Executions found.
+            {noExecutionsFoundString}
         </Typography>
     </div>
 );

--- a/src/components/Executions/Tables/WorkflowExecutionsTable.tsx
+++ b/src/components/Executions/Tables/WorkflowExecutionsTable.tsx
@@ -1,6 +1,7 @@
 import Link from '@material-ui/core/Link';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import * as classnames from 'classnames';
+import { noExecutionsFoundString } from 'common/constants';
 import {
     dateFromNow,
     formatDateUTC,
@@ -211,7 +212,7 @@ export const WorkflowExecutionsTable: React.FC<
             <DataList
                 {...props}
                 onRetry={retry}
-                noRowsContent="No executions found."
+                noRowsContent={noExecutionsFoundString}
                 ref={listRef}
                 rowContentRenderer={rowRenderer}
             />

--- a/src/components/Executions/Tables/test/NodeExecutionChildren.test.tsx
+++ b/src/components/Executions/Tables/test/NodeExecutionChildren.test.tsx
@@ -1,0 +1,65 @@
+import { render, wait } from '@testing-library/react';
+import { noExecutionsFoundString } from 'common/constants';
+import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
+import { APIContext } from 'components/data/apiContext';
+import {
+    DetailedNodeExecution,
+    NodeExecutionDisplayType
+} from 'components/Executions/types';
+import {
+    listTaskExecutions,
+    NodeExecution,
+    SortDirection,
+    taskSortFields
+} from 'models';
+import { mockNodeExecutionResponse } from 'models/Execution/__mocks__/mockNodeExecutionsData';
+import * as React from 'react';
+import { NodeExecutionChildren } from '../NodeExecutionChildren';
+
+describe('NodeExecutionChildren', () => {
+    let nodeExecution: DetailedNodeExecution;
+    let mockListTaskExecutions: jest.Mock<
+        ReturnType<typeof listTaskExecutions>
+    >;
+
+    const renderChildren = () =>
+        render(
+            <APIContext.Provider
+                value={mockAPIContextValue({
+                    listTaskExecutions: mockListTaskExecutions
+                })}
+            >
+                <NodeExecutionChildren execution={nodeExecution} />
+            </APIContext.Provider>
+        );
+    beforeEach(() => {
+        nodeExecution = {
+            ...(mockNodeExecutionResponse as NodeExecution),
+            displayId: 'testNode',
+            displayType: NodeExecutionDisplayType.PythonTask,
+            cacheKey: 'abcdefg'
+        };
+        mockListTaskExecutions = jest.fn().mockResolvedValue({ entities: [] });
+    });
+
+    it('Renders message when no task executions exist', async () => {
+        const { queryByText } = renderChildren();
+        await wait();
+        expect(mockListTaskExecutions).toHaveBeenCalled();
+        expect(queryByText(noExecutionsFoundString)).toBeInTheDocument();
+    });
+
+    it('Requests items in correct order', async () => {
+        renderChildren();
+        await wait();
+        expect(mockListTaskExecutions).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                sort: {
+                    key: taskSortFields.createdAt,
+                    direction: SortDirection.ASCENDING
+                }
+            })
+        );
+    });
+});

--- a/src/components/Executions/TaskExecutionsList/TaskExecutionsList.tsx
+++ b/src/components/Executions/TaskExecutionsList/TaskExecutionsList.tsx
@@ -1,5 +1,5 @@
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { compareTimestampsAscending } from 'common/utils';
+import { noExecutionsFoundString } from 'common/constants';
 import { NonIdealState, WaitForData } from 'components/common';
 import { NodeExecution, TaskExecution } from 'models';
 import * as React from 'react';
@@ -20,13 +20,6 @@ interface TaskExecutionsListProps {
     nodeExecution: NodeExecution;
 }
 
-function compareTaskExecutionCreatedAtAscending(
-    a: TaskExecution,
-    b: TaskExecution
-) {
-    return compareTimestampsAscending(a.closure.createdAt, b.closure.createdAt);
-}
-
 const TaskExecutionsListContent: React.FC<{
     taskExecutions: TaskExecution[];
 }> = ({ taskExecutions }) => {
@@ -36,20 +29,18 @@ const TaskExecutionsListContent: React.FC<{
             <NonIdealState
                 className={styles.noExecutionsMessage}
                 size="small"
-                title="No executions found"
+                title={noExecutionsFoundString}
             />
         );
     }
     return (
         <>
-            {taskExecutions
-                .sort(compareTaskExecutionCreatedAtAscending)
-                .map(taskExecution => (
-                    <TaskExecutionsListItem
-                        key={getUniqueTaskExecutionName(taskExecution)}
-                        taskExecution={taskExecution}
-                    />
-                ))}
+            {taskExecutions.map(taskExecution => (
+                <TaskExecutionsListItem
+                    key={getUniqueTaskExecutionName(taskExecution)}
+                    taskExecution={taskExecution}
+                />
+            ))}
         </>
     );
 };

--- a/src/components/Executions/TaskExecutionsList/test/TaskExecutionsList.test.tsx
+++ b/src/components/Executions/TaskExecutionsList/test/TaskExecutionsList.test.tsx
@@ -1,0 +1,56 @@
+import { render, wait } from '@testing-library/react';
+import { noExecutionsFoundString } from 'common/constants';
+import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
+import { APIContext } from 'components/data/apiContext';
+import {
+    listTaskExecutions,
+    NodeExecution,
+    SortDirection,
+    taskSortFields
+} from 'models';
+import { mockNodeExecutionResponse } from 'models/Execution/__mocks__/mockNodeExecutionsData';
+import * as React from 'react';
+import { TaskExecutionsList } from '../TaskExecutionsList';
+
+describe('TaskExecutionsList', () => {
+    let nodeExecution: NodeExecution;
+    let mockListTaskExecutions: jest.Mock<
+        ReturnType<typeof listTaskExecutions>
+    >;
+
+    const renderList = () =>
+        render(
+            <APIContext.Provider
+                value={mockAPIContextValue({
+                    listTaskExecutions: mockListTaskExecutions
+                })}
+            >
+                <TaskExecutionsList nodeExecution={nodeExecution} />
+            </APIContext.Provider>
+        );
+    beforeEach(() => {
+        nodeExecution = { ...mockNodeExecutionResponse } as NodeExecution;
+        mockListTaskExecutions = jest.fn().mockResolvedValue({ entities: [] });
+    });
+
+    it('Renders message when no task executions exist', async () => {
+        const { queryByText } = renderList();
+        await wait();
+        expect(mockListTaskExecutions).toHaveBeenCalled();
+        expect(queryByText(noExecutionsFoundString)).toBeInTheDocument();
+    });
+
+    it('Requests items in correct order', async () => {
+        renderList();
+        await wait();
+        expect(mockListTaskExecutions).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                sort: {
+                    key: taskSortFields.createdAt,
+                    direction: SortDirection.ASCENDING
+                }
+            })
+        );
+    });
+});

--- a/src/components/Tables/DataTable.tsx
+++ b/src/components/Tables/DataTable.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@material-ui/core';
 import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import * as classnames from 'classnames';
+import { noExecutionsFoundString } from 'common/constants';
 import { ListProps } from 'components/common';
 import { useCommonStyles } from 'components/common/styles';
 import {
@@ -136,7 +137,7 @@ export const DataTableImpl: React.FC<DataTableImplProps> = props => {
 
     const noRowsRenderer = () => (
         <div className={styles.noRowsContent}>
-            <Typography variant="h6">No executions found.</Typography>
+            <Typography variant="h6">{noExecutionsFoundString}</Typography>
         </div>
     );
 


### PR DESCRIPTION
See lyft/flyte#86

We have two places where we show a list of task executions. One of them was already doing sorting of the list by creation time, but was doing it in the component itself. Task executions support sorting when fetching from the API, so this should at least be done when requesting the data.
Since we always list them in order of creation, I put the sorting into the hook that is shared by both components.


* Removed explicit sort in `TaskExecutionsList`
* Updated `useTaskExecutions` to always request a sort by created_at, ascending
* Added tests for `TaskExecutionsList` and `NodeExecutionChildren` to ensure empty states and that the request includes the expected sort values
* Cleanup: Moved a string that appears as a literal in a few places into a constant