### PR TITLE
Adds support for default values

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -87,9 +87,9 @@ export function createCorsProxyURL(path: string) {
 }
 
 /** Returns entires for an object, sorted lexicographically */
-export function sortedObjectEntries(
-    object: Object
-): ReturnType<typeof Object.entries> {
+export function sortedObjectEntries<T = any>(object: {
+    [s: string]: T;
+}): [string, T][] {
     return Object.entries(object).sort((a, b) => a[0].localeCompare(b[0]));
 }
 

--- a/src/components/Launch/LaunchWorkflowForm/__mocks__/mockInputs.ts
+++ b/src/components/Launch/LaunchWorkflowForm/__mocks__/mockInputs.ts
@@ -1,10 +1,5 @@
 import { mapValues } from 'lodash';
-import {
-    ParameterMap,
-    SimpleType,
-    TypedInterface,
-    Variable
-} from 'models/Common';
+import { SimpleType, TypedInterface, Variable } from 'models/Common';
 
 function simpleType(primitiveType: SimpleType, description?: string): Variable {
     return {

--- a/src/components/Launch/LaunchWorkflowForm/__mocks__/mockInputs.ts
+++ b/src/components/Launch/LaunchWorkflowForm/__mocks__/mockInputs.ts
@@ -1,5 +1,10 @@
+import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
+import { Core } from 'flyteidl';
 import { mapValues } from 'lodash';
+import * as Long from 'long';
 import { SimpleType, TypedInterface, Variable } from 'models/Common';
+import { literalNone } from '../inputHelpers/constants';
+import { primitiveLiteral } from './utils';
 
 function simpleType(primitiveType: SimpleType, description?: string): Variable {
     return {
@@ -10,7 +15,21 @@ function simpleType(primitiveType: SimpleType, description?: string): Variable {
     };
 }
 
-export const mockSimpleVariables: Record<string, Variable> = {
+const validDateString = '2019-01-10T00:00:00.000Z'; // Dec 1, 2019
+
+export type SimpleVariableKey =
+    | 'simpleString'
+    | 'stringNoLabel'
+    | 'simpleInteger'
+    | 'simpleFloat'
+    | 'simpleBoolean'
+    | 'simpleDuration'
+    | 'simpleDatetime'
+    | 'simpleBinary'
+    | 'simpleError'
+    | 'simpleStruct';
+
+export const mockSimpleVariables: Record<SimpleVariableKey, Variable> = {
     simpleString: simpleType(SimpleType.STRING, 'a simple string value'),
     stringNoLabel: simpleType(SimpleType.STRING),
     simpleInteger: simpleType(SimpleType.INTEGER, 'a simple integer value'),
@@ -25,6 +44,26 @@ export const mockSimpleVariables: Record<string, Variable> = {
     // collection: {},
     // mapValue: {},
     // blob: {}
+};
+
+export const simpleVariableDefaults: Record<
+    SimpleVariableKey,
+    Core.ILiteral
+> = {
+    simpleString: primitiveLiteral({ stringValue: 'abcdefg' }),
+    stringNoLabel: primitiveLiteral({ stringValue: 'abcdefg' }),
+    simpleBinary: literalNone(),
+    simpleBoolean: primitiveLiteral({ boolean: false }),
+    simpleDatetime: primitiveLiteral({
+        datetime: dateToTimestamp(new Date(validDateString))
+    }),
+    simpleDuration: primitiveLiteral({
+        duration: millisecondsToDuration(10000)
+    }),
+    simpleError: literalNone(),
+    simpleFloat: primitiveLiteral({ floatValue: 1.5 }),
+    simpleInteger: primitiveLiteral({ integer: Long.fromNumber(12345) }),
+    simpleStruct: literalNone()
 };
 
 export const mockCollectionVariables: Record<string, Variable> = mapValues(

--- a/src/components/Launch/LaunchWorkflowForm/__mocks__/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/__mocks__/utils.ts
@@ -1,0 +1,5 @@
+import { Core } from 'flyteidl';
+
+export function primitiveLiteral(primitive: Core.IPrimitive): Core.ILiteral {
+    return { scalar: { primitive } };
+}

--- a/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
@@ -22,6 +22,7 @@ import {
 } from '../__mocks__/mockInputs';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
 
+const booleanInputName = 'simpleBoolean';
 const stringInputName = 'simpleString';
 const integerInputName = 'simpleInteger';
 const submitAction = action('createWorkflowExecution');
@@ -96,6 +97,7 @@ stories.add('Required Inputs', () => {
     const parameters = mocks.mockLaunchPlan.closure!.expectedInputs.parameters;
     parameters[stringInputName].required = true;
     parameters[integerInputName].required = true;
+    parameters[booleanInputName].required = true;
     return renderForm(mocks);
 });
 stories.add('Default Values', () => {

--- a/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
@@ -20,9 +20,11 @@ import {
 } from '../__mocks__/mockInputs';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
 
+const stringInputName = 'simpleString';
+const integerInputName = 'simpleInteger';
 const submitAction = action('createWorkflowExecution');
 
-const renderForm = (variables: Record<string, Variable>) => {
+const generateMocks = (variables: Record<string, Variable>) => {
     const mockWorkflow = createMockWorkflow('MyWorkflow');
     const mockLaunchPlan = createMockLaunchPlan(
         mockWorkflow.id.name,
@@ -63,6 +65,13 @@ const renderForm = (variables: Record<string, Variable>) => {
         listLaunchPlans: () => resolveAfter(500, { entities: [mockLaunchPlan] })
     });
 
+    return { mockWorkflow, mockLaunchPlan, mockWorkflowVersions, mockApi };
+};
+
+const renderForm = ({
+    mockApi,
+    mockWorkflow
+}: ReturnType<typeof generateMocks>) => {
     const onClose = () => console.log('Close');
 
     return (
@@ -79,8 +88,17 @@ const renderForm = (variables: Record<string, Variable>) => {
 
 const stories = storiesOf('Launch/LaunchWorkflowForm', module);
 
-stories.add('Simple', () => renderForm(mockSimpleVariables));
-stories.add('Collections', () => renderForm(mockCollectionVariables));
+stories.add('Simple', () => renderForm(generateMocks(mockSimpleVariables)));
+stories.add('Required Inputs', () => {
+    const mocks = generateMocks(mockSimpleVariables);
+    const parameters = mocks.mockLaunchPlan.closure!.expectedInputs.parameters;
+    parameters[stringInputName].required = true;
+    parameters[integerInputName].required = true;
+    return renderForm(mocks);
+});
+stories.add('Collections', () =>
+    renderForm(generateMocks(mockCollectionVariables))
+);
 stories.add('Nested Collections', () =>
-    renderForm(mockNestedCollectionVariables)
+    renderForm(generateMocks(mockNestedCollectionVariables))
 );

--- a/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
@@ -4,7 +4,7 @@ import { resolveAfter } from 'common/promiseUtils';
 import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
 import { APIContext } from 'components/data/apiContext';
 import { mapValues } from 'lodash';
-import { Variable, Workflow } from 'models';
+import { Literal, Variable, Workflow } from 'models';
 import { createMockLaunchPlan } from 'models/__mocks__/launchPlanData';
 import {
     createMockWorkflow,
@@ -16,7 +16,9 @@ import {
     createMockWorkflowInputsInterface,
     mockCollectionVariables,
     mockNestedCollectionVariables,
-    mockSimpleVariables
+    mockSimpleVariables,
+    simpleVariableDefaults,
+    SimpleVariableKey
 } from '../__mocks__/mockInputs';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
 
@@ -94,6 +96,16 @@ stories.add('Required Inputs', () => {
     const parameters = mocks.mockLaunchPlan.closure!.expectedInputs.parameters;
     parameters[stringInputName].required = true;
     parameters[integerInputName].required = true;
+    return renderForm(mocks);
+});
+stories.add('Default Values', () => {
+    const mocks = generateMocks(mockSimpleVariables);
+    const parameters = mocks.mockLaunchPlan.closure!.expectedInputs.parameters;
+    Object.keys(parameters).forEach(paramName => {
+        const defaultValue =
+            simpleVariableDefaults[paramName as SimpleVariableKey];
+        parameters[paramName].default = defaultValue as Literal;
+    });
     return renderForm(mocks);
 });
 stories.add('Collections', () =>

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/boolean.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/boolean.ts
@@ -1,6 +1,6 @@
 import { Core } from 'flyteidl';
 import { InputValue } from '../types';
-import { literalValuePaths } from './constants';
+import { primitiveLiteralPaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
 import { extractLiteralWithCheck } from './utils';
 
@@ -43,7 +43,7 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
 function fromLiteral(literal: Core.ILiteral): InputValue {
     return extractLiteralWithCheck<boolean>(
         literal,
-        literalValuePaths.scalarBoolean
+        primitiveLiteralPaths.scalarBoolean
     );
 }
 

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/boolean.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/boolean.ts
@@ -1,6 +1,9 @@
 import { Core } from 'flyteidl';
+import { Literal } from 'models';
 import { InputValue } from '../types';
+import { literalValuePaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
+import { extractLiteralWithCheck } from './utils';
 
 /** Checks that a value is an acceptable boolean value. These can be
  * an actual Boolean instance, any variant of ('T', 'F', 'TRUE', 'FALSE') or
@@ -38,6 +41,13 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
     return { scalar: { primitive: { boolean: parseBoolean(value) } } };
 }
 
+function fromLiteral(literal: Literal): InputValue {
+    return extractLiteralWithCheck<boolean>(
+        literal,
+        literalValuePaths.scalarBoolean
+    );
+}
+
 function validate({ value }: ConverterInput) {
     if (!isValidBoolean(value)) {
         throw new Error('Value is not a valid boolean');
@@ -45,6 +55,8 @@ function validate({ value }: ConverterInput) {
 }
 
 export const booleanHelper: InputHelper = {
+    fromLiteral,
     toLiteral,
-    validate
+    validate,
+    defaultValue: false
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/boolean.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/boolean.ts
@@ -1,5 +1,4 @@
 import { Core } from 'flyteidl';
-import { Literal } from 'models';
 import { InputValue } from '../types';
 import { literalValuePaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
@@ -41,7 +40,7 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
     return { scalar: { primitive: { boolean: parseBoolean(value) } } };
 }
 
-function fromLiteral(literal: Literal): InputValue {
+function fromLiteral(literal: Core.ILiteral): InputValue {
     return extractLiteralWithCheck<boolean>(
         literal,
         literalValuePaths.scalarBoolean

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/collection.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/collection.ts
@@ -1,4 +1,6 @@
 import { Core } from 'flyteidl';
+import { Literal } from 'models';
+import { InputValue } from '../types';
 import { literalNone } from './constants';
 import { getHelperForInput } from './getHelperForInput';
 import { parseJSON } from './parseJson';
@@ -12,7 +14,12 @@ function parseCollection(list: string) {
     return parsed;
 }
 
-export function toLiteral({
+function fromLiteral(literal: Literal): InputValue {
+    // TODO
+    return '';
+}
+
+function toLiteral({
     value,
     typeDefinition: { subtype }
 }: ConverterInput): Core.ILiteral {
@@ -63,6 +70,7 @@ function validate({ value }: ConverterInput) {
 }
 
 export const collectionHelper: InputHelper = {
+    fromLiteral,
     toLiteral,
     validate
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/collection.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/collection.ts
@@ -1,5 +1,4 @@
 import { Core } from 'flyteidl';
-import { Literal } from 'models';
 import { InputValue } from '../types';
 import { literalNone } from './constants';
 import { getHelperForInput } from './getHelperForInput';
@@ -14,7 +13,7 @@ function parseCollection(list: string) {
     return parsed;
 }
 
-function fromLiteral(literal: Literal): InputValue {
+function fromLiteral(literal: Core.ILiteral): InputValue {
     // TODO
     return '';
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/constants.ts
@@ -6,3 +6,14 @@ export function literalNone(): Core.ILiteral {
 }
 
 export const allowedDateFormats = [ISO_8601, RFC_2822];
+
+const primitivePath = 'scalar.primitive';
+
+export const literalValuePaths = {
+    scalarBoolean: `${primitivePath}.boolean`,
+    scalarDatetime: `${primitivePath}.datetime`,
+    scalarDuration: `${primitivePath}.duration`,
+    scalarFloat: `${primitivePath}.floatValue`,
+    scalarInteger: `${primitivePath}.integer`,
+    scalarString: `${primitivePath}.stringValue`
+};

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/constants.ts
@@ -9,7 +9,10 @@ export const allowedDateFormats = [ISO_8601, RFC_2822];
 
 const primitivePath = 'scalar.primitive';
 
-export const literalValuePaths = {
+/** Strings constants which can be used to perform a deep `get` on a scalar
+ * literal type using a primitive value.
+ */
+export const primitiveLiteralPaths = {
     scalarBoolean: `${primitivePath}.boolean`,
     scalarDatetime: `${primitivePath}.datetime`,
     scalarDuration: `${primitivePath}.duration`,

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
@@ -1,10 +1,10 @@
-import { dateToTimestamp } from 'common/utils';
-import { Core } from 'flyteidl';
-import { Literal } from 'models';
+import { dateToTimestamp, timestampToDate } from 'common/utils';
+import { Core, Protobuf } from 'flyteidl';
 import { utc as moment } from 'moment';
 import { InputValue } from '../types';
-import { allowedDateFormats } from './constants';
+import { allowedDateFormats, literalValuePaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
+import { extractLiteralWithCheck } from './utils';
 
 function parseDate(value: InputValue) {
     return value instanceof Date
@@ -12,9 +12,12 @@ function parseDate(value: InputValue) {
         : moment(value.toString(), allowedDateFormats).toDate();
 }
 
-function fromLiteral(literal: Literal): InputValue {
-    // TODO
-    return '';
+function fromLiteral(literal: Core.ILiteral): InputValue {
+    const value = extractLiteralWithCheck<Protobuf.ITimestamp>(
+        literal,
+        literalValuePaths.scalarDatetime
+    );
+    return timestampToDate(value);
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
@@ -2,7 +2,7 @@ import { dateToTimestamp, timestampToDate } from 'common/utils';
 import { Core, Protobuf } from 'flyteidl';
 import { utc as moment } from 'moment';
 import { InputValue } from '../types';
-import { allowedDateFormats, literalValuePaths } from './constants';
+import { allowedDateFormats, primitiveLiteralPaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
 import { extractLiteralWithCheck } from './utils';
 
@@ -15,7 +15,7 @@ function parseDate(value: InputValue) {
 function fromLiteral(literal: Core.ILiteral): InputValue {
     const value = extractLiteralWithCheck<Protobuf.ITimestamp>(
         literal,
-        literalValuePaths.scalarDatetime
+        primitiveLiteralPaths.scalarDatetime
     );
     return timestampToDate(value);
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
@@ -1,5 +1,6 @@
 import { dateToTimestamp } from 'common/utils';
 import { Core } from 'flyteidl';
+import { Literal } from 'models';
 import { utc as moment } from 'moment';
 import { InputValue } from '../types';
 import { allowedDateFormats } from './constants';
@@ -9,6 +10,11 @@ function parseDate(value: InputValue) {
     return value instanceof Date
         ? value
         : moment(value.toString(), allowedDateFormats).toDate();
+}
+
+function fromLiteral(literal: Literal): InputValue {
+    // TODO
+    return '';
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {
@@ -26,6 +32,7 @@ function validate({ value }: ConverterInput) {
 }
 
 export const datetimeHelper: InputHelper = {
+    fromLiteral,
     toLiteral,
     validate
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
@@ -17,7 +17,7 @@ function fromLiteral(literal: Core.ILiteral): InputValue {
         literal,
         primitiveLiteralPaths.scalarDatetime
     );
-    return timestampToDate(value);
+    return timestampToDate(value).toISOString();
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/duration.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/duration.ts
@@ -1,7 +1,14 @@
 import { millisecondsToDuration } from 'common/utils';
 import { Core } from 'flyteidl';
+import { Literal } from 'models';
+import { InputValue } from '../types';
 import { isValidFloat } from './float';
 import { ConverterInput, InputHelper } from './types';
+
+function fromLiteral(literal: Literal): InputValue {
+    // TODO
+    return '';
+}
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {
     const parsed =
@@ -19,6 +26,7 @@ function validate({ value }: ConverterInput) {
 }
 
 export const durationHelper: InputHelper = {
+    fromLiteral,
     toLiteral,
     validate
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/duration.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/duration.ts
@@ -1,13 +1,17 @@
-import { millisecondsToDuration } from 'common/utils';
-import { Core } from 'flyteidl';
-import { Literal } from 'models';
+import { durationToMilliseconds, millisecondsToDuration } from 'common/utils';
+import { Core, Protobuf } from 'flyteidl';
 import { InputValue } from '../types';
+import { literalValuePaths } from './constants';
 import { isValidFloat } from './float';
 import { ConverterInput, InputHelper } from './types';
+import { extractLiteralWithCheck } from './utils';
 
-function fromLiteral(literal: Literal): InputValue {
-    // TODO
-    return '';
+function fromLiteral(literal: Core.ILiteral): InputValue {
+    const value = extractLiteralWithCheck<Protobuf.IDuration>(
+        literal,
+        literalValuePaths.scalarDuration
+    );
+    return durationToMilliseconds(value);
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/duration.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/duration.ts
@@ -1,7 +1,7 @@
 import { durationToMilliseconds, millisecondsToDuration } from 'common/utils';
 import { Core, Protobuf } from 'flyteidl';
 import { InputValue } from '../types';
-import { literalValuePaths } from './constants';
+import { primitiveLiteralPaths } from './constants';
 import { isValidFloat } from './float';
 import { ConverterInput, InputHelper } from './types';
 import { extractLiteralWithCheck } from './utils';
@@ -9,7 +9,7 @@ import { extractLiteralWithCheck } from './utils';
 function fromLiteral(literal: Core.ILiteral): InputValue {
     const value = extractLiteralWithCheck<Protobuf.IDuration>(
         literal,
-        literalValuePaths.scalarDuration
+        primitiveLiteralPaths.scalarDuration
     );
     return durationToMilliseconds(value);
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/float.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/float.ts
@@ -1,13 +1,13 @@
 import { Core } from 'flyteidl';
 import { InputValue } from '../types';
-import { literalValuePaths } from './constants';
+import { primitiveLiteralPaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
 import { extractLiteralWithCheck } from './utils';
 
 function fromLiteral(literal: Core.ILiteral): InputValue {
     return extractLiteralWithCheck<number>(
         literal,
-        literalValuePaths.scalarFloat
+        primitiveLiteralPaths.scalarFloat
     );
 }
 

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/float.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/float.ts
@@ -1,11 +1,14 @@
 import { Core } from 'flyteidl';
-import { Literal } from 'models';
 import { InputValue } from '../types';
+import { literalValuePaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
+import { extractLiteralWithCheck } from './utils';
 
-function fromLiteral(literal: Literal): InputValue {
-    // TODO
-    return '';
+function fromLiteral(literal: Core.ILiteral): InputValue {
+    return extractLiteralWithCheck<number>(
+        literal,
+        literalValuePaths.scalarFloat
+    );
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/float.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/float.ts
@@ -1,6 +1,12 @@
 import { Core } from 'flyteidl';
+import { Literal } from 'models';
 import { InputValue } from '../types';
 import { ConverterInput, InputHelper } from './types';
+
+function fromLiteral(literal: Literal): InputValue {
+    // TODO
+    return '';
+}
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {
     const floatValue =
@@ -27,6 +33,7 @@ function validate({ value }: ConverterInput) {
 }
 
 export const floatHelper: InputHelper = {
+    fromLiteral,
     toLiteral,
     validate
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
@@ -6,6 +6,9 @@ import { literalNone } from './constants';
 import { getHelperForInput } from './getHelperForInput';
 
 type ToLiteralParams = Pick<InputProps, 'typeDefinition' | 'value'>;
+/** Converts a type/InputValue combination to a `Core.ILiteral` which can be
+ * submitted to Admin for creating an execution.
+ */
 export function inputToLiteral(input: ToLiteralParams): Core.ILiteral {
     if (input.value == null) {
         return literalNone();
@@ -16,12 +19,16 @@ export function inputToLiteral(input: ToLiteralParams): Core.ILiteral {
     return toLiteral({ value, typeDefinition });
 }
 
+/** Generates the default value (if any) for a given type. */
 export function defaultValueForInputType(
     typeDefinition: InputTypeDefinition
 ): InputValue | undefined {
     return getHelperForInput(typeDefinition.type).defaultValue;
 }
 
+/** Converts a Core.ILiteral to an InputValue which can be used to populate
+ * a form control.
+ */
 export function literalToInputValue(
     typeDefinition: InputTypeDefinition,
     literal: Core.ILiteral
@@ -45,6 +52,9 @@ export function literalToInputValue(
 }
 
 type ValidationParams = Pick<InputProps, 'name' | 'typeDefinition' | 'value'>;
+/** Validates a given InputValue based on rules for the provided type. Returns
+ * void if no errors, throws an error otherwise.
+ */
 export function validateInput(input: ValidationParams) {
     if (input.value == null) {
         return;

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
@@ -24,7 +24,7 @@ export function defaultValueForInputType(
 
 export function literalToInputValue(
     typeDefinition: InputTypeDefinition,
-    literal: Literal
+    literal: Core.ILiteral
 ): InputValue | undefined {
     const { defaultValue, fromLiteral } = getHelperForInput(
         typeDefinition.type

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
@@ -30,8 +30,12 @@ export function literalToInputValue(
         typeDefinition.type
     );
 
+    if (literal.scalar && literal.scalar.noneType) {
+        return undefined;
+    }
+
     try {
-        return fromLiteral(literal);
+        return fromLiteral(literal, typeDefinition);
     } catch (e) {
         // If something goes wrong (most likely malformed default value input),
         // we'll return the system default value.

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
@@ -1,6 +1,7 @@
 import { ValueError } from 'errors';
 import { Core } from 'flyteidl';
-import { InputProps } from '../types';
+import { Literal } from 'models';
+import { InputProps, InputTypeDefinition, InputValue } from '../types';
 import { literalNone } from './constants';
 import { getHelperForInput } from './getHelperForInput';
 
@@ -13,6 +14,30 @@ export function inputToLiteral(input: ToLiteralParams): Core.ILiteral {
 
     const { toLiteral } = getHelperForInput(typeDefinition.type);
     return toLiteral({ value, typeDefinition });
+}
+
+export function defaultValueForInputType(
+    typeDefinition: InputTypeDefinition
+): InputValue | undefined {
+    return getHelperForInput(typeDefinition.type).defaultValue;
+}
+
+export function literalToInputValue(
+    typeDefinition: InputTypeDefinition,
+    literal: Literal
+): InputValue | undefined {
+    const { defaultValue, fromLiteral } = getHelperForInput(
+        typeDefinition.type
+    );
+
+    try {
+        return fromLiteral(literal);
+    } catch (e) {
+        // If something goes wrong (most likely malformed default value input),
+        // we'll return the system default value.
+        console.error((e as Error).message);
+        return defaultValue;
+    }
 }
 
 type ValidationParams = Pick<InputProps, 'name' | 'typeDefinition' | 'value'>;

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
@@ -51,12 +51,18 @@ export function literalToInputValue(
     }
 }
 
-type ValidationParams = Pick<InputProps, 'name' | 'typeDefinition' | 'value'>;
+type ValidationParams = Pick<
+    InputProps,
+    'name' | 'required' | 'typeDefinition' | 'value'
+>;
 /** Validates a given InputValue based on rules for the provided type. Returns
  * void if no errors, throws an error otherwise.
  */
 export function validateInput(input: ValidationParams) {
     if (input.value == null) {
+        if (input.required) {
+            throw new ValueError(input.name, 'Value is required');
+        }
         return;
     }
 

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
@@ -35,7 +35,7 @@ export function literalToInputValue(
     } catch (e) {
         // If something goes wrong (most likely malformed default value input),
         // we'll return the system default value.
-        console.error((e as Error).message);
+        console.debug((e as Error).message);
         return defaultValue;
     }
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/integer.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/integer.ts
@@ -1,7 +1,7 @@
 import { Core } from 'flyteidl';
 import * as Long from 'long';
 import { InputValue } from '../types';
-import { literalValuePaths } from './constants';
+import { primitiveLiteralPaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
 import { extractLiteralWithCheck } from './utils';
 
@@ -10,7 +10,7 @@ const integerRegexPattern = /^-?[0-9]+$/;
 function fromLiteral(literal: Core.ILiteral): InputValue {
     return extractLiteralWithCheck<Long>(
         literal,
-        literalValuePaths.scalarInteger
+        primitiveLiteralPaths.scalarInteger
     ).toString();
 }
 

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/integer.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/integer.ts
@@ -1,14 +1,17 @@
 import { Core } from 'flyteidl';
 import * as Long from 'long';
-import { Literal } from 'models';
 import { InputValue } from '../types';
+import { literalValuePaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
+import { extractLiteralWithCheck } from './utils';
 
 const integerRegexPattern = /^-?[0-9]+$/;
 
-function fromLiteral(literal: Literal): InputValue {
-    // TODO
-    return '';
+function fromLiteral(literal: Core.ILiteral): InputValue {
+    return extractLiteralWithCheck<Long>(
+        literal,
+        literalValuePaths.scalarInteger
+    ).toString();
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/integer.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/integer.ts
@@ -1,9 +1,15 @@
 import { Core } from 'flyteidl';
 import * as Long from 'long';
+import { Literal } from 'models';
 import { InputValue } from '../types';
 import { ConverterInput, InputHelper } from './types';
 
 const integerRegexPattern = /^-?[0-9]+$/;
+
+function fromLiteral(literal: Literal): InputValue {
+    // TODO
+    return '';
+}
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {
     const integer =
@@ -33,6 +39,7 @@ function validate({ value }: ConverterInput) {
 }
 
 export const integerHelper: InputHelper = {
+    fromLiteral,
     toLiteral,
     validate
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/none.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/none.ts
@@ -2,7 +2,7 @@ import { literalNone } from './constants';
 import { InputHelper } from './types';
 
 export const noneHelper: InputHelper = {
-    fromLiteral: () => '',
+    fromLiteral: () => undefined,
     toLiteral: literalNone,
     validate: () => {}
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/none.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/none.ts
@@ -2,6 +2,7 @@ import { literalNone } from './constants';
 import { InputHelper } from './types';
 
 export const noneHelper: InputHelper = {
+    fromLiteral: () => '',
     toLiteral: literalNone,
     validate: () => {}
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/string.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/string.ts
@@ -1,11 +1,14 @@
 import { Core } from 'flyteidl';
-import { Literal } from 'models';
 import { InputValue } from '../types';
+import { literalValuePaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
+import { extractLiteralWithCheck } from './utils';
 
-function fromLiteral(literal: Literal): InputValue {
-    // TODO
-    return '';
+function fromLiteral(literal: Core.ILiteral): InputValue {
+    return extractLiteralWithCheck<string>(
+        literal,
+        literalValuePaths.scalarString
+    );
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/string.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/string.ts
@@ -1,13 +1,13 @@
 import { Core } from 'flyteidl';
 import { InputValue } from '../types';
-import { literalValuePaths } from './constants';
+import { primitiveLiteralPaths } from './constants';
 import { ConverterInput, InputHelper } from './types';
 import { extractLiteralWithCheck } from './utils';
 
 function fromLiteral(literal: Core.ILiteral): InputValue {
     return extractLiteralWithCheck<string>(
         literal,
-        literalValuePaths.scalarString
+        primitiveLiteralPaths.scalarString
     );
 }
 

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/string.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/string.ts
@@ -1,5 +1,12 @@
 import { Core } from 'flyteidl';
+import { Literal } from 'models';
+import { InputValue } from '../types';
 import { ConverterInput, InputHelper } from './types';
+
+function fromLiteral(literal: Literal): InputValue {
+    // TODO
+    return '';
+}
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {
     const stringValue = typeof value === 'string' ? value : value.toString();
@@ -13,6 +20,7 @@ function validate({ value }: ConverterInput) {
 }
 
 export const stringHelper: InputHelper = {
+    fromLiteral,
     toLiteral,
     validate
 };

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -1,4 +1,5 @@
 import { InputProps, InputType } from '../../types';
+import { getHelperForInput } from '../getHelperForInput';
 import {
     inputToLiteral,
     literalToInputValue,
@@ -54,8 +55,16 @@ describe('literalToInputValue', () => {
         );
     });
 
-    // TODO
-    it('should return system default if parsing literal fails', () => {});
+    it('should return system default if parsing literal fails', () => {
+        const { defaultValue } = getHelperForInput(InputType.Boolean);
+        expect(
+            literalToInputValue(
+                { type: InputType.Boolean },
+                // Invalid boolean input value because it uses the string field
+                { scalar: { primitive: { stringValue: 'whoops' } } }
+            )
+        ).toEqual(defaultValue);
+    });
 });
 
 describe('inputToLiteral', () => {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -1,6 +1,14 @@
 import { InputProps, InputType } from '../../types';
-import { inputToLiteral, validateInput } from '../inputHelpers';
-import { literalTestCases, validityTestCases } from './testCases';
+import {
+    inputToLiteral,
+    literalToInputValue,
+    validateInput
+} from '../inputHelpers';
+import {
+    literalTestCases,
+    literalToInputTestCases,
+    validityTestCases
+} from './testCases';
 
 const baseInputProps: InputProps = {
     description: 'test',
@@ -35,7 +43,16 @@ function makeNestedCollectionInput(type: InputType, value: string): InputProps {
 }
 
 describe('literalToInputValue', () => {
-    // TODO: test cases for all of the input types
+    describe.only('Primitives', () => {
+        literalToInputTestCases.map(([type, input, output]) =>
+            it(`Should correctly convert ${type}: ${JSON.stringify(
+                input.scalar!.primitive
+            )}`, () => {
+                const result = literalToInputValue({ type }, input);
+                expect(result).toEqual(output);
+            })
+        );
+    });
 
     // TODO
     it('should return system default if parsing literal fails', () => {});

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -34,6 +34,13 @@ function makeNestedCollectionInput(type: InputType, value: string): InputProps {
     };
 }
 
+describe('literalToInputValue', () => {
+    // TODO: test cases for all of the input types
+
+    // TODO
+    it('should return system default if parsing literal fails', () => {});
+});
+
 describe('inputToLiteral', () => {
     describe('Primitives', () => {
         literalTestCases.map(([type, input, output]) =>

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -235,4 +235,12 @@ describe('validateInput', () => {
     describe('string', () => {
         generateValidityTests(InputType.String, validityTestCases.string);
     });
+
+    it('should throw errors for missing required values', () => {
+        const [type, input] = literalTestCases[0];
+        const simpleInput = makeSimpleInput(type, input);
+        simpleInput.required = true;
+        delete simpleInput.value;
+        expect(() => validateInput(simpleInput)).toThrowError();
+    });
 });

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -43,7 +43,7 @@ function makeNestedCollectionInput(type: InputType, value: string): InputProps {
 }
 
 describe('literalToInputValue', () => {
-    describe.only('Primitives', () => {
+    describe('Primitives', () => {
         literalToInputTestCases.map(([type, input, output]) =>
             it(`Should correctly convert ${type}: ${JSON.stringify(
                 input.scalar!.primitive

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
@@ -156,6 +156,5 @@ export const literalToInputTestCases: InputToLiteralTestParams[] = [
         Long.MIN_VALUE.toString()
     ],
     [InputType.String, primitiveLiteral({ stringValue: '' }), ''],
-    [InputType.String, primitiveLiteral({ stringValue: 'abcdefg' }), 'abcdefg'],
-    [InputType.None, literalNone(), undefined]
+    [InputType.String, primitiveLiteral({ stringValue: 'abcdefg' }), 'abcdefg']
 ];

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
@@ -1,7 +1,8 @@
 import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
 import { Core } from 'flyteidl';
 import * as Long from 'long';
-import { InputType } from '../../types';
+import { InputType, InputValue } from '../../types';
+import { literalNone } from '../constants';
 
 // Defines type of value, input, and expected value of innermost `IScalar`
 type PrimitiveTestParams = [InputType, any, Core.IPrimitive];
@@ -96,4 +97,65 @@ export const literalTestCases: PrimitiveTestParams[] = [
     [InputType.Integer, Long.MIN_VALUE, { integer: Long.MIN_VALUE }],
     [InputType.String, '', { stringValue: '' }],
     [InputType.String, 'abcdefg', { stringValue: 'abcdefg' }]
+];
+
+function primitiveLiteral(primitive: Core.IPrimitive): Core.ILiteral {
+    return { scalar: { primitive } };
+}
+
+type InputToLiteralTestParams = [
+    InputType,
+    Core.ILiteral,
+    InputValue | undefined
+];
+export const literalToInputTestCases: InputToLiteralTestParams[] = [
+    [InputType.Boolean, primitiveLiteral({ boolean: true }), true],
+    [InputType.Boolean, primitiveLiteral({ boolean: false }), false],
+    [
+        InputType.Datetime,
+        primitiveLiteral({
+            datetime: dateToTimestamp(new Date(validDateString))
+        }),
+        new Date(validDateString)
+    ],
+    [
+        InputType.Duration,
+        primitiveLiteral({ duration: millisecondsToDuration(0) }),
+        0
+    ],
+    [
+        InputType.Duration,
+        primitiveLiteral({ duration: millisecondsToDuration(10000) }),
+        10000
+    ],
+    [
+        InputType.Duration,
+        primitiveLiteral({ duration: millisecondsToDuration(1.5) }),
+        1.5
+    ],
+    [InputType.Float, primitiveLiteral({ floatValue: 0 }), 0],
+    [InputType.Float, primitiveLiteral({ floatValue: -1.5 }), -1.5],
+    [InputType.Float, primitiveLiteral({ floatValue: 1.5 }), 1.5],
+    [InputType.Float, primitiveLiteral({ floatValue: 1.25e10 }), 1.25e10],
+    // Integers will be returned as strings because they may overflow numbers
+    [InputType.Integer, primitiveLiteral({ integer: Long.fromNumber(0) }), '0'],
+    [InputType.Integer, primitiveLiteral({ integer: Long.fromNumber(1) }), '1'],
+    [
+        InputType.Integer,
+        primitiveLiteral({ integer: Long.fromNumber(-1) }),
+        '-1'
+    ],
+    [
+        InputType.Integer,
+        primitiveLiteral({ integer: Long.MAX_VALUE }),
+        Long.MAX_VALUE.toString()
+    ],
+    [
+        InputType.Integer,
+        primitiveLiteral({ integer: Long.MIN_VALUE }),
+        Long.MIN_VALUE.toString()
+    ],
+    [InputType.String, primitiveLiteral({ stringValue: '' }), ''],
+    [InputType.String, primitiveLiteral({ stringValue: 'abcdefg' }), 'abcdefg'],
+    [InputType.None, literalNone(), undefined]
 ];

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
@@ -1,8 +1,8 @@
 import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
 import { Core } from 'flyteidl';
 import * as Long from 'long';
+import { primitiveLiteral } from '../../__mocks__/utils';
 import { InputType, InputValue } from '../../types';
-import { literalNone } from '../constants';
 
 // Defines type of value, input, and expected value of innermost `IScalar`
 type PrimitiveTestParams = [InputType, any, Core.IPrimitive];
@@ -99,10 +99,6 @@ export const literalTestCases: PrimitiveTestParams[] = [
     [InputType.String, 'abcdefg', { stringValue: 'abcdefg' }]
 ];
 
-function primitiveLiteral(primitive: Core.IPrimitive): Core.ILiteral {
-    return { scalar: { primitive } };
-}
-
 type InputToLiteralTestParams = [
     InputType,
     Core.ILiteral,
@@ -116,7 +112,7 @@ export const literalToInputTestCases: InputToLiteralTestParams[] = [
         primitiveLiteral({
             datetime: dateToTimestamp(new Date(validDateString))
         }),
-        new Date(validDateString)
+        validDateString
     ],
     [
         InputType.Duration,

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/types.ts
@@ -1,4 +1,5 @@
 import { Core } from 'flyteidl';
+import { Literal } from 'models';
 import { InputTypeDefinition, InputValue } from '../types';
 
 export interface ConverterInput {
@@ -6,9 +7,14 @@ export interface ConverterInput {
     typeDefinition: InputTypeDefinition;
 }
 
-export type LiteralConverterFn = (input: ConverterInput) => Core.ILiteral;
+export type InputToLiteralConverterFn = (
+    input: ConverterInput
+) => Core.ILiteral;
+export type LiteralToInputConterterFn = (literal: Literal) => InputValue;
 export interface InputHelper {
-    toLiteral: LiteralConverterFn;
+    defaultValue?: InputValue;
+    toLiteral: InputToLiteralConverterFn;
+    fromLiteral: LiteralToInputConterterFn;
     /** Will throw in the case of a failed validation */
     validate: (input: ConverterInput) => void;
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/types.ts
@@ -10,7 +10,8 @@ export type InputToLiteralConverterFn = (
     input: ConverterInput
 ) => Core.ILiteral;
 export type LiteralToInputConterterFn = (
-    literal: Core.ILiteral
+    literal: Core.ILiteral,
+    typeDefinition: InputTypeDefinition
 ) => InputValue | undefined;
 export interface InputHelper {
     defaultValue?: InputValue;

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/types.ts
@@ -1,5 +1,4 @@
 import { Core } from 'flyteidl';
-import { Literal } from 'models';
 import { InputTypeDefinition, InputValue } from '../types';
 
 export interface ConverterInput {
@@ -10,7 +9,9 @@ export interface ConverterInput {
 export type InputToLiteralConverterFn = (
     input: ConverterInput
 ) => Core.ILiteral;
-export type LiteralToInputConterterFn = (literal: Literal) => InputValue;
+export type LiteralToInputConterterFn = (
+    literal: Core.ILiteral
+) => InputValue | undefined;
 export interface InputHelper {
     defaultValue?: InputValue;
     toLiteral: InputToLiteralConverterFn;

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -1,6 +1,9 @@
 import { Core } from 'flyteidl';
 import { get } from 'lodash';
 
+/** Performs a deep get of `path` on the given `Core.ILiteral`. Will throw
+ * if the given property doesn't exist.
+ */
 export function extractLiteralWithCheck<T>(
     literal: Core.ILiteral,
     path: string

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -1,0 +1,10 @@
+import { get } from 'lodash';
+import { Literal } from 'models';
+
+export function extractLiteralWithCheck<T>(literal: Literal, path: string): T {
+    const value = get(literal, path);
+    if (value === undefined) {
+        throw new Error(`Failed to extract literal value with path ${path}`);
+    }
+    return value as T;
+}

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -1,7 +1,10 @@
+import { Core } from 'flyteidl';
 import { get } from 'lodash';
-import { Literal } from 'models';
 
-export function extractLiteralWithCheck<T>(literal: Literal, path: string): T {
+export function extractLiteralWithCheck<T>(
+    literal: Core.ILiteral,
+    path: string
+): T {
     const value = get(literal, path);
     if (value === undefined) {
         throw new Error(`Failed to extract literal value with path ${path}`);

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -400,6 +400,8 @@ describe('LaunchWorkflowForm', () => {
                 );
                 expect(value).toBe(false);
             });
+
+            it('should use default values when provided', async () => {});
         });
     });
 });

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -375,10 +375,7 @@ describe('LaunchWorkflowForm', () => {
         });
 
         describe('Input Values', () => {
-            /* TODO: Un-skip this when https://github.com/lyft/flyte/issues/18
-             * is fixed.
-             */
-            it.skip('Should send false for untouched toggles', async () => {
+            it('Should send false for untouched toggles', async () => {
                 let inputs: Core.ILiteralMap = {};
                 mockCreateWorkflowExecution.mockImplementation(
                     ({

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -426,6 +426,21 @@ describe('LaunchWorkflowForm', () => {
                     getByLabelText(integerInputName, { exact: false })
                 ).toHaveValue('10000');
             });
+
+            it('should decorate labels for required inputs', async () => {
+                // Add defaults for the string/integer inputs and check that they are
+                // correctly populated
+                const parameters = mockLaunchPlans[0].closure!.expectedInputs
+                    .parameters;
+                parameters[stringInputName].required = true;
+                mockGetLaunchPlan.mockResolvedValue(mockLaunchPlans[0]);
+
+                const { getByText } = renderForm();
+                await wait();
+                expect(
+                    getByText(stringInputName, { exact: false }).textContent
+                ).toContain('*');
+            });
         });
     });
 });

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -14,6 +14,7 @@ import { APIContext } from 'components/data/apiContext';
 import { muiTheme } from 'components/Theme';
 import { Core } from 'flyteidl';
 import { get, mapValues } from 'lodash';
+import * as Long from 'long';
 import {
     createWorkflowExecution,
     CreateWorkflowExecutionArguments,
@@ -23,6 +24,7 @@ import {
     LaunchPlan,
     listLaunchPlans,
     listWorkflows,
+    Literal,
     NamedEntityIdentifier,
     Variable,
     Workflow
@@ -401,7 +403,29 @@ describe('LaunchWorkflowForm', () => {
                 expect(value).toBe(false);
             });
 
-            it('should use default values when provided', async () => {});
+            it('should use default values when provided', async () => {
+                // Add defaults for the string/integer inputs and check that they are
+                // correctly populated
+                const parameters = mockLaunchPlans[0].closure!.expectedInputs
+                    .parameters;
+                parameters[stringInputName].default = {
+                    scalar: { primitive: { stringValue: 'abc' } }
+                } as Literal;
+                parameters[integerInputName].default = {
+                    scalar: { primitive: { integer: Long.fromNumber(10000) } }
+                } as Literal;
+                mockGetLaunchPlan.mockResolvedValue(mockLaunchPlans[0]);
+
+                const { getByLabelText } = renderForm();
+                await wait();
+
+                expect(
+                    getByLabelText(stringInputName, { exact: false })
+                ).toHaveValue('abc');
+                expect(
+                    getByLabelText(integerInputName, { exact: false })
+                ).toHaveValue('10000');
+            });
         });
     });
 });

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -77,7 +77,10 @@ export interface InputProps {
     onChange: InputChangeHandler;
 }
 
-export type ParsedInput = Pick<
-    InputProps,
-    'description' | 'label' | 'name' | 'required' | 'typeDefinition'
->;
+export interface ParsedInput
+    extends Pick<
+        InputProps,
+        'description' | 'label' | 'name' | 'required' | 'typeDefinition'
+    > {
+    defaultValue?: InputValue;
+}

--- a/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
@@ -26,9 +26,9 @@ function useFormInputState(parsedInput: ParsedInput): FormInputState {
     const validationValue = useDebouncedValue(value, debounceDelay);
 
     const validate = () => {
-        const { name, typeDefinition } = parsedInput;
+        const { name, required, typeDefinition } = parsedInput;
         try {
-            validateInput({ name, typeDefinition, value });
+            validateInput({ name, required, typeDefinition, value });
             setError(undefined);
             return true;
         } catch (e) {

--- a/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
@@ -1,5 +1,4 @@
 import { useDebouncedValue } from 'components/hooks/useDebouncedValue';
-import { ValidationError, ValueError } from 'errors';
 import { Core } from 'flyteidl';
 import { useEffect, useState } from 'react';
 import { validateInput } from './inputHelpers/inputHelpers';
@@ -19,7 +18,9 @@ interface FormInputsState {
 }
 
 function useFormInputState(parsedInput: ParsedInput): FormInputState {
-    const [value, setValue] = useState<InputValue>();
+    const [value, setValue] = useState<InputValue | undefined>(
+        parsedInput.defaultValue
+    );
     const [error, setError] = useState<string>();
 
     const validationValue = useDebouncedValue(value, debounceDelay);

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -18,6 +18,10 @@ import {
 } from 'models';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { history, Routes } from 'routes';
+import {
+    defaultValueForInputType,
+    literalToInputValue
+} from './inputHelpers/inputHelpers';
 import { SearchableSelectorOption } from './SearchableSelector';
 import {
     LaunchWorkflowFormInputsRef,
@@ -59,9 +63,13 @@ function getInputs(workflow: Workflow, launchPlan: LaunchPlan): ParsedInput[] {
         );
         const label = formatLabelWithType(name, typeDefinition);
 
-        // TODO:
-        // Extract default value for more specific type (maybe just for simple)
+        const defaultValue =
+            parameter.default !== undefined
+                ? literalToInputValue(typeDefinition, parameter.default)
+                : defaultValueForInputType(typeDefinition);
+
         return {
+            defaultValue,
             description,
             label,
             name,

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -51,7 +51,7 @@ function getInputs(workflow: Workflow, launchPlan: LaunchPlan): ParsedInput[] {
     const launchPlanInputs = launchPlan.closure.expectedInputs.parameters;
     return sortedObjectEntries(launchPlanInputs).map(value => {
         const [name, parameter] = value;
-        const required = !!(parameter.default || parameter.required);
+        const required = !!parameter.required;
         const workflowInput = workflowInputs[name];
         const description =
             workflowInput && workflowInput.description

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -61,7 +61,8 @@ function getInputs(workflow: Workflow, launchPlan: LaunchPlan): ParsedInput[] {
         const typeDefinition = getInputDefintionForLiteralType(
             parameter.var.type
         );
-        const label = formatLabelWithType(name, typeDefinition);
+        const typeLabel = formatLabelWithType(name, typeDefinition);
+        const label = required ? `${typeLabel}*` : typeLabel;
 
         const defaultValue =
             parameter.default !== undefined

--- a/src/models/Common/types.ts
+++ b/src/models/Common/types.ts
@@ -1,4 +1,5 @@
 import { Admin, Core, Protobuf } from 'flyteidl';
+import { Collection } from 'react-virtualized';
 
 /* --- BEGIN flyteidl type aliases --- */
 /** These are types shared across multiple sections of the data model. Most of
@@ -59,6 +60,8 @@ export interface Error extends RequiredNonNullable<Core.IError> {}
 
 export interface Literal extends Core.Literal {
     value: keyof Core.ILiteral;
+    collection?: Core.ILiteralCollection;
+    map?: Core.ILiteralMap;
     scalar?: Scalar;
 }
 
@@ -72,6 +75,7 @@ export interface LiteralMapBlob extends Admin.ILiteralMapBlob {
 }
 
 export interface Scalar extends Core.IScalar {
+    primitive?: Primitive;
     value: keyof Core.IScalar;
 }
 


### PR DESCRIPTION
Fixes lyft/flyte#18 

This change adds support for default values when populating the Launch form. The default values are read from the selected launch plan and set as the initial value for the state hooks used to handle input interaction.

* Added `fromLiteral` function to all `InputHelper` implementations. This function is intended to parse a `Core.ILiteral` (the type used for default values) into an `InputValue` which can be used to populate a control in the Launch form
* Added `defaultValue` static property to `InputHelper`. For most types, this will be unset/undefined, because the default for an untouched control should be completely empty. For booleans, the default value will be set to `false`. This is because a toggle can't have an empty state and it causes issues when we send a `noneType` value for booleans.
* Added logic to handle validation of required values
* Added stories for default and required values
* Added/updated helper functions to allow extraction of primitive values when parsing literals.
* Unit tests for the literal parsing
