### PR TITLE
Correctly handling null default value properties

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/getInputs.ts
+++ b/src/components/Launch/LaunchWorkflowForm/getInputs.ts
@@ -1,0 +1,57 @@
+import { sortedObjectEntries } from 'common/utils';
+import { LaunchPlan, Workflow } from 'models';
+import {
+    defaultValueForInputType,
+    literalToInputValue
+} from './inputHelpers/inputHelpers';
+import { ParsedInput } from './types';
+import {
+    formatLabelWithType,
+    getInputDefintionForLiteralType,
+    getWorkflowInputs
+} from './utils';
+
+// We use a non-empty string for the description to allow display components
+// to depend on the existence of a value
+const emptyDescription = ' ';
+
+export function getInputs(
+    workflow: Workflow,
+    launchPlan: LaunchPlan
+): ParsedInput[] {
+    if (!launchPlan.closure || !workflow) {
+        return [];
+    }
+
+    const workflowInputs = getWorkflowInputs(workflow);
+    const launchPlanInputs = launchPlan.closure.expectedInputs.parameters;
+    return sortedObjectEntries(launchPlanInputs).map(value => {
+        const [name, parameter] = value;
+        const required = !!parameter.required;
+        const workflowInput = workflowInputs[name];
+        const description =
+            workflowInput && workflowInput.description
+                ? workflowInput.description
+                : emptyDescription;
+
+        const typeDefinition = getInputDefintionForLiteralType(
+            parameter.var.type
+        );
+        const typeLabel = formatLabelWithType(name, typeDefinition);
+        const label = required ? `${typeLabel}*` : typeLabel;
+
+        const defaultValue =
+            parameter.default != null
+                ? literalToInputValue(typeDefinition, parameter.default)
+                : defaultValueForInputType(typeDefinition);
+
+        return {
+            defaultValue,
+            description,
+            label,
+            name,
+            required,
+            typeDefinition
+        };
+    });
+}

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -13,7 +13,7 @@ import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
 import { APIContext } from 'components/data/apiContext';
 import { muiTheme } from 'components/Theme';
 import { Core } from 'flyteidl';
-import { get, mapValues } from 'lodash';
+import { get } from 'lodash';
 import * as Long from 'long';
 import {
     createWorkflowExecution,
@@ -29,12 +29,7 @@ import {
     Variable,
     Workflow
 } from 'models';
-import { createMockLaunchPlan } from 'models/__mocks__/launchPlanData';
-import {
-    createMockWorkflow,
-    createMockWorkflowClosure,
-    createMockWorkflowVersions
-} from 'models/__mocks__/workflowData';
+import { createMockWorkflowClosure } from 'models/__mocks__/workflowData';
 import * as React from 'react';
 import { delayedPromise, pendingPromise } from 'test/utils';
 import {
@@ -43,35 +38,13 @@ import {
 } from '../__mocks__/mockInputs';
 import { formStrings } from '../constants';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
-
-const booleanInputName = 'simpleBoolean';
-const stringInputName = 'simpleString';
-const stringNoLabelName = 'stringNoLabel';
-const integerInputName = 'simpleInteger';
-
-function createMockObjects(variables: Record<string, Variable>) {
-    const mockWorkflow = createMockWorkflow('MyWorkflow');
-
-    const mockWorkflowVersions = createMockWorkflowVersions(
-        mockWorkflow.id.name,
-        10
-    );
-
-    const mockLaunchPlans = [mockWorkflow.id.name, 'OtherLaunchPlan'].map(
-        name => {
-            const parameterMap = {
-                parameters: mapValues(variables, v => ({ var: v }))
-            };
-            const launchPlan = createMockLaunchPlan(
-                name,
-                mockWorkflow.id.version
-            );
-            launchPlan.closure!.expectedInputs = parameterMap;
-            return launchPlan;
-        }
-    );
-    return { mockWorkflow, mockLaunchPlans, mockWorkflowVersions };
-}
+import {
+    booleanInputName,
+    integerInputName,
+    stringInputName,
+    stringNoLabelName
+} from './constants';
+import { createMockObjects } from './utils';
 
 describe('LaunchWorkflowForm', () => {
     let onClose: jest.Mock;

--- a/src/components/Launch/LaunchWorkflowForm/test/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/test/constants.ts
@@ -1,0 +1,4 @@
+export const booleanInputName = 'simpleBoolean';
+export const stringInputName = 'simpleString';
+export const stringNoLabelName = 'stringNoLabel';
+export const integerInputName = 'simpleInteger';

--- a/src/components/Launch/LaunchWorkflowForm/test/getInputs.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/test/getInputs.test.ts
@@ -1,0 +1,23 @@
+import { mockSimpleVariables } from '../__mocks__/mockInputs';
+import { getInputs } from '../getInputs';
+import { stringInputName } from './constants';
+import { createMockObjects } from './utils';
+
+describe('getInputs', () => {
+    let mocks: ReturnType<typeof createMockObjects>;
+    beforeEach(() => {
+        mocks = createMockObjects(mockSimpleVariables);
+    });
+
+    it('should not throw when parameter default is null/undefined', () => {
+        const { mockLaunchPlans, mockWorkflow } = mocks;
+        const launchPlan = mockLaunchPlans[0];
+        const parameters = launchPlan.closure!.expectedInputs.parameters;
+        parameters[stringInputName].default = null;
+
+        expect(() => getInputs(mockWorkflow, launchPlan)).not.toThrowError();
+
+        delete parameters[stringInputName].default;
+        expect(() => getInputs(mockWorkflow, launchPlan)).not.toThrowError();
+    });
+});

--- a/src/components/Launch/LaunchWorkflowForm/test/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/test/utils.ts
@@ -1,0 +1,31 @@
+import { mapValues } from 'lodash';
+import { Variable } from 'models';
+import { createMockLaunchPlan } from 'models/__mocks__/launchPlanData';
+import {
+    createMockWorkflow,
+    createMockWorkflowVersions
+} from 'models/__mocks__/workflowData';
+
+export function createMockObjects(variables: Record<string, Variable>) {
+    const mockWorkflow = createMockWorkflow('MyWorkflow');
+
+    const mockWorkflowVersions = createMockWorkflowVersions(
+        mockWorkflow.id.name,
+        10
+    );
+
+    const mockLaunchPlans = [mockWorkflow.id.name, 'OtherLaunchPlan'].map(
+        name => {
+            const parameterMap = {
+                parameters: mapValues(variables, v => ({ var: v }))
+            };
+            const launchPlan = createMockLaunchPlan(
+                name,
+                mockWorkflow.id.version
+            );
+            launchPlan.closure!.expectedInputs = parameterMap;
+            return launchPlan;
+        }
+    );
+    return { mockWorkflow, mockLaunchPlans, mockWorkflowVersions };
+}

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -1,4 +1,3 @@
-import { sortedObjectEntries } from 'common/utils';
 import { getCacheKey } from 'components/Cache';
 import { useAPIContext } from 'components/data/apiContext';
 import {
@@ -18,10 +17,7 @@ import {
 } from 'models';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { history, Routes } from 'routes';
-import {
-    defaultValueForInputType,
-    literalToInputValue
-} from './inputHelpers/inputHelpers';
+import { getInputs } from './getInputs';
 import { SearchableSelectorOption } from './SearchableSelector';
 import {
     LaunchWorkflowFormInputsRef,
@@ -30,55 +26,9 @@ import {
     ParsedInput
 } from './types';
 import {
-    formatLabelWithType,
-    getInputDefintionForLiteralType,
-    getWorkflowInputs,
     launchPlansToSearchableSelectorOptions,
     workflowsToSearchableSelectorOptions
 } from './utils';
-
-// We use a non-empty string for the description to allow display components
-// to depend on the existence of a value
-const emptyDescription = ' ';
-
-function getInputs(workflow: Workflow, launchPlan: LaunchPlan): ParsedInput[] {
-    if (!launchPlan.closure || !workflow) {
-        // TODO: is this an error?
-        return [];
-    }
-
-    const workflowInputs = getWorkflowInputs(workflow);
-    const launchPlanInputs = launchPlan.closure.expectedInputs.parameters;
-    return sortedObjectEntries(launchPlanInputs).map(value => {
-        const [name, parameter] = value;
-        const required = !!parameter.required;
-        const workflowInput = workflowInputs[name];
-        const description =
-            workflowInput && workflowInput.description
-                ? workflowInput.description
-                : emptyDescription;
-
-        const typeDefinition = getInputDefintionForLiteralType(
-            parameter.var.type
-        );
-        const typeLabel = formatLabelWithType(name, typeDefinition);
-        const label = required ? `${typeLabel}*` : typeLabel;
-
-        const defaultValue =
-            parameter.default !== undefined
-                ? literalToInputValue(typeDefinition, parameter.default)
-                : defaultValueForInputType(typeDefinition);
-
-        return {
-            defaultValue,
-            description,
-            label,
-            name,
-            required,
-            typeDefinition
-        };
-    });
-}
 
 export function useWorkflowSelectorOptions(workflows: Workflow[]) {
     return useMemo(() => {

--- a/src/models/Common/types.ts
+++ b/src/models/Common/types.ts
@@ -139,7 +139,7 @@ export interface VariableMap extends Core.IVariableMap {
 
 export interface Parameter extends Core.IParameter {
     var: Variable;
-    default?: Literal;
+    default?: Literal | null;
     required?: boolean;
 }
 


### PR DESCRIPTION
* Split the `getInputs` function into a separate file to make it easier to test
* Added a loose null check to handle both null/undefined for the value of the `default` property. This prevents us from attempting to read properties on a null object.
* Added a test for the regression