### PR TITLE
Removing command in Dockerfile to copy a non-existent file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8 as builder
 
 RUN npm install -g yarn@1.9
 WORKDIR /code/flyteconsole
-COPY package*.json yarn.lock .snyk ./
+COPY package*.json yarn.lock ./
 RUN : \
   # install production dependencies
   && yarn install --production \


### PR DESCRIPTION
I removed the Snyk integration a while ago and missed the line from the Dockerfile which attempts to copy the Snyk config file. This change removes the offending command.