### PR TITLE
Adds support for initializing the Launch form using a workflow/launch plan/ inputs

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
@@ -17,6 +17,7 @@ import {
 } from 'models';
 import * as React from 'react';
 import { formStrings } from './constants';
+import { InputValueCacheContext } from './inputValueCache';
 import { LaunchWorkflowFormInputs } from './LaunchWorkflowFormInputs';
 import { SearchableSelector } from './SearchableSelector';
 import { useStyles } from './styles';
@@ -63,7 +64,7 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
     };
 
     return (
-        <>
+        <InputValueCacheContext.Provider value={state.inputValueCache}>
             <DialogTitle disableTypography={true} className={styles.header}>
                 <div className={styles.inputLabel}>{formStrings.title}</div>
                 <Typography variant="h6">{state.workflowName}</Typography>
@@ -152,6 +153,6 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                     </Button>
                 </DialogActions>
             </div>
-        </>
+        </InputValueCacheContext.Provider>
     );
 };

--- a/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
@@ -1,16 +1,26 @@
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import { resolveAfter } from 'common/promiseUtils';
+import { WaitForData } from 'components/common';
 import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
 import { APIContext } from 'components/data/apiContext';
 import { mapValues } from 'lodash';
-import { Literal, Variable, Workflow } from 'models';
+import * as Long from 'long';
+import {
+    Execution,
+    ExecutionData,
+    Literal,
+    LiteralMap,
+    Variable,
+    Workflow
+} from 'models';
 import { createMockLaunchPlan } from 'models/__mocks__/launchPlanData';
 import {
     createMockWorkflow,
     createMockWorkflowClosure,
     createMockWorkflowVersions
 } from 'models/__mocks__/workflowData';
+import { mockWorkflowExecutionResponse } from 'models/Execution/__mocks__/mockWorkflowExecutionsData';
 import * as React from 'react';
 import {
     createMockWorkflowInputsInterface,
@@ -21,6 +31,8 @@ import {
     SimpleVariableKey
 } from '../__mocks__/mockInputs';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
+import { useExecutionLaunchConfiguration } from '../useExecutionLaunchConfiguration';
+import { getWorkflowInputs } from '../utils';
 
 const booleanInputName = 'simpleBoolean';
 const stringInputName = 'simpleString';
@@ -29,6 +41,11 @@ const submitAction = action('createWorkflowExecution');
 
 const generateMocks = (variables: Record<string, Variable>) => {
     const mockWorkflow = createMockWorkflow('MyWorkflow');
+    mockWorkflow.closure = createMockWorkflowClosure();
+    mockWorkflow.closure!.compiledWorkflow!.primary.template.interface = createMockWorkflowInputsInterface(
+        variables
+    );
+
     const mockLaunchPlan = createMockLaunchPlan(
         mockWorkflow.id.name,
         mockWorkflow.id.version
@@ -45,12 +62,31 @@ const generateMocks = (variables: Record<string, Variable>) => {
 
     mockLaunchPlan.closure!.expectedInputs = parameterMap;
 
+    const mockExecutionData: ExecutionData = {
+        inputs: { url: 'inputsUrl', bytes: Long.fromNumber(1000) },
+        outputs: { url: 'outputsUrl', bytes: Long.fromNumber(1000) }
+    };
+
+    const mockExecutionInputs: LiteralMap = Object.keys(
+        parameterMap.parameters
+    ).reduce(
+        (out, paramName) => {
+            const defaultValue =
+                simpleVariableDefaults[paramName as SimpleVariableKey];
+            out.literals[paramName] = defaultValue as Literal;
+            return out;
+        },
+        { literals: {} } as LiteralMap
+    );
+
     const mockApi = mockAPIContextValue({
         createWorkflowExecution: input => {
             console.log(input);
             submitAction('See console for data');
             return Promise.reject('Not implemented');
         },
+        getExecutionData: () => resolveAfter(100, mockExecutionData),
+        getRemoteLiteralMap: () => resolveAfter(100, mockExecutionInputs),
         getLaunchPlan: () => resolveAfter(500, mockLaunchPlan),
         getWorkflow: id => {
             const workflow: Workflow = {
@@ -71,19 +107,50 @@ const generateMocks = (variables: Record<string, Variable>) => {
     return { mockWorkflow, mockLaunchPlan, mockWorkflowVersions, mockApi };
 };
 
-const renderForm = ({
-    mockApi,
-    mockWorkflow
-}: ReturnType<typeof generateMocks>) => {
+interface RenderFormArgs {
+    execution?: Execution;
+    mocks: ReturnType<typeof generateMocks>;
+}
+
+const LaunchFormWithExecution: React.FC<RenderFormArgs & {
+    execution: Execution;
+}> = ({ execution, mocks: { mockWorkflow } }) => {
+    const launchConfig = useExecutionLaunchConfiguration({
+        execution,
+        workflowInputs: getWorkflowInputs(mockWorkflow)
+    });
+    const onClose = () => console.log('Close');
+    return (
+        <WaitForData {...launchConfig}>
+            <LaunchWorkflowForm
+                onClose={onClose}
+                workflowId={mockWorkflow.id}
+                initialParameters={launchConfig.value}
+            />
+        </WaitForData>
+    );
+};
+
+const renderForm = (args: RenderFormArgs) => {
+    const {
+        mocks: { mockApi, mockWorkflow }
+    } = args;
     const onClose = () => console.log('Close');
 
     return (
         <APIContext.Provider value={mockApi}>
             <div style={{ width: 600, height: '95vh' }}>
-                <LaunchWorkflowForm
-                    onClose={onClose}
-                    workflowId={mockWorkflow.id}
-                />
+                {args.execution ? (
+                    <LaunchFormWithExecution
+                        {...args}
+                        execution={args.execution}
+                    />
+                ) : (
+                    <LaunchWorkflowForm
+                        onClose={onClose}
+                        workflowId={mockWorkflow.id}
+                    />
+                )}
             </div>
         </APIContext.Provider>
     );
@@ -91,14 +158,16 @@ const renderForm = ({
 
 const stories = storiesOf('Launch/LaunchWorkflowForm', module);
 
-stories.add('Simple', () => renderForm(generateMocks(mockSimpleVariables)));
+stories.add('Simple', () =>
+    renderForm({ mocks: generateMocks(mockSimpleVariables) })
+);
 stories.add('Required Inputs', () => {
     const mocks = generateMocks(mockSimpleVariables);
     const parameters = mocks.mockLaunchPlan.closure!.expectedInputs.parameters;
     parameters[stringInputName].required = true;
     parameters[integerInputName].required = true;
     parameters[booleanInputName].required = true;
-    return renderForm(mocks);
+    return renderForm({ mocks });
 });
 stories.add('Default Values', () => {
     const mocks = generateMocks(mockSimpleVariables);
@@ -108,11 +177,26 @@ stories.add('Default Values', () => {
             simpleVariableDefaults[paramName as SimpleVariableKey];
         parameters[paramName].default = defaultValue as Literal;
     });
-    return renderForm(mocks);
+    return renderForm({ mocks });
 });
 stories.add('Collections', () =>
-    renderForm(generateMocks(mockCollectionVariables))
+    renderForm({ mocks: generateMocks(mockCollectionVariables) })
 );
 stories.add('Nested Collections', () =>
-    renderForm(generateMocks(mockNestedCollectionVariables))
+    renderForm({ mocks: generateMocks(mockNestedCollectionVariables) })
 );
+stories.add('Launched from Execution', () => {
+    const mocks = generateMocks(mockSimpleVariables);
+    // Only providing values for the properties in the execution which
+    // are actually used by the component
+    const execution = {
+        closure: {
+            workflowId: mocks.mockWorkflow.id
+        },
+        spec: {
+            launchPlan: mocks.mockLaunchPlan.id
+        },
+        id: mockWorkflowExecutionResponse.id
+    } as Execution;
+    return renderForm({ mocks, execution });
+});

--- a/src/components/Launch/LaunchWorkflowForm/inputValueCache.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputValueCache.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+import { InputValue } from './types';
+
+export type InputValueCache = Map<string, InputValue>;
+
+export function createInputValueCache(): InputValueCache {
+    return new Map();
+}
+
+export const InputValueCacheContext = createContext<InputValueCache>(
+    createInputValueCache()
+);
+
+export function useInputValueCacheContext() {
+    return useContext(InputValueCacheContext);
+}

--- a/src/components/Launch/LaunchWorkflowForm/inputValueCache.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputValueCache.ts
@@ -1,13 +1,11 @@
 import { createContext, useContext } from 'react';
-import { InputValue } from './types';
+import { InputValueMap } from './types';
 
-export type InputValueCache = Map<string, InputValue>;
-
-export function createInputValueCache(): InputValueCache {
-    return new Map();
+export function createInputValueCache(values?: InputValueMap): InputValueMap {
+    return values ? new Map(values.entries()) : new Map();
 }
 
-export const InputValueCacheContext = createContext<InputValueCache>(
+export const InputValueCacheContext = createContext<InputValueMap>(
     createInputValueCache()
 );
 

--- a/src/components/Launch/LaunchWorkflowForm/inputValueCache.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputValueCache.ts
@@ -1,14 +1,17 @@
 import { createContext, useContext } from 'react';
 import { InputValueMap } from './types';
 
+/** Creates a Map of InputValues, optionally initializing it with the passed values */
 export function createInputValueCache(values?: InputValueMap): InputValueMap {
     return values ? new Map(values.entries()) : new Map();
 }
 
+/** Provides an InputValue cache Map to child components */
 export const InputValueCacheContext = createContext<InputValueMap>(
     createInputValueCache()
 );
 
+/** Convenience hook to retrieve the nearest ancestor InputValueCache context object. */
 export function useInputValueCacheContext() {
     return useContext(InputValueCacheContext);
 }

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -317,6 +317,35 @@ describe('LaunchWorkflowForm', () => {
             ).toBeNull();
         });
 
+        it('should preserve input values when changing launch plan', async () => {
+            jest.useFakeTimers();
+            const { getByLabelText, getByTitle } = renderForm();
+            await wait();
+
+            const integerInput = getByLabelText(integerInputName, {
+                exact: false
+            });
+            fireEvent.change(integerInput, { target: { value: '10' } });
+            act(jest.runAllTimers);
+            await wait();
+
+            // Click the expander for the launch plan, select the second item
+            const launchPlanDiv = getByTitle(formStrings.launchPlan);
+            const expander = getByRole(launchPlanDiv, 'button');
+            fireEvent.click(expander);
+            const items = await waitForElement(() =>
+                getAllByRole(launchPlanDiv, 'menuitem')
+            );
+            fireEvent.click(items[1]);
+            await wait();
+
+            expect(
+                getByLabelText(integerInputName, {
+                    exact: false
+                })
+            ).toHaveValue('10');
+        });
+
         it('should reset form error when inputs change', async () => {
             const errorString = 'Something went wrong';
             mockCreateWorkflowExecution.mockRejectedValue(

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -38,6 +38,7 @@ import {
 } from '../__mocks__/mockInputs';
 import { formStrings } from '../constants';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
+import { InitialLaunchParameters, LaunchWorkflowFormProps } from '../types';
 import {
     booleanInputName,
     integerInputName,
@@ -107,7 +108,7 @@ describe('LaunchWorkflowForm', () => {
             .mockResolvedValue({ entities: mockWorkflowVersions });
     };
 
-    const renderForm = () => {
+    const renderForm = (props?: Partial<LaunchWorkflowFormProps>) => {
         return render(
             <ThemeProvider theme={muiTheme}>
                 <APIContext.Provider
@@ -122,6 +123,7 @@ describe('LaunchWorkflowForm', () => {
                     <LaunchWorkflowForm
                         onClose={onClose}
                         workflowId={workflowId}
+                        {...props}
                     />
                 </APIContext.Provider>
             </ThemeProvider>
@@ -443,6 +445,37 @@ describe('LaunchWorkflowForm', () => {
                     getByText(stringInputName, { exact: false }).textContent
                 ).toContain('*');
             });
+        });
+
+        describe('When using initial parameters', () => {
+            it('should prefer the provided workflow version', async () => {
+                const initialParameters: InitialLaunchParameters = {
+                    workflow: mockWorkflowVersions[2].id
+                };
+                const { getByLabelText } = renderForm({ initialParameters });
+                await wait();
+                expect(getByLabelText(formStrings.workflowVersion)).toHaveValue(
+                    mockWorkflowVersions[2].id.version
+                );
+            });
+
+            it('should fall back to the first item in the list if preferred workflow is not found', async () => {
+                const baseId = mockWorkflowVersions[2].id;
+                const initialParameters: InitialLaunchParameters = {
+                    workflow: { ...baseId, version: 'nonexistentValue' }
+                };
+                const { getByLabelText } = renderForm({ initialParameters });
+                await wait();
+                expect(getByLabelText(formStrings.workflowVersion)).toHaveValue(
+                    mockWorkflowVersions[0].id.version
+                );
+            });
+
+            it('should prefer the provided launch plan', async () => {});
+
+            it('should fall back to the first launch plan if the preferred is not found', async () => {});
+
+            it('should prepopulate inputs with provided initial values', async () => {});
         });
     });
 });

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -178,38 +178,23 @@ describe('LaunchWorkflowForm', () => {
             );
         });
 
-        it('should not render inputs until workflow and launch plan are selected', async () => {
-            // Remove default launch plan so it is not auto-selected
-            const launchPlans = mockLaunchPlans.filter(
-                lp => lp.id.name !== workflowId.name
-            );
+        it('should not render inputs if no launch plan is selected', async () => {
             mockListLaunchPlans.mockResolvedValue({
-                entities: launchPlans
+                entities: []
             });
-            const { getByLabelText, getByTitle } = renderForm();
+            const { getByLabelText, queryByLabelText } = renderForm();
             await wait();
 
             // Find the launch plan selector, verify it has no value selected
             const launchPlanInput = getByLabelText(formStrings.launchPlan);
             expect(launchPlanInput).toBeInTheDocument();
             expect(launchPlanInput).toHaveValue('');
-
-            // Click the expander for the launch plan, select the first/only item
-            const launchPlanDiv = getByTitle(formStrings.launchPlan);
-            const expander = getByRole(launchPlanDiv, 'button');
-            fireEvent.click(expander);
-            const item = await waitForElement(() =>
-                getByRole(launchPlanDiv, 'menuitem')
-            );
-            fireEvent.click(item);
-
-            await wait();
             expect(
-                getByLabelText(stringInputName, {
+                queryByLabelText(stringInputName, {
                     // Don't use exact match because the label will be decorated with type info
                     exact: false
                 })
-            ).toBeInTheDocument();
+            ).toBeNull();
         });
 
         it('should disable submit button until inputs have loaded', async () => {
@@ -471,11 +456,17 @@ describe('LaunchWorkflowForm', () => {
                 );
             });
 
+            // TODO-NOW:
             it('should prefer the provided launch plan', async () => {});
 
-            it('should fall back to the first launch plan if the preferred is not found', async () => {});
+            it('should fall back to the default launch plan if the preferred is not found', async () => {});
+
+            it('should use preferred launch plan after switching workflow versions', async () => {});
 
             it('should prepopulate inputs with provided initial values', async () => {});
+
+            // TODO-NOW: Test for when the preferred values aren't in the first ten.
+            // Needs the mock list endpoint to return different values based on the scope
         });
     });
 });

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -1,16 +1,25 @@
 import { FetchableData, MultiFetchableState } from 'components/hooks';
 import { Core } from 'flyteidl';
 import {
+    Identifier,
     LaunchPlan,
     NamedEntityIdentifier,
     WorkflowExecutionIdentifier,
     WorkflowId
 } from 'models';
-import { InputValueCache } from './inputValueCache';
 import { SearchableSelectorOption } from './SearchableSelector';
+
+export type InputValueMap = Map<string, InputValue>;
+
+export interface InitialLaunchParameters {
+    launchPlan?: Identifier;
+    workflow?: WorkflowId;
+    values?: InputValueMap;
+}
 
 export interface LaunchWorkflowFormProps {
     workflowId: NamedEntityIdentifier;
+    initialParameters?: InitialLaunchParameters;
     onClose(): void;
 }
 
@@ -25,7 +34,7 @@ export interface LaunchWorkflowFormState {
     formInputsRef: React.RefObject<LaunchWorkflowFormInputsRef>;
     inputLoadingState: MultiFetchableState;
     inputs: ParsedInput[];
-    inputValueCache: InputValueCache;
+    inputValueCache: InputValueMap;
     launchPlanOptionsLoadingState: MultiFetchableState;
     launchPlanSelectorOptions: SearchableSelectorOption<LaunchPlan>[];
     selectedLaunchPlan?: SearchableSelectorOption<LaunchPlan>;

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -6,6 +6,7 @@ import {
     WorkflowExecutionIdentifier,
     WorkflowId
 } from 'models';
+import { InputValueCache } from './inputValueCache';
 import { SearchableSelectorOption } from './SearchableSelector';
 
 export interface LaunchWorkflowFormProps {
@@ -24,6 +25,7 @@ export interface LaunchWorkflowFormState {
     formInputsRef: React.RefObject<LaunchWorkflowFormInputsRef>;
     inputLoadingState: MultiFetchableState;
     inputs: ParsedInput[];
+    inputValueCache: InputValueCache;
     launchPlanOptionsLoadingState: MultiFetchableState;
     launchPlanSelectorOptions: SearchableSelectorOption<LaunchPlan>[];
     selectedLaunchPlan?: SearchableSelectorOption<LaunchPlan>;
@@ -82,5 +84,6 @@ export interface ParsedInput
         InputProps,
         'description' | 'label' | 'name' | 'required' | 'typeDefinition'
     > {
+    /** Indicates the value to use when the input is in a default state */
     defaultValue?: InputValue;
 }

--- a/src/components/Launch/LaunchWorkflowForm/useExecutionLaunchConfiguration.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useExecutionLaunchConfiguration.ts
@@ -1,0 +1,54 @@
+import { FetchableData, useWorkflowExecutionInputs } from 'components/hooks';
+import { Execution, Variable } from 'models';
+import { useEffect, useState } from 'react';
+import { literalToInputValue } from './inputHelpers/inputHelpers';
+import { InitialLaunchParameters, InputValueMap } from './types';
+import { createInputCacheKey, getInputDefintionForLiteralType } from './utils';
+
+export interface UseExecutionLaunchConfigurationArgs {
+    execution: Execution;
+    workflowInputs: Record<string, Variable>;
+}
+
+export function useExecutionLaunchConfiguration({
+    execution,
+    workflowInputs
+}: UseExecutionLaunchConfigurationArgs): FetchableData<
+    InitialLaunchParameters
+> {
+    const inputs = useWorkflowExecutionInputs(execution);
+    const [values, setValues] = useState<InputValueMap>(new Map());
+    const {
+        closure: { workflowId },
+        spec: { launchPlan }
+    } = execution;
+
+    const value = { launchPlan, values, workflow: workflowId };
+
+    useEffect(() => {
+        const { literals } = inputs.value;
+        const convertedValues = Object.keys(literals).reduce((out, name) => {
+            const workflowInput = workflowInputs[name];
+            if (!workflowInput) {
+                // TODO-NOW: Log it? Error?
+                return out;
+            }
+            const typeDefinition = getInputDefintionForLiteralType(
+                workflowInput.type
+            );
+            const inputValue = literalToInputValue(
+                typeDefinition,
+                literals[name]
+            );
+            const key = createInputCacheKey(name, typeDefinition);
+            if (inputValue !== undefined) {
+                out.set(key, inputValue);
+            }
+            return out;
+        }, new Map());
+
+        setValues(convertedValues);
+    }, [inputs.value]);
+
+    return { ...inputs, value };
+}

--- a/src/components/Launch/LaunchWorkflowForm/useExecutionLaunchConfiguration.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useExecutionLaunchConfiguration.ts
@@ -1,3 +1,4 @@
+import { log } from 'common/log';
 import { FetchableData, useWorkflowExecutionInputs } from 'components/hooks';
 import { Execution, Variable } from 'models';
 import { useEffect, useState } from 'react';
@@ -30,7 +31,7 @@ export function useExecutionLaunchConfiguration({
         const convertedValues = Object.keys(literals).reduce((out, name) => {
             const workflowInput = workflowInputs[name];
             if (!workflowInput) {
-                // TODO-NOW: Log it? Error?
+                log.error(`Unexpected missing workflow input: ${name}`);
                 return out;
             }
             const typeDefinition = getInputDefintionForLiteralType(

--- a/src/components/Launch/LaunchWorkflowForm/useExecutionLaunchConfiguration.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useExecutionLaunchConfiguration.ts
@@ -11,6 +11,7 @@ export interface UseExecutionLaunchConfigurationArgs {
     workflowInputs: Record<string, Variable>;
 }
 
+/** Returns a fetchable that will result in a `InitialLaunchParameters` object based on a provided `Execution` and its associated workflow inputs. */
 export function useExecutionLaunchConfiguration({
     execution,
     workflowInputs

--- a/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
@@ -4,17 +4,9 @@ import { useEffect, useState } from 'react';
 import { validateInput } from './inputHelpers/inputHelpers';
 import { useInputValueCacheContext } from './inputValueCache';
 import { InputProps, InputValue, ParsedInput } from './types';
-import { convertFormInputsToLiterals } from './utils';
+import { convertFormInputsToLiterals, createInputCacheKey } from './utils';
 
 const debounceDelay = 500;
-
-function createInputCacheKey(input: ParsedInput) {
-    const {
-        name,
-        typeDefinition: { type }
-    } = input;
-    return `${name}_${type}`;
-}
 
 interface FormInputState extends InputProps {
     validate(): boolean;
@@ -28,7 +20,10 @@ interface FormInputsState {
 
 function useFormInputState(parsedInput: ParsedInput): FormInputState {
     const inputValueCache = useInputValueCacheContext();
-    const cacheKey = createInputCacheKey(parsedInput);
+    const cacheKey = createInputCacheKey(
+        parsedInput.name,
+        parsedInput.typeDefinition
+    );
 
     const defaultValue = inputValueCache.has(cacheKey)
         ? inputValueCache.get(cacheKey)

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -89,6 +89,7 @@ function useLaunchPlansForWorkflow(workflowId: WorkflowId | null = null) {
  * definitions, current input values, and errors.
  */
 export function useLaunchWorkflowFormState({
+    initialParameters = {},
     onClose,
     workflowId
 }: LaunchWorkflowFormProps): LaunchWorkflowFormState {
@@ -108,7 +109,11 @@ export function useLaunchWorkflowFormState({
     >();
     const selectedWorkflowId = selectedWorkflow ? selectedWorkflow.data : null;
 
-    const [inputValueCache] = useState(createInputValueCache());
+    const inputValueCache = useMemo(
+        () => createInputValueCache(initialParameters.values),
+        [initialParameters.values]
+    );
+    // const [inputValueCache] = useState(createInputValueCache());
 
     // We have to do a single item get once a workflow is selected so that we
     // receive the full workflow spec

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -5,7 +5,7 @@ import {
     useWorkflow,
     waitForAllFetchables
 } from 'components/hooks';
-import { uniqBy } from 'lodash';
+import { isEqual, uniqBy } from 'lodash';
 import {
     FilterOperationName,
     Identifier,
@@ -308,6 +308,15 @@ export function useLaunchWorkflowFormState({
     // plan, or fall back to selecting the first option
     useEffect(() => {
         if (workflowSelectorOptions.length > 0 && !selectedWorkflow) {
+            if (preferredWorkflowId) {
+                const preferred = workflowSelectorOptions.find(({ data }) =>
+                    isEqual(data, preferredWorkflowId)
+                );
+                if (preferred) {
+                    setWorkflow(preferred);
+                    return;
+                }
+            }
             setWorkflow(workflowSelectorOptions[0]);
         }
     }, [workflows.value]);
@@ -319,10 +328,25 @@ export function useLaunchWorkflowFormState({
         if (!launchPlanSelectorOptions.length) {
             return;
         }
+
+        if (preferredLaunchPlanId) {
+            const preferred = launchPlanSelectorOptions.find(({ data }) =>
+                isEqual(data, preferredLaunchPlanId)
+            );
+            if (preferred) {
+                setLaunchPlan(preferred);
+                return;
+            }
+        }
+
         const defaultLaunchPlan = launchPlanSelectorOptions.find(
             ({ id }) => id === workflowId.name
         );
-        setLaunchPlan(defaultLaunchPlan);
+        if (defaultLaunchPlan) {
+            setLaunchPlan(defaultLaunchPlan);
+            return;
+        }
+        setLaunchPlan(launchPlanSelectorOptions[0]);
     }, [launchPlanSelectorOptions]);
 
     return {

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -18,6 +18,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { history, Routes } from 'routes';
 import { getInputs } from './getInputs';
+import { createInputValueCache } from './inputValueCache';
 import { SearchableSelectorOption } from './SearchableSelector';
 import {
     LaunchWorkflowFormInputsRef,
@@ -106,6 +107,8 @@ export function useLaunchWorkflowFormState({
         SearchableSelectorOption<WorkflowId>
     >();
     const selectedWorkflowId = selectedWorkflow ? selectedWorkflow.data : null;
+
+    const [inputValueCache] = useState(createInputValueCache());
 
     // We have to do a single item get once a workflow is selected so that we
     // receive the full workflow spec
@@ -236,6 +239,7 @@ export function useLaunchWorkflowFormState({
         formInputsRef,
         formKey,
         inputLoadingState,
+        inputValueCache,
         launchPlanOptionsLoadingState,
         launchPlanSelectorOptions,
         onCancel,

--- a/src/components/Launch/LaunchWorkflowForm/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/utils.ts
@@ -13,6 +13,17 @@ import { inputToLiteral } from './inputHelpers/inputHelpers';
 import { SearchableSelectorOption } from './SearchableSelector';
 import { InputProps, InputType, InputTypeDefinition } from './types';
 
+/** Creates a unique cache key for an input based on its name and type.
+ * Note: This will not be *globally* unique, only unique within a single workflow
+ * definition.
+ */
+export function createInputCacheKey(
+    name: string,
+    { type }: InputTypeDefinition
+): string {
+    return `${name}_${type}`;
+}
+
 /** Safely retrieves the input mapping stored in a workflow, or an empty
  * logic if any optional property along the chain is undefined.
  */

--- a/src/components/Literals/RemoteLiteralMapViewer.tsx
+++ b/src/components/Literals/RemoteLiteralMapViewer.tsx
@@ -2,7 +2,7 @@ import { WaitForData } from 'components/common';
 import { useRemoteLiteralMap } from 'components/hooks';
 import { UrlBlob } from 'models';
 import * as React from 'react';
-import { maxViewSizeBytes } from './constants';
+import { maxBlobDownloadSizeBytes } from './constants';
 import { LiteralMapViewer } from './LiteralMapViewer';
 
 const DownloadAndRenderBlob: React.FC<{ url: string }> = ({ url }) => {
@@ -37,7 +37,7 @@ export const RemoteLiteralMapViewer: React.FC<{ blob: UrlBlob }> = ({
         );
     }
 
-    return blob.bytes.gt(maxViewSizeBytes) ? (
+    return blob.bytes.gt(maxBlobDownloadSizeBytes) ? (
         <BlobTooLarge url={blob.url} />
     ) : (
         <DownloadAndRenderBlob url={blob.url} />

--- a/src/components/Literals/constants.ts
+++ b/src/components/Literals/constants.ts
@@ -1,4 +1,4 @@
-export const maxViewSizeBytes = 100000;
+export const maxBlobDownloadSizeBytes = 100000;
 export const htmlEntities = {
     leftBracket: '\u005B',
     rightBracket: '\u005D',

--- a/src/components/hooks/types.ts
+++ b/src/components/hooks/types.ts
@@ -10,7 +10,7 @@ export interface FetchArgs {
 }
 
 export interface FetchableData<T> {
-    fetch(fetchArgs?: FetchArgs): Promise<T>;
+    fetch(fetchArgs?: FetchArgs): Promise<any>;
     hasLoaded: boolean;
     lastError: Error | null;
     loading: boolean;

--- a/src/components/hooks/useRemoteLiteralMap.ts
+++ b/src/components/hooks/useRemoteLiteralMap.ts
@@ -1,20 +1,17 @@
-import { createCorsProxyURL } from 'common/utils';
-import { getProtobufObject, LiteralMap } from 'models';
+import { useAPIContext } from 'components/data/apiContext';
+import { LiteralMap } from 'models';
 import { FetchableData } from './types';
 import { useFetchableData } from './useFetchableData';
 
 /** Fetches a LiteralMap from a given URL */
 export function useRemoteLiteralMap(url: string): FetchableData<LiteralMap> {
+    const { getRemoteLiteralMap } = useAPIContext();
     // TODO: caching of these objects (can they change?)
     return useFetchableData<LiteralMap, string>(
         {
             debugName: 'RemoteLiteralMap',
             defaultValue: {} as LiteralMap,
-            doFetch: blobUrl =>
-                getProtobufObject(
-                    { url: createCorsProxyURL(blobUrl) },
-                    LiteralMap
-                )
+            doFetch: blobUrl => getRemoteLiteralMap(blobUrl)
         },
         url
     );

--- a/src/components/hooks/useWorkflowExecution.ts
+++ b/src/components/hooks/useWorkflowExecution.ts
@@ -48,6 +48,9 @@ export function useWorkflowExecutionData(
     );
 }
 
+/** A hook for fetching the inputs object associated with an Execution. Will
+ * handle both the legacy (`computedInputs`) and current (externally stored) formats
+ */
 export function useWorkflowExecutionInputs(execution: Execution) {
     const { getExecutionData, getRemoteLiteralMap } = useAPIContext();
     return useFetchableData<LiteralMap, WorkflowExecutionIdentifier>(

--- a/src/components/hooks/useWorkflowExecution.ts
+++ b/src/components/hooks/useWorkflowExecution.ts
@@ -2,11 +2,13 @@ import {
     Execution,
     ExecutionData,
     getExecution,
-    getExecutionData,
+    LiteralMap,
     terminateWorkflowExecution,
     WorkflowExecutionIdentifier
 } from 'models';
 
+import { useAPIContext } from 'components/data/apiContext';
+import { maxBlobDownloadSizeBytes } from 'components/Literals/constants';
 import { FetchableData, FetchableExecution } from './types';
 import { useFetchableData } from './useFetchableData';
 
@@ -35,6 +37,7 @@ export function useWorkflowExecution(
 export function useWorkflowExecutionData(
     id: WorkflowExecutionIdentifier
 ): FetchableData<ExecutionData> {
+    const { getExecutionData } = useAPIContext();
     return useFetchableData<ExecutionData, WorkflowExecutionIdentifier>(
         {
             debugName: 'ExecutionData',
@@ -42,5 +45,30 @@ export function useWorkflowExecutionData(
             doFetch: id => getExecutionData(id)
         },
         id
+    );
+}
+
+export function useWorkflowExecutionInputs(execution: Execution) {
+    const { getExecutionData, getRemoteLiteralMap } = useAPIContext();
+    return useFetchableData<LiteralMap, WorkflowExecutionIdentifier>(
+        {
+            debugName: 'ExecutionInputs',
+            defaultValue: { literals: {} } as LiteralMap,
+            doFetch: async () => {
+                if (execution.closure.computedInputs) {
+                    return execution.closure.computedInputs;
+                }
+                const { inputs } = await getExecutionData(execution.id);
+                if (
+                    !inputs.url ||
+                    !inputs.bytes ||
+                    inputs.bytes.gt(maxBlobDownloadSizeBytes)
+                ) {
+                    return { literals: {} };
+                }
+                return getRemoteLiteralMap(inputs.url);
+            }
+        },
+        execution.id
     );
 }

--- a/src/models/Common/api.ts
+++ b/src/models/Common/api.ts
@@ -4,15 +4,18 @@ import {
     defaultPaginationConfig,
     getAdminEntity,
     getProfileUrl,
+    getProtobufObject,
     PaginatedEntityResponse,
     RequestConfig
 } from 'models/AdminEntity';
 
 import { log } from 'common/log';
+import { createCorsProxyURL } from 'common/utils';
 import { transformRequestError } from 'models/AdminEntity/transformRequestError';
 import { defaultAxiosConfig, identifierPrefixes } from './constants';
 import {
     IdentifierScope,
+    LiteralMap,
     NamedEntity,
     NamedEntityIdentifier,
     ResourceType,
@@ -123,3 +126,6 @@ export const getUserProfile = async () => {
         return null;
     }
 };
+
+export const getRemoteLiteralMap = async (url: string) =>
+    getProtobufObject<LiteralMap>({ url: createCorsProxyURL(url) }, LiteralMap);

--- a/src/models/Common/api.ts
+++ b/src/models/Common/api.ts
@@ -127,5 +127,8 @@ export const getUserProfile = async () => {
     }
 };
 
+/** Given a url to a `LiteralMap` stored at a remote location, will fetch and
+ * decode the resulting object.
+ */
 export const getRemoteLiteralMap = async (url: string) =>
     getProtobufObject<LiteralMap>({ url: createCorsProxyURL(url) }, LiteralMap);


### PR DESCRIPTION
lyft/flyte#84

This is the bulk of the work needed to support a "Relaunch with edits" experience. It adds the ability for the launch form state to be initialized from specific parameters.

**Workflow Version**
The launch form can be pre-initialized to point to a specific workflow version. The provided version will be included in the fetching of workflow versions to show in the selector, and we will attempt to select that version after loading the options. Fallback behavior is to select the first item in the list (the latest version)

**Launch Plan**
Providing a launch plan id will cause that launch plan to be preferred. Similar to workflow versions, it will be included in the fetching of options. If we can't select the desired launch plan, we fall back to the first item in the list.
_Additionally_, when changing workflow versions, we will now preserve the selected launch plan **name** and attempt to select it before falling back to the first item in the list. This allows the user to change versions without losing their selected launch plan

**Input values**
A `Map` of `InputValue`s can also be provided. The keys for the map are a computed cache key based on the `type` of the input as well as its `name`. This ensures that we don't attempt to use a provided value for an input with the same name but a different type (for example, changing the type of an input between one version of a workflow and another).

_Caching of Input Values_
Values entered into the form (whether loaded from an execution or entered by the user) will be pushed into a cache held in a Context provider. When changing versions/launch plans, we will re-initialize the inputs using their cached values if possible. This allows users to change versions or launch plans without losing the values they entered.

The change also includes unit tests for most of the above-mentioned behavior, and a Storybook story that exercises the "launch from execution" behavior.

![image](https://user-images.githubusercontent.com/1815175/73795362-41d27c00-475f-11ea-94b3-ddde0b75b918.png)

(Preserving input values across version/launch plan changes)
![PreserveInputsAfterFormChange](https://user-images.githubusercontent.com/1815175/73795650-ff5d6f00-475f-11ea-8f8a-ca692fe1f684.gif)
