### PR TITLE
Fixing small issues with new Launch functionality

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -315,6 +315,28 @@ describe('LaunchWorkflowForm', () => {
             expect(mockListLaunchPlans).toHaveBeenCalled();
         });
 
+        it('should not clear launch plan when selecting the already selected workflow version', async () => {
+            const { getByLabelText, getByTitle } = renderForm();
+            await wait();
+
+            mockListLaunchPlans.mockClear();
+
+            // Click the expander for the workflow, select the second item
+            const workflowDiv = getByTitle(formStrings.workflowVersion);
+            const expander = getByRole(workflowDiv, 'button');
+            fireEvent.click(expander);
+            const items = await waitForElement(() =>
+                getAllByRole(workflowDiv, 'menuitem')
+            );
+            fireEvent.click(items[0]);
+
+            await wait();
+            expect(mockListLaunchPlans).not.toHaveBeenCalled();
+            expect(getByLabelText(formStrings.launchPlan)).toHaveValue(
+                mockWorkflow.id.name
+            );
+        });
+
         it('should update inputs when selecting a new launch plan', async () => {
             const { queryByLabelText, getByTitle } = renderForm();
             await wait();
@@ -486,6 +508,30 @@ describe('LaunchWorkflowForm', () => {
                 );
             });
 
+            it('should only include one instance of the preferred version in the selector', async () => {
+                const initialParameters: InitialLaunchParameters = {
+                    workflow: mockWorkflowVersions[2].id
+                };
+                const { getByTitle } = renderForm({ initialParameters });
+                await wait();
+                // Click the expander for the workflow, select the second item
+                const versionDiv = getByTitle(formStrings.workflowVersion);
+                const expander = getByRole(versionDiv, 'button');
+                fireEvent.click(expander);
+                const items = await waitForElement(() =>
+                    getAllByRole(versionDiv, 'menuitem')
+                );
+
+                const expectedVersion = mockWorkflowVersions[2].id.version;
+                expect(
+                    items.filter(
+                        item =>
+                            item.textContent &&
+                            item.textContent.includes(expectedVersion)
+                    )
+                ).toHaveLength(1);
+            });
+
             it('should fall back to the first item in the list if preferred workflow is not found', async () => {
                 mockListWorkflows.mockImplementation(
                     (scope: Partial<Identifier>) => {
@@ -519,6 +565,30 @@ describe('LaunchWorkflowForm', () => {
                 expect(getByLabelText(formStrings.launchPlan)).toHaveValue(
                     mockLaunchPlans[1].id.name
                 );
+            });
+
+            it('should only include one instance of the preferred launch plan in the selector', async () => {
+                const initialParameters: InitialLaunchParameters = {
+                    launchPlan: mockLaunchPlans[1].id
+                };
+                const { getByTitle } = renderForm({ initialParameters });
+                await wait();
+                // Click the expander for the LaunchPlan, select the second item
+                const launchPlanDiv = getByTitle(formStrings.launchPlan);
+                const expander = getByRole(launchPlanDiv, 'button');
+                fireEvent.click(expander);
+                const items = await waitForElement(() =>
+                    getAllByRole(launchPlanDiv, 'menuitem')
+                );
+
+                const expectedName = mockLaunchPlans[1].id.name;
+                expect(
+                    items.filter(
+                        item =>
+                            item.textContent &&
+                            item.textContent.includes(expectedName)
+                    )
+                ).toHaveLength(1);
             });
 
             it('should fall back to the default launch plan if the preferred is not found', async () => {

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -121,7 +121,7 @@ function useLaunchPlansForWorkflow({
                     ...launchPlansResult.entities,
                     ...preferredLaunchPlanResult.entities
                 ];
-                return uniqBy(merged, ({ id: name }) => name);
+                return uniqBy(merged, ({ id }) => id.name);
             }
         },
         workflowId
@@ -268,6 +268,9 @@ export function useLaunchWorkflowFormState({
     const onSelectWorkflow = (
         newWorkflow: SearchableSelectorOption<WorkflowId>
     ) => {
+        if (newWorkflow === selectedWorkflow) {
+            return;
+        }
         setLaunchPlan(undefined);
         setWorkflow(newWorkflow);
     };
@@ -275,6 +278,9 @@ export function useLaunchWorkflowFormState({
     const onSelectLaunchPlan = (
         newLaunchPlan: SearchableSelectorOption<LaunchPlan>
     ) => {
+        if (newLaunchPlan === selectedLaunchPlan) {
+            return;
+        }
         setLastSelectedLaunchPlanName(newLaunchPlan.name);
         setLaunchPlan(newLaunchPlan);
     };


### PR DESCRIPTION
Some testing discovered the following issues:
* Selecting the already-selected version in the Workflow Version dropdown causes the LaunchPlan to be de-selected.
  * This was caused by allowing the workflow selection code to run even when the value is the same. Since we clear the selected launch plan in response to that, and the effects which would auto-select the launch plan do not run (because no inputs have _actually_ changed), it results in a de-selection of the launch plan. The fix is to bail out early if we're attempting to select the currently selected items. 
* When re-launching an execution, there are two copies of the same LaunchPlan name in the selector.
  * This was caused by a bad destructuring of the input. I had meant to extract the `id.name` property for comparison when de-duplicating the list of launch plans. Instead I ended up assigning the `id` property to a local variable called `name`.

Also includes tests for these two regressions.