### PR TITLE
Fixing hanging docker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "favicons-webpack-plugin": "^1.0.2",
     "file-loader": "^1.1.11",
     "fork-ts-checker-webpack-plugin": "^4.0.3",
-    "happypack": "^5.0.0-beta.3",
     "html-webpack-externals-plugin": "^3.7.0",
     "html-webpack-plugin": "^3.2.0",
     "husky": "^0.14.3",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -8,7 +8,6 @@ import * as webpack from 'webpack';
 const { StatsWriterPlugin } = require('webpack-stats-plugin');
 const FavIconWebpackPlugin = require('favicons-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const HappyPack = require('happypack');
 const HTMLExternalsWebpackPlugin = require('html-webpack-externals-plugin');
 const nodeExternals = require('webpack-node-externals');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
@@ -67,7 +66,7 @@ export const resolve: webpack.Resolve = {
     /** Base directories that Webpack will look to resolve absolutely imported modules */
     modules: ['src', 'node_modules'],
     /** Extension that are allowed to be omitted from import statements */
-    extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
     /** "main" fields in package.json files to resolve a CommonJS module for */
     mainFields: ['browser', 'module', 'main']
 };
@@ -210,7 +209,7 @@ export const limitChunksPlugin = new webpack.optimize.LimitChunkCountPlugin({
 const typescriptRule = {
     test: /\.tsx?$/,
     exclude: /node_modules/,
-    loader: 'happypack/loader?id=ts'
+    use: ['babel-loader', 'ts-loader']
 };
 
 /**
@@ -273,10 +272,6 @@ export const clientConfig: webpack.Configuration = {
     get plugins() {
         const plugins: webpack.Plugin[] = [
             htmlPlugin,
-            new HappyPack({
-                id: 'ts',
-                loaders: ['babel-loader', 'ts-loader?happyPackMode=true']
-            }),
             new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true }),
             favIconPlugin,
             statsWriterPlugin,
@@ -323,10 +318,6 @@ export const serverConfig: webpack.Configuration = {
     },
     plugins: [
         limitChunksPlugin,
-        new HappyPack({
-            id: 'ts',
-            loaders: ['babel-loader', 'ts-loader?happyPackMode=true']
-        }),
         new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true }),
         getDefinePlugin(true)
         // namedModulesPlugin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,11 +3447,6 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.0.tgz#2796642723573859565633fc6274444bee2f8ce3"
-  integrity sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM=
-
 async@^2.5.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -6889,16 +6884,6 @@ gzip-size@5.1.1:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-happypack@^5.0.0-beta.3:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/happypack/-/happypack-5.0.1.tgz#850839426d6205a520bf913e962349fbe523a07c"
-  integrity sha512-AzXVxLzX0mtv0T40Kic72rfcGK4Y2b/cDdtcyw+e+V/13ozl7x0+EZ4hvrL1rJ8MoefR9+FfUJQsK2irH0GWOw==
-  dependencies:
-    async "1.5.0"
-    json-stringify-safe "5.0.1"
-    loader-utils "1.1.0"
-    serialize-error "^2.1.0"
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -8474,7 +8459,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -8807,15 +8792,6 @@ loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
-
-loader-utils@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
-  integrity sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
 
 loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
@@ -11841,11 +11817,6 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
-
-serialize-error@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
-  integrity sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=
 
 serialize-javascript@^1.4.0:
   version "1.9.1"


### PR DESCRIPTION
With the recent dependency upgrades, running the docker build is hanging on the forked Typescript processes launched by Happypack.

A little investigation revealed that Happypack has been deprecated by its author, and that in Webpack 4+ environments it doesn't add much benefit. So I've removed it from our config and ✨ the docker build finishes again. ✨ I may come back later and investigate using `thread-loader` to get an extra performance benefit.

I also re-ordered the resolve config to prefer typescript extensions when searching.