### PR TITLE
Fixing a bug with searching workflow versions when relaunching an execution

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
@@ -30,19 +30,23 @@ function generateFetchSearchResults(
     workflowId: NamedEntityIdentifier
 ) {
     return async (query: string) => {
-        const { entities: workflows } = await listWorkflows(workflowId, {
-            filter: [
-                {
-                    key: 'version',
-                    operation: FilterOperationName.CONTAINS,
-                    value: query
+        const { project, domain, name } = workflowId;
+        const { entities: workflows } = await listWorkflows(
+            { project, domain, name },
+            {
+                filter: [
+                    {
+                        key: 'version',
+                        operation: FilterOperationName.CONTAINS,
+                        value: query
+                    }
+                ],
+                sort: {
+                    key: workflowSortFields.createdAt,
+                    direction: SortDirection.DESCENDING
                 }
-            ],
-            sort: {
-                key: workflowSortFields.createdAt,
-                direction: SortDirection.DESCENDING
             }
-        });
+        );
         return workflowsToSearchableSelectorOptions(workflows);
     };
 }

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -67,6 +67,11 @@ describe('LaunchWorkflowForm', () => {
 
     beforeEach(() => {
         onClose = jest.fn();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
     });
 
     const createMockWorkflowWithInputs = (id: Identifier) => {
@@ -254,7 +259,6 @@ describe('LaunchWorkflowForm', () => {
         });
 
         it('should not show validation errors until first submit', async () => {
-            jest.useFakeTimers();
             const { container, getByLabelText } = renderForm();
             await wait();
 
@@ -276,7 +280,6 @@ describe('LaunchWorkflowForm', () => {
         });
 
         it('should update validation errors while typing', async () => {
-            jest.useFakeTimers();
             const { container, getByLabelText } = renderForm();
             await wait();
 
@@ -367,7 +370,6 @@ describe('LaunchWorkflowForm', () => {
         });
 
         it('should preserve input values when changing launch plan', async () => {
-            jest.useFakeTimers();
             const { getByLabelText, getByTitle } = renderForm();
             await wait();
 
@@ -688,6 +690,37 @@ describe('LaunchWorkflowForm', () => {
                 await wait();
                 expect(getByLabelText(formStrings.launchPlan)).toHaveValue(
                     missingLaunchPlan.id.name
+                );
+            });
+
+            it('should correctly render workflow version search results', async () => {
+                const initialParameters: InitialLaunchParameters = {
+                    workflow: mockWorkflowVersions[2].id
+                };
+                const inputString = mockWorkflowVersions[1].id.version.substring(
+                    0,
+                    4
+                );
+                const { getByLabelText } = renderForm({ initialParameters });
+                await wait();
+
+                mockListWorkflows.mockClear();
+
+                const versionInput = getByLabelText(
+                    formStrings.workflowVersion
+                );
+                fireEvent.change(versionInput, {
+                    target: { value: inputString }
+                });
+
+                act(() => {
+                    jest.runAllTimers();
+                });
+                await wait();
+                const { project, domain, name } = mockWorkflowVersions[2].id;
+                expect(mockListWorkflows).toHaveBeenCalledWith(
+                    { project, domain, name },
+                    expect.anything()
                 );
             });
         });

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -209,7 +209,10 @@ export const limitChunksPlugin = new webpack.optimize.LimitChunkCountPlugin({
 const typescriptRule = {
     test: /\.tsx?$/,
     exclude: /node_modules/,
-    use: ['babel-loader', 'ts-loader']
+    use: [
+        'babel-loader',
+        { loader: 'ts-loader', options: { transpileOnly: true } }
+    ]
 };
 
 /**


### PR DESCRIPTION
There is a fetch function used to search for workflow versions. It was relying on the incoming workflow id to be only partially specified. In the case of a relaunch, the workflow id will include a version, but that version should not be included in the `scope` value we pass to the list endpoint function.

Also during this fix, I was running into OOM crashes with `ts-loader` because it was doing type-checking in addition to transpiling. In our webpack setup, we are using the forked checker plugin for type checking, so `ts-loader` should be put into `transpileOnly` mode.

And I also cleaned up the timer usage in the launch form tests, because I was getting arbitrary infinite timer loops due to the 

Before:
![wf_version_search_bug_beforegif](https://user-images.githubusercontent.com/1815175/74572501-12c4c300-4f34-11ea-9233-b812d6bb530b.gif)

After:
![wf_version_search_bug_after](https://user-images.githubusercontent.com/1815175/74572510-15271d00-4f34-11ea-8cda-596e6b5ad621.gif)
