### PR TITLE
Fixes initial population of values for string Collections in the launch form.

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/collection.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/collection.ts
@@ -1,9 +1,10 @@
 import { Core } from 'flyteidl';
-import { InputTypeDefinition, InputValue } from '../types';
+import { InputType, InputTypeDefinition, InputValue } from '../types';
 import { literalNone } from './constants';
 import { getHelperForInput } from './getHelperForInput';
 import { parseJSON } from './parseJson';
 import { ConverterInput, InputHelper } from './types';
+import { collectionChildToString } from './utils';
 
 const missingSubTypeError = 'Unexpected missing subtype for collection';
 
@@ -36,7 +37,7 @@ function fromLiteral(
         (out, literal) => {
             const value = subTypeHelper.fromLiteral(literal, subtype);
             if (value !== undefined) {
-                out.push(value.toString());
+                out.push(collectionChildToString(subtype.type, value));
             }
             return out;
         },

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -7,6 +7,7 @@ import {
     literalToInputValue,
     validateInput
 } from '../inputHelpers';
+import { collectionChildToString } from '../utils';
 import {
     literalTestCases,
     literalToInputTestCases,
@@ -89,8 +90,7 @@ describe('literalToInputValue', () => {
                         literals: [input, input]
                     }
                 };
-                const stringifiedValue =
-                    output === undefined ? '' : output.toString();
+                const stringifiedValue = collectionChildToString(type, output);
                 const expectedString = `[${stringifiedValue},${stringifiedValue}]`;
                 const result = literalToInputValue(
                     { type: InputType.Collection, subtype: { type } },

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -23,10 +23,5 @@ export function collectionChildToString(type: InputType, value: any) {
     if (value === undefined) {
         return '';
     }
-    switch (type) {
-        case InputType.Integer:
-            return `${value}`;
-        default:
-            return JSON.stringify(value);
-    }
+    return type === InputType.Integer ? `${value}` : JSON.stringify(value);
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -1,5 +1,6 @@
 import { Core } from 'flyteidl';
 import { get } from 'lodash';
+import { InputType } from '../types';
 
 /** Performs a deep get of `path` on the given `Core.ILiteral`. Will throw
  * if the given property doesn't exist.
@@ -13,4 +14,20 @@ export function extractLiteralWithCheck<T>(
         throw new Error(`Failed to extract literal value with path ${path}`);
     }
     return value as T;
+}
+
+/** Converts a value within a collection to it appropriate string
+ * representation. Some values require additional quotes.
+ */
+export function collectionChildToString(type: InputType, value: any) {
+    if (value === undefined) {
+        return '';
+    }
+    switch (type) {
+        case InputType.Integer:
+        case InputType.Float:
+            return `${value}`;
+        default:
+            return JSON.stringify(value);
+    }
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -16,7 +16,7 @@ export function extractLiteralWithCheck<T>(
     return value as T;
 }
 
-/** Converts a value within a collection to it appropriate string
+/** Converts a value within a collection to the appropriate string
  * representation. Some values require additional quotes.
  */
 export function collectionChildToString(type: InputType, value: any) {
@@ -25,7 +25,6 @@ export function collectionChildToString(type: InputType, value: any) {
     }
     switch (type) {
         case InputType.Integer:
-        case InputType.Float:
             return `${value}`;
         default:
             return JSON.stringify(value);


### PR DESCRIPTION
lyft/flyte#181

When converting `Literal` values to `InputValue`s for use in the form, the `Collection` type is output as a JSON representation of an array. The existing implementation was blindly wrapping `[]` around values and comma-separating them. For Dates and strings, the resulting array string is not valid JSON and will trigger validation errors.

It turned out to be easier to allow `JSON.stringify` to do this work for us, with the exception of integers. Since we use a special type for integers, `stringify` would result in a quoted string value instead of a bare integer value.