### PR TITLE
Select contents of workflow version selector on focus

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -693,6 +693,29 @@ describe('LaunchWorkflowForm', () => {
                 );
             });
 
+            it('should select contents of workflow version input on focus', async () => {
+                const { getByLabelText } = renderForm();
+                await wait();
+
+                // Focus the workflow version input
+                const workflowInput = getByLabelText(
+                    formStrings.workflowVersion
+                );
+                fireEvent.focus(workflowInput);
+
+                act(() => {
+                    jest.runAllTimers();
+                });
+
+                const expectedValue = mockWorkflowVersions[0].id.version;
+
+                // The value should remain, but selection should be the entire string
+                expect(workflowInput).toHaveValue(expectedValue);
+                expect((workflowInput as HTMLInputElement).selectionEnd).toBe(
+                    expectedValue.length
+                );
+            });
+
             it('should correctly render workflow version search results', async () => {
                 const initialParameters: InitialLaunchParameters = {
                     workflow: mockWorkflowVersions[2].id


### PR DESCRIPTION
lyft/flyte#140

Previously, we would clear the value of this input every time the user focused, so that they could begin typing right away. The goal was convenience. But it makes it difficult to copy the value from the input.

A solution that covers both needs is to simply highlight the contents on focus, so they are copyable and so that typing will have the effect of clearing the existing value.

![DontClearWFVersionOnClick](https://user-images.githubusercontent.com/1815175/75078956-e40e9580-54bb-11ea-922a-1dee6dbb64d9.gif)
