### PR TITLE
Preserves unsupported input types when relaunching

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/UnsupportedInput.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/UnsupportedInput.tsx
@@ -14,7 +14,7 @@ export const UnsupportedInput: React.FC<InputProps> = props => {
             variant="outlined"
             disabled={true}
             helperText={description}
-            value="This type is not supported by Flyte Console"
+            value="Flyte Console does not support entering values of this type"
         />
     );
 };

--- a/src/components/Launch/LaunchWorkflowForm/getInputs.ts
+++ b/src/components/Launch/LaunchWorkflowForm/getInputs.ts
@@ -1,11 +1,8 @@
 import { sortedObjectEntries } from 'common/utils';
 import { LaunchPlan, Workflow } from 'models';
+import { LiteralValueMap, ParsedInput } from './types';
 import {
-    defaultValueForInputType,
-    literalToInputValue
-} from './inputHelpers/inputHelpers';
-import { ParsedInput } from './types';
-import {
+    createInputCacheKey,
     formatLabelWithType,
     getInputDefintionForLiteralType,
     getWorkflowInputs
@@ -17,7 +14,8 @@ const emptyDescription = ' ';
 
 export function getInputs(
     workflow: Workflow,
-    launchPlan: LaunchPlan
+    launchPlan: LaunchPlan,
+    initialValues: LiteralValueMap = new Map()
 ): ParsedInput[] {
     if (!launchPlan.closure || !workflow) {
         return [];
@@ -39,15 +37,16 @@ export function getInputs(
         );
         const typeLabel = formatLabelWithType(name, typeDefinition);
         const label = required ? `${typeLabel}*` : typeLabel;
-
-        const defaultValue =
-            parameter.default != null
-                ? literalToInputValue(typeDefinition, parameter.default)
-                : defaultValueForInputType(typeDefinition);
+        const inputKey = createInputCacheKey(name, typeDefinition);
+        const defaultVaue =
+            parameter.default != null ? parameter.default : undefined;
+        const initialValue = initialValues.has(inputKey)
+            ? initialValues.get(inputKey)
+            : defaultVaue;
 
         return {
-            defaultValue,
             description,
+            initialValue,
             label,
             name,
             required,

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -1,4 +1,5 @@
 import { Core } from 'flyteidl';
+import { primitiveLiteral } from '../../__mocks__/utils';
 import { InputProps, InputType } from '../../types';
 import { literalNone } from '../constants';
 import { getHelperForInput } from '../getHelperForInput';
@@ -192,6 +193,18 @@ describe('inputToLiteral', () => {
             })
         );
     });
+
+    it('Should return initial value for inputs with no value', () => {
+        const simpleInput = makeSimpleInput(
+            InputType.String,
+            primitiveLiteral({ stringValue: '' })
+        );
+        const initialValue = primitiveLiteral({ stringValue: 'abcdefg' });
+        simpleInput.required = true;
+        simpleInput.initialValue = initialValue;
+        delete simpleInput.value;
+        expect(inputToLiteral(simpleInput)).toEqual(initialValue);
+    });
 });
 
 function generateValidityTests(
@@ -242,5 +255,16 @@ describe('validateInput', () => {
         simpleInput.required = true;
         delete simpleInput.value;
         expect(() => validateInput(simpleInput)).toThrowError();
+    });
+
+    it('should not throw an error for a required input with an initial value and no value', () => {
+        const simpleInput = makeSimpleInput(
+            InputType.String,
+            primitiveLiteral({ stringValue: '' })
+        );
+        simpleInput.required = true;
+        simpleInput.initialValue = primitiveLiteral({ stringValue: 'abcdefg' });
+        delete simpleInput.value;
+        expect(() => validateInput(simpleInput)).not.toThrowError();
     });
 });

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -646,7 +646,10 @@ describe('LaunchWorkflowForm', () => {
             });
 
             it('should prepopulate inputs with provided initial values', async () => {
-                const initialStringValue = 'initialStringValue';
+                const stringValue = 'initialStringValue';
+                const initialStringValue: Core.ILiteral = {
+                    scalar: { primitive: { stringValue } }
+                };
                 const parameters = mockLaunchPlans[0].closure!.expectedInputs
                     .parameters;
                 const values = new Map();
@@ -664,7 +667,7 @@ describe('LaunchWorkflowForm', () => {
 
                 expect(
                     getByLabelText(stringInputName, { exact: false })
-                ).toHaveValue(initialStringValue);
+                ).toHaveValue(stringValue);
             });
 
             it('loads preferred workflow version when it does not exist in the list of suggestions', async () => {

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -10,11 +10,12 @@ import {
 import { SearchableSelectorOption } from './SearchableSelector';
 
 export type InputValueMap = Map<string, InputValue>;
+export type LiteralValueMap = Map<string, Core.ILiteral>;
 
 export interface InitialLaunchParameters {
     launchPlan?: Identifier;
     workflow?: WorkflowId;
-    values?: InputValueMap;
+    values?: LiteralValueMap;
 }
 
 export interface LaunchWorkflowFormProps {
@@ -80,6 +81,7 @@ export interface InputProps {
     description: string;
     error?: string;
     helperText?: string;
+    initialValue?: Core.ILiteral;
     name: string;
     label: string;
     required: boolean;
@@ -93,6 +95,6 @@ export interface ParsedInput
         InputProps,
         'description' | 'label' | 'name' | 'required' | 'typeDefinition'
     > {
-    /** Indicates the value to use when the input is in a default state */
-    defaultValue?: InputValue;
+    /** Provides an initial value for the input, which can be changed by the user. */
+    initialValue?: Core.ILiteral;
 }

--- a/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
@@ -101,7 +101,6 @@ export function useFormInputsState(
         return valid;
     };
 
-    // TODO: We need the initialValues passed into this as well
     const getValues = () => convertFormInputsToLiterals(inputs);
 
     return {

--- a/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useFormInputsState.ts
@@ -2,6 +2,7 @@ import { useDebouncedValue } from 'components/hooks/useDebouncedValue';
 import { Core } from 'flyteidl';
 import { useEffect, useMemo, useState } from 'react';
 import {
+    defaultValueForInputType,
     literalToInputValue,
     validateInput
 } from './inputHelpers/inputHelpers';
@@ -34,7 +35,7 @@ function useFormInputState(parsedInput: ParsedInput): FormInputState {
     const [value, setValue] = useState<InputValue | undefined>(() => {
         const parsedInitialValue = initialValue
             ? literalToInputValue(parsedInput.typeDefinition, initialValue)
-            : undefined;
+            : defaultValueForInputType(typeDefinition);
         return inputValueCache.has(cacheKey)
             ? inputValueCache.get(cacheKey)
             : parsedInitialValue;

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -221,10 +221,7 @@ export function useLaunchWorkflowFormState({
     >();
     const selectedWorkflowId = selectedWorkflow ? selectedWorkflow.data : null;
 
-    const inputValueCache = useMemo(
-        () => createInputValueCache(initialParameters.values),
-        [initialParameters.values]
-    );
+    const [inputValueCache] = useState(createInputValueCache());
 
     // We have to do a single item get once a workflow is selected so that we
     // receive the full workflow spec
@@ -345,7 +342,11 @@ export function useLaunchWorkflowFormState({
     useEffect(() => {
         const parsedInputs =
             launchPlanData && workflow.hasLoaded
-                ? getInputs(workflow.value, launchPlanData)
+                ? getInputs(
+                      workflow.value,
+                      launchPlanData,
+                      initialParameters.values
+                  )
                 : [];
         setParsedInputs(parsedInputs);
     }, [workflow.hasLoaded, workflow.value, launchPlanData]);


### PR DESCRIPTION
lyft/flyte#186

For some input types, we don't yet have editing support in Flyte Console. This caused a regression when changing our relaunch flow to use the form (see the above issue). 

However, it's possible for us to preserve the `Literal` that we extracted from the source execution and pass it along unmodified when we relaunch the execution. This change enables that behavior by changing the types passed down to our input state to be a `Core.ILiteral` until it is actually necessary to convert it to an `InputValue`. When the form is submitted, if there is no user-provided value, but there *is* an initial value, we will send that instead.

* Updated `ParsedInput` and `InputProps` to add the `initialValue` field. Removed the `defaultValue` field.
* Moved the logic for converting from `Literal` to `InputValue` down to the input state hook.
* Moved logic for using the default `InputValue` into the input state hook.
* Updated validation to only throw errors if a required input does not have an initial value
* Updated `inputToLiteral` to return the `initialValue` property if provided and the user entered no value.
* No longer setting any values into the InputCache from the form state hook. It's only used by the input state hook to preserve user-provided values. Default values and values initialized from an execution will be passed down via the `initialValue` properties and parsed by the input state hook.