### PR TITLE
Status endpoints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .git
 .env
 node_modules
+Dockerfile
+.dockerignore
 npm-debug.log
 .storybook
 .vscode

--- a/env.js
+++ b/env.js
@@ -15,6 +15,15 @@ const CORS_PROXY_PREFIX = process.env.CORS_PROXY_PREFIX || '/cors_proxy';
 const CONFIG_DIR = process.env.CONFIG_DIR || './config';
 const CONFIG_CACHE_TTL_SECONDS = process.env.CONFIG_CACHE_TTL_SECONDS || '60';
 
+// Defines a file to be required which will provide implementations for
+// any user-definable code.
+const PLUGINS_MODULE = process.env.PLUGINS_MODULE;
+
+// Optional URL which will provide information about system status. This is used
+// to show informational banners to the user.
+// If it has no protocol, it will be treated as relative to window.location.origin
+const STATUS_URL = process.env.STATUS_URL;
+
 module.exports = {
     ADMIN_API_URL,
     BASE_URL,
@@ -23,10 +32,13 @@ module.exports = {
     CONFIG_DIR,
     CORS_PROXY_PREFIX,
     NODE_ENV,
+    PLUGINS_MODULE,
+    STATUS_URL,
     processEnv: {
         ADMIN_API_URL,
         BASE_URL,
         CORS_PROXY_PREFIX,
-        NODE_ENV
+        NODE_ENV,
+        STATUS_URL
     }
 };

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const app = express();
 
 // Enable logging for HTTP access
 app.use(morgan('combined'));
+app.use(express.json());
 
 app.get(`${env.BASE_URL}/healthz`, (_req, res) => res.status(200).send());
 app.use(corsProxy(`${env.BASE_URL}${env.CORS_PROXY_PREFIX}`));

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const morgan = require('morgan');
 const express = require('express');
 const env = require('./env');
+const { applyMiddleware } = require('./plugins');
 
 const corsProxy = require('./corsProxy.js');
 
@@ -18,6 +19,11 @@ app.use(morgan('combined'));
 
 app.get(`${env.BASE_URL}/healthz`, (_req, res) => res.status(200).send());
 app.use(corsProxy(`${env.BASE_URL}${env.CORS_PROXY_PREFIX}`));
+
+if (typeof applyMiddleware === 'function') {
+    console.log('Found middleware plugins, applying...');
+    applyMiddleware(app);
+}
 
 if (process.env.NODE_ENV === 'production') {
     const path = require('path');

--- a/plugins.js
+++ b/plugins.js
@@ -1,0 +1,11 @@
+const env = require('./env');
+
+const { middleware } = env.PLUGINS_MODULE ? require(env.PLUGINS_MODULE) : {};
+
+if (Array.isArray(middleware)) {
+    module.exports.applyMiddleware = app => middleware.forEach(m => m(app));
+} else if (middleware !== undefined) {
+    console.log(
+        `Expected middleware to be of type Array, but got ${middleware} instead`
+    );
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -12,4 +12,5 @@ export interface Env extends NodeJS.ProcessEnv {
     BASE_URL?: string;
     CORS_PROXY_PREFIX: string;
     DISABLE_ANALYTICS?: string;
+    STATUS_URL?: string;
 }


### PR DESCRIPTION
This is the first change set for implementing a global notification banner. _Note_: This is being opened against a feature branch, as this is not the completely implementation of the change.

* Added ability for the console server to load custom middleware. This makes it possible to implement additional endpoints in private code that will be added to the console server at runtime.
* Added environment variable for `STATUS_URL`. This will be used in an upcoming change to ping for system status and conditionally show the notification banner.
* Updated Dockerfile excludes.

## Tracking Issue
https://github.com/lyft/flyte/issues/223
