### PR TITLE
Status banner

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -4,6 +4,7 @@ import { env } from 'common/env';
 import { debug, debugPrefix } from 'common/log';
 import { APIContext, useAPIState } from 'components/data/apiContext';
 import { LoginExpiredHandler } from 'components/Errors/LoginExpiredHandler';
+import { SystemStatusBanner } from 'components/Notifications/SystemStatusBanner';
 import { skeletonColor, skeletonHighlightColor } from 'components/Theme';
 import { muiTheme } from 'components/Theme/muiTheme';
 import * as React from 'react';
@@ -41,6 +42,7 @@ export const AppComponent: React.StatelessComponent<{}> = () => {
                             <LoginExpiredHandler />
                         </ErrorBoundary>
                     </Router>
+                    <SystemStatusBanner />
                 </SkeletonTheme>
             </APIContext.Provider>
         </ThemeProvider>

--- a/src/components/Notifications/SystemStatusBanner.tsx
+++ b/src/components/Notifications/SystemStatusBanner.tsx
@@ -1,0 +1,59 @@
+import Paper from '@material-ui/core/Paper';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import { WaitForData } from 'components/common';
+import { SystemStatus } from 'models/Common/types';
+import * as React from 'react';
+import { useSystemStatus } from './useSystemStatus';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    statusPaper: {
+        bottom: theme.spacing(3),
+        margin: theme.spacing(3),
+        position: 'absolute'
+    },
+    statusContentContainer: {
+        display: 'flex'
+    },
+    statusClose: {
+        flex: '0 0 auto'
+    },
+    statusIcon: {
+        flex: '0 0 auto'
+    },
+    statusMessage: {
+        flex: '1 1 auto'
+    }
+}));
+
+const RenderSystemStatusBanner: React.FC<{
+    status: SystemStatus;
+    onClose: () => void;
+}> = ({ status, onClose }) => {
+    const styles = useStyles();
+    return (
+        <Paper className={styles.statusPaper} elevation={2} square={true}>
+            <div className={styles.statusContentContainer}>
+                <div className={styles.statusMessage}>{status.message}</div>
+            </div>
+        </Paper>
+    );
+};
+
+export const SystemStatusBanner: React.FC<{}> = () => {
+    const systemStatus = useSystemStatus();
+    const [dismissed, setDismissed] = React.useState(false);
+    const onClose = () => setDismissed(true);
+    if (dismissed) {
+        return null;
+    }
+    return (
+        <WaitForData {...systemStatus}>
+            {systemStatus.value.message && (
+                <RenderSystemStatusBanner
+                    status={systemStatus.value}
+                    onClose={onClose}
+                />
+            )}
+        </WaitForData>
+    );
+};

--- a/src/components/Notifications/SystemStatusBanner.tsx
+++ b/src/components/Notifications/SystemStatusBanner.tsx
@@ -112,6 +112,10 @@ const RenderSystemStatusBanner: React.FC<{
     );
 };
 
+/** Fetches and renders the system status returned by issuing a GET to
+ * `env.STATUS_URL`. If the status includes a message, a dismissable toast
+ * will be rendered. Otherwise, nothing will be rendered.
+ */
 export const SystemStatusBanner: React.FC<{}> = () => {
     const systemStatus = useSystemStatus();
     const [dismissed, setDismissed] = React.useState(false);

--- a/src/components/Notifications/SystemStatusBanner.tsx
+++ b/src/components/Notifications/SystemStatusBanner.tsx
@@ -1,39 +1,112 @@
+import { ButtonBase, SvgIcon, Typography } from '@material-ui/core';
 import Paper from '@material-ui/core/Paper';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import Close from '@material-ui/icons/Close';
+import Info from '@material-ui/icons/Info';
+import Warning from '@material-ui/icons/Warning';
 import { WaitForData } from 'components/common';
-import { SystemStatus } from 'models/Common/types';
+import {
+    infoIconColor,
+    mutedButtonColor,
+    mutedButtonHoverColor,
+    warningIconColor
+} from 'components/Theme';
+import { StatusString, SystemStatus } from 'models/Common/types';
 import * as React from 'react';
 import { useSystemStatus } from './useSystemStatus';
 
 const useStyles = makeStyles((theme: Theme) => ({
+    closeButton: {
+        alignItems: 'center',
+        color: mutedButtonColor,
+        '&:hover': {
+            color: mutedButtonHoverColor
+        },
+        display: 'flex',
+        height: theme.spacing(3)
+    },
     statusPaper: {
-        bottom: theme.spacing(3),
-        margin: theme.spacing(3),
-        position: 'absolute'
+        bottom: theme.spacing(2),
+        display: 'flex',
+        left: '50%',
+        padding: theme.spacing(2),
+        position: 'fixed',
+        transform: 'translateX(-50%)'
     },
     statusContentContainer: {
-        display: 'flex'
+        alignItems: 'flex-start',
+        display: 'flex',
+        maxWidth: theme.spacing(131)
     },
     statusClose: {
+        alignItems: 'flex-start',
+        display: 'flex',
         flex: '0 0 auto'
     },
     statusIcon: {
-        flex: '0 0 auto'
+        alignItems: 'center',
+        display: 'flex',
+        flex: '0 0 auto',
+        lineHeight: `${theme.spacing(3)}px`
     },
     statusMessage: {
-        flex: '1 1 auto'
+        flex: '1 1 auto',
+        fontWeight: 'normal',
+        lineHeight: `${theme.spacing(3)}px`,
+        marginLeft: theme.spacing(2),
+        marginRight: theme.spacing(2)
     }
 }));
 
+interface StatusConstantValues {
+    color: string;
+    IconComponent: typeof SvgIcon;
+}
+
+const statusConstants: Record<StatusString, StatusConstantValues> = {
+    normal: {
+        color: infoIconColor,
+        IconComponent: Info
+    },
+    degraded: {
+        color: warningIconColor,
+        IconComponent: Warning
+    },
+    down: {
+        color: warningIconColor,
+        IconComponent: Warning
+    }
+};
+
+const StatusIcon: React.FC<{ status: StatusString }> = ({ status }) => {
+    const { color, IconComponent } =
+        statusConstants[status] || statusConstants.normal;
+    return <IconComponent htmlColor={color} />;
+};
+
 const RenderSystemStatusBanner: React.FC<{
-    status: SystemStatus;
+    systemStatus: SystemStatus;
     onClose: () => void;
-}> = ({ status, onClose }) => {
+}> = ({ systemStatus: { message, status }, onClose }) => {
     const styles = useStyles();
     return (
-        <Paper className={styles.statusPaper} elevation={2} square={true}>
+        <Paper className={styles.statusPaper} elevation={1} square={true}>
+            <div className={styles.statusIcon}>
+                <StatusIcon status={status} />
+            </div>
             <div className={styles.statusContentContainer}>
-                <div className={styles.statusMessage}>{status.message}</div>
+                <Typography variant="h6" className={styles.statusMessage}>
+                    {message}
+                </Typography>
+            </div>
+            <div className={styles.statusClose}>
+                <ButtonBase
+                    aria-label="Close"
+                    className={styles.closeButton}
+                    onClick={onClose}
+                >
+                    <Close fontSize="small" />
+                </ButtonBase>
             </div>
         </Paper>
     );
@@ -50,7 +123,7 @@ export const SystemStatusBanner: React.FC<{}> = () => {
         <WaitForData {...systemStatus}>
             {systemStatus.value.message && (
                 <RenderSystemStatusBanner
-                    status={systemStatus.value}
+                    systemStatus={systemStatus.value}
                     onClose={onClose}
                 />
             )}

--- a/src/components/Notifications/__stories__/SystemStatusBanner.stories.tsx
+++ b/src/components/Notifications/__stories__/SystemStatusBanner.stories.tsx
@@ -1,0 +1,40 @@
+import { storiesOf } from '@storybook/react';
+import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
+import { APIContext } from 'components/data/apiContext';
+import { SystemStatus } from 'models';
+import * as React from 'react';
+import { SystemStatusBanner } from '../SystemStatusBanner';
+
+const normalStatus: SystemStatus = {
+    status: 'normal',
+    message:
+        'This is a test. It is only a test. Check out https://flyte.org for more information.'
+};
+
+const degradedStatus: SystemStatus = {
+    status: 'degraded',
+    message:
+        'Something is a bit wrong with the system. We can probably still do some things, but may be slow about it.'
+};
+
+const downStatus: SystemStatus = {
+    status: 'down',
+    message:
+        'We are down. You should probably go get a cup of coffee while the administrators attempt to troubleshoot.'
+};
+
+function renderBanner(status: SystemStatus) {
+    const mockApi = mockAPIContextValue({
+        getSystemStatus: () => Promise.resolve(status)
+    });
+    return (
+        <APIContext.Provider value={mockApi}>
+            <SystemStatusBanner />
+        </APIContext.Provider>
+    );
+}
+
+const stories = storiesOf('Notifications/SystemStatusBanner', module);
+stories.add('Normal Status', () => renderBanner(normalStatus));
+stories.add('Degraded Status', () => renderBanner(degradedStatus));
+stories.add('Down Status', () => renderBanner(downStatus));

--- a/src/components/Notifications/__stories__/SystemStatusBanner.stories.tsx
+++ b/src/components/Notifications/__stories__/SystemStatusBanner.stories.tsx
@@ -11,6 +11,13 @@ const normalStatus: SystemStatus = {
         'This is a test. It is only a test. Check out https://flyte.org for more information.'
 };
 
+// Max length for a status should be 500 characters
+const longTextStatus: SystemStatus = {
+    status: 'normal',
+    message:
+        'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibu'
+};
+
 const degradedStatus: SystemStatus = {
     status: 'degraded',
     message:
@@ -38,3 +45,4 @@ const stories = storiesOf('Notifications/SystemStatusBanner', module);
 stories.add('Normal Status', () => renderBanner(normalStatus));
 stories.add('Degraded Status', () => renderBanner(degradedStatus));
 stories.add('Down Status', () => renderBanner(downStatus));
+stories.add('Long Message', () => renderBanner(longTextStatus));

--- a/src/components/Notifications/useSystemStatus.ts
+++ b/src/components/Notifications/useSystemStatus.ts
@@ -1,0 +1,14 @@
+import { useAPIContext } from 'components/data/apiContext';
+import { useFetchableData } from 'components/hooks';
+import { defaultSystemStatus } from 'models/Common/constants';
+
+/** Hook for fetching the current system status. Defaults to a safe value
+ * indicating normal system status.
+ */
+export function useSystemStatus() {
+    const { getSystemStatus } = useAPIContext();
+    return useFetchableData({
+        defaultValue: defaultSystemStatus,
+        doFetch: getSystemStatus
+    });
+}

--- a/src/components/Notifications/useSystemStatus.ts
+++ b/src/components/Notifications/useSystemStatus.ts
@@ -1,11 +1,12 @@
 import { useAPIContext } from 'components/data/apiContext';
-import { useFetchableData } from 'components/hooks';
+import { FetchableData, useFetchableData } from 'components/hooks';
+import { SystemStatus } from 'models';
 import { defaultSystemStatus } from 'models/Common/constants';
 
 /** Hook for fetching the current system status. Defaults to a safe value
  * indicating normal system status.
  */
-export function useSystemStatus() {
+export function useSystemStatus(): FetchableData<SystemStatus> {
     const { getSystemStatus } = useAPIContext();
     return useFetchableData({
         defaultValue: defaultSystemStatus,

--- a/src/components/Theme/constants.ts
+++ b/src/components/Theme/constants.ts
@@ -38,9 +38,14 @@ export const nestedListColor = COLOR_SPECTRUM.gray0.color;
 export const buttonHoverColor = COLOR_SPECTRUM.gray0.color;
 export const inputFocusBorderColor = COLOR_SPECTRUM.blue60.color;
 
+export const warningIconColor = COLOR_SPECTRUM.sunset60.color;
+export const infoIconColor = COLOR_SPECTRUM.blue40.color;
+
 export const dangerousButtonBorderColor = COLOR_SPECTRUM.red20.color;
 export const dangerousButtonColor = COLOR_SPECTRUM.red30.color;
 export const dangerousButtonHoverColor = COLOR_SPECTRUM.red40.color;
+export const mutedButtonColor = COLOR_SPECTRUM.gray30.color;
+export const mutedButtonHoverColor = COLOR_SPECTRUM.gray60.color;
 
 export const errorBackgroundColor = '#FBFBFC';
 

--- a/src/models/Common/api.ts
+++ b/src/models/Common/api.ts
@@ -9,16 +9,22 @@ import {
     RequestConfig
 } from 'models/AdminEntity';
 
+import { env } from 'common/env';
 import { log } from 'common/log';
 import { createCorsProxyURL } from 'common/utils';
 import { transformRequestError } from 'models/AdminEntity/transformRequestError';
-import { defaultAxiosConfig, identifierPrefixes } from './constants';
+import {
+    defaultAxiosConfig,
+    defaultSystemStatus,
+    identifierPrefixes
+} from './constants';
 import {
     IdentifierScope,
     LiteralMap,
     NamedEntity,
     NamedEntityIdentifier,
     ResourceType,
+    SystemStatus,
     UserProfile
 } from './types';
 import { makeIdentifierPath, makeNamedEntityPath } from './utils';
@@ -123,6 +129,29 @@ export const getUserProfile = async () => {
     } catch (e) {
         const { message } = transformRequestError(e, path);
         log.error(`Failed to fetch user profile: ${message}`);
+        return null;
+    }
+};
+
+/** If env.STATUS_URL is set, will issue a fetch to retrieve the current system
+ * status. If not, will resolve immediately with a default value indicating
+ * normal system status.
+ */
+export const getSystemStatus = async () => {
+    if (!env.STATUS_URL) {
+        return defaultSystemStatus;
+    }
+    const path = env.STATUS_URL;
+
+    try {
+        const { data } = await axios.get<SystemStatus>(
+            path,
+            defaultAxiosConfig
+        );
+        return data;
+    } catch (e) {
+        const { message } = transformRequestError(e, path);
+        log.error(`Failed to fetch system status: ${message}`);
         return null;
     }
 };

--- a/src/models/Common/api.ts
+++ b/src/models/Common/api.ts
@@ -151,8 +151,7 @@ export const getSystemStatus = async () => {
         return data;
     } catch (e) {
         const { message } = transformRequestError(e, path);
-        log.error(`Failed to fetch system status: ${message}`);
-        return null;
+        throw new Error(`Failed to fetch system status: ${message}`);
     }
 };
 

--- a/src/models/Common/constants.ts
+++ b/src/models/Common/constants.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig, AxiosTransformer } from 'axios';
 import * as camelcaseKeys from 'camelcase-keys';
 import * as snakecaseKeys from 'snakecase-keys';
 import { isObject } from 'util';
-import { LiteralMapBlob, ResourceType } from './types';
+import { LiteralMapBlob, ResourceType, SystemStatus } from './types';
 
 export const endpointPrefixes = {
     execution: '/executions',
@@ -44,3 +44,5 @@ export const defaultAxiosConfig: AxiosRequestConfig = {
     ],
     withCredentials: true
 };
+
+export const defaultSystemStatus: SystemStatus = { status: 'normal' };

--- a/src/models/Common/types.ts
+++ b/src/models/Common/types.ts
@@ -176,3 +176,8 @@ export interface UserProfile {
     email: string;
     picture: string;
 }
+
+export interface SystemStatus {
+    message?: string;
+    status: 'normal' | 'degraded' | 'down';
+}

--- a/src/models/Common/types.ts
+++ b/src/models/Common/types.ts
@@ -177,7 +177,9 @@ export interface UserProfile {
     picture: string;
 }
 
+export type StatusString = 'normal' | 'degraded' | 'down';
+
 export interface SystemStatus {
     message?: string;
-    status: 'normal' | 'degraded' | 'down';
+    status: StatusString;
 }


### PR DESCRIPTION
lyft/flyte#223

This implements the status banner that will show whatever status/message is retrieved from the `STATUS_URL` endpoint. There are two possible icons (info and warning). The banner will only show if the `message` field of the status is provided. The banner is dismissable per-session and will return on refresh for as long as the status message exists.

Still to do in future PRs:
* Tests
* Automatically parse and render links

![image](https://user-images.githubusercontent.com/1815175/78404636-b08f5280-75b3-11ea-95b8-3b7bdee07731.png)

![image](https://user-images.githubusercontent.com/1815175/78404672-c00e9b80-75b3-11ea-80ca-9f11531594e8.png)

![image](https://user-images.githubusercontent.com/1815175/78404702-ce5cb780-75b3-11ea-9555-1d5e36308485.png)
