### PR TITLE
Handle new TaskExecutionPhase values

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
     "@date-io/moment": "1.3.9",
-    "@lyft/flyteidl": "^0.16.1",
+    "@lyft/flyteidl": "^0.17.27",
     "@material-ui/core": "^4.0.0",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/pickers": "^3.2.2",

--- a/src/components/Executions/constants.ts
+++ b/src/components/Executions/constants.ts
@@ -131,9 +131,19 @@ export const taskExecutionPhaseConstants: {
         text: 'Failed',
         textColor: negativeTextColor
     },
+    [TaskExecutionPhase.WAITING_FOR_RESOURCES]: {
+        badgeColor: statusColors.RUNNING,
+        text: 'Waiting',
+        textColor: secondaryTextColor
+    },
     [TaskExecutionPhase.QUEUED]: {
         badgeColor: statusColors.RUNNING,
         text: 'Queued',
+        textColor: secondaryTextColor
+    },
+    [TaskExecutionPhase.INITIALIZING]: {
+        badgeColor: statusColors.RUNNING,
+        text: 'Initializing',
         textColor: secondaryTextColor
     },
     [TaskExecutionPhase.RUNNING]: {

--- a/src/models/Execution/__mocks__/mockTaskExecutionsData.ts
+++ b/src/models/Execution/__mocks__/mockTaskExecutionsData.ts
@@ -1,6 +1,6 @@
 import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
 import { Admin, Core } from 'flyteidl';
-import { cloneDeep, random } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { NodeExecutionPhase, TaskExecutionPhase } from '../enums';
 import { TaskExecution } from '../types';
 import { sampleError } from './sampleExecutionError';
@@ -51,7 +51,10 @@ export const createMockTaskExecutionsListResponse = (length: number) => {
             const startedAt = dateToTimestamp(
                 new Date(Date.now() - 1000 * 60 * (idx + 1))
             );
-            const phase = random(Object.keys(TaskExecutionPhase).length - 1);
+            const phase =
+                idx < length - 1
+                    ? TaskExecutionPhase.FAILED
+                    : TaskExecutionPhase.SUCCEEDED;
 
             // random duration between 0-90 minutes
             const duration = millisecondsToDuration(

--- a/src/models/Execution/__mocks__/mockTaskExecutionsData.ts
+++ b/src/models/Execution/__mocks__/mockTaskExecutionsData.ts
@@ -1,6 +1,6 @@
 import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
 import { Admin, Core } from 'flyteidl';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, random } from 'lodash';
 import { NodeExecutionPhase, TaskExecutionPhase } from '../enums';
 import { TaskExecution } from '../types';
 import { sampleError } from './sampleExecutionError';
@@ -51,10 +51,7 @@ export const createMockTaskExecutionsListResponse = (length: number) => {
             const startedAt = dateToTimestamp(
                 new Date(Date.now() - 1000 * 60 * (idx + 1))
             );
-            const phase =
-                idx < length - 1
-                    ? TaskExecutionPhase.FAILED
-                    : TaskExecutionPhase.SUCCEEDED;
+            const phase = random(Object.keys(TaskExecutionPhase).length - 1);
 
             // random duration between 0-90 minutes
             const duration = millisecondsToDuration(
@@ -62,7 +59,7 @@ export const createMockTaskExecutionsListResponse = (length: number) => {
             );
 
             const error =
-                phase === NodeExecutionPhase.FAILED
+                phase === TaskExecutionPhase.FAILED
                     ? {
                           code: 'user_error',
                           errorUri: '',

--- a/src/models/Execution/__mocks__/mockWorkflowExecutionsData.ts
+++ b/src/models/Execution/__mocks__/mockWorkflowExecutionsData.ts
@@ -72,6 +72,7 @@ export const createMockWorkflowExecutionsListResponse = (length: number) => ({
             execution.closure.error = {
                 code: 'user_error',
                 errorUri: '',
+                kind: Core.ExecutionError.ErrorKind.USER,
                 message: sampleError
             };
         }

--- a/src/models/__mocks__/sampleTaskNames.ts
+++ b/src/models/__mocks__/sampleTaskNames.ts
@@ -1,4 +1,4 @@
-import { Core } from 'flyteidl';
+import { Admin, Core } from 'flyteidl';
 import { NamedEntity, NamedEntityIdentifier } from 'models/Common';
 
 export const sampleTaskIds: NamedEntityIdentifier[] = [
@@ -52,6 +52,7 @@ export const sampleTaskNames: NamedEntity[] = sampleTaskIds.map(id => ({
     id,
     resourceType: Core.ResourceType.TASK,
     metadata: {
-        description: `A description for ${id.name}`
+        description: `A description for ${id.name}`,
+        state: Admin.NamedEntityState.NAMED_ENTITY_ACTIVE
     }
 }));

--- a/src/models/__mocks__/sampleWorkflowNames.ts
+++ b/src/models/__mocks__/sampleWorkflowNames.ts
@@ -1,4 +1,4 @@
-import { Core } from 'flyteidl';
+import { Admin, Core } from 'flyteidl';
 import { NamedEntity, NamedEntityIdentifier } from 'models/Common';
 
 export const sampleWorkflowIds: NamedEntityIdentifier[] = [
@@ -33,6 +33,7 @@ export const sampleWorkflowNames: NamedEntity[] = sampleWorkflowIds.map(id => ({
     id,
     resourceType: Core.ResourceType.WORKFLOW,
     metadata: {
-        description: `A description for ${id.name}`
+        description: `A description for ${id.name}`,
+        state: Admin.NamedEntityState.NAMED_ENTITY_ACTIVE
     }
 }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1498,10 +1498,10 @@
   dependencies:
     core-js "^2.5.7"
 
-"@lyft/flyteidl@^0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lyft/flyteidl/-/flyteidl-0.16.1.tgz#a433954a3664897424860333985cdfe9c3bc1811"
-  integrity sha512-FCbGJc+hHI5H0P9qyvIKXngY+eK3LbnA5p2FFmtpoJsVstAkUycn6Xe9tQavCoxWInV0blMj2/ch9RaU+5cdmA==
+"@lyft/flyteidl@^0.17.27":
+  version "0.17.27"
+  resolved "https://registry.yarnpkg.com/@lyft/flyteidl/-/flyteidl-0.17.27.tgz#5d7a13f27e1ae6bc775041bb60751abc23883ffa"
+  integrity sha512-WYyGT9aEfT9Kov75xmFu93kI6mox263ovO9pipWjPecn7hrvtYPfjxcefWsCS8FFfh4JBS7tuv76ELYecZfdOQ==
 
 "@material-ui/core@^4.0.0":
   version "4.9.3"


### PR DESCRIPTION
* Upgraded `flyteidl`
* Added entries to task execution phase constants to handle the two new phase values ("waiting for resources" and "initializing")
* Fixed a few other errors in mock data due to some proto messages getting additional required fields.

![image](https://user-images.githubusercontent.com/1815175/78616709-d160dd80-7829-11ea-8a09-8c3ba33fd83e.png)

![image](https://user-images.githubusercontent.com/1815175/78616675-ba21f000-7829-11ea-96fa-d45d71a6e1c4.png)
