### PR TITLE
Ensuring banner shows no content while loading or in an error state

### DIFF
--- a/src/components/Notifications/SystemStatusBanner.tsx
+++ b/src/components/Notifications/SystemStatusBanner.tsx
@@ -5,6 +5,7 @@ import Close from '@material-ui/icons/Close';
 import Info from '@material-ui/icons/Info';
 import Warning from '@material-ui/icons/Warning';
 import { WaitForData } from 'components/common';
+import { Empty } from 'components/common/Empty';
 import { LinkifiedText } from 'components/common/LinkifiedText';
 import {
     infoIconColor,
@@ -139,7 +140,11 @@ export const SystemStatusBanner: React.FC<{}> = () => {
         return null;
     }
     return (
-        <WaitForData {...systemStatus}>
+        <WaitForData
+            {...systemStatus}
+            loadingComponent={Empty}
+            errorComponent={Empty}
+        >
             {systemStatus.value.message ? (
                 <RenderSystemStatusBanner
                     systemStatus={systemStatus.value}

--- a/src/components/common/Empty.tsx
+++ b/src/components/common/Empty.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+
+/** Utility component that will return no content. */
+export const Empty: React.FC = () => null;


### PR DESCRIPTION
`SystemStatusBanner` should not show anything unless it has successfully loaded and a `message` property exists. However, since it uses `WaitForData`, it will show a loading spinner and any resulting errors unless those are explicitly disabled.

This PR uses a simple `Empty` component as the override for both loading and error states to ensure that `WaitForData` will only render the banner on a successful load, and nothing in the other cases.