### PR TITLE
refactor: fetch child node executions for NodeExecution rows

### DIFF
--- a/src/components/Cache/utils.ts
+++ b/src/components/Cache/utils.ts
@@ -6,5 +6,6 @@ import * as objectHash from 'object-hash';
 export function getCacheKey(id: any[] | object | string) {
     return typeof id === 'string' || typeof id === 'symbol'
         ? id
-        : objectHash(id);
+        : // We only want to compare own properties, not .__proto__, .constructor, etc.
+          objectHash(id, { respectType: false });
 }

--- a/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
@@ -8,6 +8,7 @@ import { ExecutionFilters } from '../ExecutionFilters';
 import { useNodeExecutionFiltersState } from '../filters/useExecutionFiltersState';
 import { NodeExecutionsTable } from '../Tables/NodeExecutionsTable';
 import { useWorkflowExecutionState } from '../useWorkflowExecutionState';
+import { NodeExecutionsRequestConfigContext } from './contexts';
 import { ExecutionWorkflowGraph } from './ExecutionWorkflowGraph';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -43,10 +44,11 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({
     const filterState = useNodeExecutionFiltersState();
     const tabState = useTabState(tabIds, tabIds.nodes);
 
-    const { workflow, nodeExecutions } = useWorkflowExecutionState(
-        execution,
-        filterState.appliedFilters
-    );
+    const {
+        workflow,
+        nodeExecutions,
+        nodeExecutionsRequestConfig
+    } = useWorkflowExecutionState(execution, filterState.appliedFilters);
 
     return (
         <WaitForData {...workflow}>
@@ -61,10 +63,14 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({
                             <ExecutionFilters {...filterState} />
                         </div>
                         <WaitForData {...nodeExecutions}>
-                            <NodeExecutionsTable
-                                {...nodeExecutions}
-                                moreItemsAvailable={false}
-                            />
+                            <NodeExecutionsRequestConfigContext.Provider
+                                value={nodeExecutionsRequestConfig}
+                            >
+                                <NodeExecutionsTable
+                                    {...nodeExecutions}
+                                    moreItemsAvailable={false}
+                                />
+                            </NodeExecutionsRequestConfigContext.Provider>
                         </WaitForData>
                     </>
                 )}

--- a/src/components/Executions/ExecutionDetails/contexts.ts
+++ b/src/components/Executions/ExecutionDetails/contexts.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-import { Execution, NodeExecution } from 'models';
+import { Execution, NodeExecution, RequestConfig } from 'models';
+import { ExecutionFiltersState } from '../filters/useExecutionFiltersState';
 
 export interface ExecutionContextData {
     execution: Execution;
@@ -11,4 +12,8 @@ export const ExecutionContext = React.createContext<ExecutionContextData>(
 );
 export const NodeExecutionsContext = React.createContext<
     Dictionary<NodeExecution>
+>({});
+
+export const NodeExecutionsRequestConfigContext = React.createContext<
+    RequestConfig
 >({});

--- a/src/components/Executions/ExecutionDetails/contexts.ts
+++ b/src/components/Executions/ExecutionDetails/contexts.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Execution, NodeExecution, RequestConfig } from 'models';
-import { ExecutionFiltersState } from '../filters/useExecutionFiltersState';
 
 export interface ExecutionContextData {
     execution: Execution;

--- a/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -45,8 +45,6 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
         : false;
     const { error } = execution.closure;
 
-    // TODO: Do we want to show any loading indicator while we're waiting for
-    // the child executions to load and determine this?
     const expanderContent = isExpandable ? (
         <RowExpander expanded={expanded} onClick={toggleExpanded} />
     ) : null;

--- a/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -1,7 +1,9 @@
 import * as classnames from 'classnames';
 import { useExpandableMonospaceTextStyles } from 'components/common/ExpandableMonospaceText';
 import * as React from 'react';
+import { NodeExecutionsRequestConfigContext } from '../ExecutionDetails/contexts';
 import { DetailedNodeExecution } from '../types';
+import { useChildNodeExecutions } from '../useChildNodeExecutions';
 import { NodeExecutionsTableContext } from './contexts';
 import { ExpandableExecutionError } from './ExpandableExecutionError';
 import { NodeExecutionChildren } from './NodeExecutionChildren';
@@ -15,10 +17,6 @@ interface NodeExecutionRowProps {
     style?: React.CSSProperties;
 }
 
-function isExpandableExecution(execution: DetailedNodeExecution) {
-    return true;
-}
-
 /** Renders a NodeExecution as a row inside a `NodeExecutionsTable` */
 export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     columns,
@@ -26,10 +24,19 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     style
 }) => {
     const state = React.useContext(NodeExecutionsTableContext);
+    const requestConfig = React.useContext(NodeExecutionsRequestConfigContext);
+
     const [expanded, setExpanded] = React.useState(false);
     const toggleExpanded = () => {
         setExpanded(!expanded);
     };
+    // TODO: This needs to be more general than child node executions
+    const childNodeExecutions = useChildNodeExecutions(
+        execution.id,
+        requestConfig
+    );
+
+    const isExpandable = childNodeExecutions.value.length > 0;
     const tableStyles = useExecutionTableStyles();
     const monospaceTextStyles = useExpandableMonospaceTextStyles();
 
@@ -38,7 +45,9 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
         : false;
     const { error } = execution.closure;
 
-    const expanderContent = isExpandableExecution(execution) ? (
+    // TODO: Do we want to show any loading indicator while we're waiting for
+    // the child executions to load and determine this?
+    const expanderContent = isExpandable ? (
         <RowExpander expanded={expanded} onClick={toggleExpanded} />
     ) : null;
 

--- a/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -30,9 +30,9 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     const toggleExpanded = () => {
         setExpanded(!expanded);
     };
-    // TODO: This needs to be more general than child node executions
+
     const childNodeExecutions = useChildNodeExecutions(
-        execution.id,
+        execution,
         requestConfig
     );
 

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -37,6 +37,8 @@ export interface DetailedTaskExecution extends TaskExecution {
 }
 
 export interface NodeExecutionGroup {
-    parentTaskExecution: TaskExecution;
+    name: string;
     nodeExecutions: NodeExecution[];
 }
+
+export enum NodeExecutionType {}

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -35,3 +35,8 @@ export interface DetailedNodeExecution extends NodeExecution {
 export interface DetailedTaskExecution extends TaskExecution {
     cacheKey: string;
 }
+
+export interface NodeExecutionGroup {
+    parentTaskExecution: TaskExecution;
+    nodeExecutions: NodeExecution[];
+}

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -40,5 +40,3 @@ export interface NodeExecutionGroup {
     name: string;
     nodeExecutions: NodeExecution[];
 }
-
-export enum NodeExecutionType {}

--- a/src/components/Executions/useChildNodeExecutions.ts
+++ b/src/components/Executions/useChildNodeExecutions.ts
@@ -1,5 +1,6 @@
 import { APIContextValue, useAPIContext } from 'components/data/apiContext';
 import {
+    FetchableData,
     fetchNodeExecutions,
     fetchTaskExecutionChildren
 } from 'components/hooks';
@@ -7,7 +8,6 @@ import { useFetchableData } from 'components/hooks/useFetchableData';
 import { isEqual } from 'lodash';
 import {
     NodeExecution,
-    NodeExecutionIdentifier,
     RequestConfig,
     TaskExecutionIdentifier,
     WorkflowExecutionIdentifier
@@ -75,10 +75,7 @@ async function fetchGroupsForTaskExecutionNode({
         nodeExecutionId,
         apiContext
     );
-    // TODO: It's possible that one of these promises fails while the
-    // others succeed. We might want to handle that in a way that
-    // allows the user to see the groups that loaded, and maybe
-    // retry the ones that did not.
+
     return await Promise.all(
         taskExecutions.map(({ id: taskExecutionId }) =>
             fetchGroupForTaskExecution({ apiContext, config, taskExecutionId })
@@ -108,10 +105,13 @@ async function fetchGroupsForWorkflowExecutionNode({
     ];
 }
 
+/** Fetches and groups `NodeExecution`s which are direct children of the given
+ * `NodeExecution`.
+ */
 export function useChildNodeExecutions(
     nodeExecution: NodeExecution,
     config: RequestConfig
-) {
+): FetchableData<NodeExecutionGroup[]> {
     const apiContext = useAPIContext();
     const { workflowNodeMetadata } = nodeExecution.closure;
     const { execution: topExecution } = React.useContext(ExecutionContext);

--- a/src/components/Executions/useChildNodeExecutions.ts
+++ b/src/components/Executions/useChildNodeExecutions.ts
@@ -115,15 +115,15 @@ export function useChildNodeExecutions(
     const apiContext = useAPIContext();
     const { workflowNodeMetadata } = nodeExecution.closure;
     const { execution: topExecution } = React.useContext(ExecutionContext);
-    return useFetchableData<NodeExecutionGroup[], NodeExecutionIdentifier>(
+    return useFetchableData<NodeExecutionGroup[], NodeExecution>(
         {
             debugName: 'ChildNodeExecutions',
             defaultValue: [],
-            doFetch: async () => {
+            doFetch: async data => {
                 const fetchArgs = {
                     apiContext,
                     config,
-                    nodeExecution
+                    nodeExecution: data
                 };
                 // Nested NodeExecutions will sometimes have `workflowNodeMetadata` that
                 // points to the parent WorkflowExecution. We're only interested in
@@ -137,6 +137,6 @@ export function useChildNodeExecutions(
                 return fetchGroupsForTaskExecutionNode(fetchArgs);
             }
         },
-        nodeExecution.id
+        nodeExecution
     );
 }

--- a/src/components/Executions/useChildNodeExecutions.ts
+++ b/src/components/Executions/useChildNodeExecutions.ts
@@ -1,0 +1,55 @@
+import { APIContextValue, useAPIContext } from 'components/data/apiContext';
+import { fetchTaskExecutionChildren } from 'components/hooks';
+import { useFetchableData } from 'components/hooks/useFetchableData';
+import { NodeExecutionIdentifier, RequestConfig, TaskExecution } from 'models';
+import { NodeExecutionGroup } from './types';
+import { fetchTaskExecutions } from './useTaskExecutions';
+
+const fetchDetailedNodeExecutionsGroup = async (
+    parentTaskExecution: TaskExecution,
+    config: RequestConfig,
+    apiContext: APIContextValue
+) => ({
+    parentTaskExecution,
+    nodeExecutions: await fetchTaskExecutionChildren(
+        { config, taskExecutionId: parentTaskExecution.id },
+        apiContext
+    )
+});
+
+export function useChildNodeExecutions(
+    id: NodeExecutionIdentifier,
+    config: RequestConfig
+) {
+    const apiContext = useAPIContext();
+
+    // useTaskExecutions followed by useTaskExecutionChildren
+    // Need a way to compose fetchables, because we want the caching
+    // logic to be used in each of them
+    return useFetchableData<NodeExecutionGroup[], NodeExecutionIdentifier>(
+        {
+            debugName: 'ChildNodeExecutions',
+            defaultValue: [],
+            doFetch: async (id: NodeExecutionIdentifier) => {
+                const taskExecutions = await fetchTaskExecutions(
+                    id,
+                    apiContext
+                );
+                // TODO: It's possible that one of these promises fails while the
+                // others succeed. We might want to handle that in a way that
+                // allows the user to see the groups that loaded, and maybe
+                // retry the ones that did not.
+                return await Promise.all(
+                    taskExecutions.map(taskExecution =>
+                        fetchDetailedNodeExecutionsGroup(
+                            taskExecution,
+                            config,
+                            apiContext
+                        )
+                    )
+                );
+            }
+        },
+        id
+    );
+}

--- a/src/components/Executions/useChildNodeExecutions.ts
+++ b/src/components/Executions/useChildNodeExecutions.ts
@@ -1,55 +1,142 @@
 import { APIContextValue, useAPIContext } from 'components/data/apiContext';
-import { fetchTaskExecutionChildren } from 'components/hooks';
+import {
+    fetchNodeExecutions,
+    fetchTaskExecutionChildren
+} from 'components/hooks';
 import { useFetchableData } from 'components/hooks/useFetchableData';
-import { NodeExecutionIdentifier, RequestConfig, TaskExecution } from 'models';
+import { isEqual } from 'lodash';
+import {
+    NodeExecution,
+    NodeExecutionIdentifier,
+    RequestConfig,
+    TaskExecutionIdentifier,
+    WorkflowExecutionIdentifier
+} from 'models';
+import * as React from 'react';
+import { ExecutionContext } from './ExecutionDetails/contexts';
+import { formatRetryAttempt } from './TaskExecutionsList/utils';
 import { NodeExecutionGroup } from './types';
 import { fetchTaskExecutions } from './useTaskExecutions';
 
-const fetchDetailedNodeExecutionsGroup = async (
-    parentTaskExecution: TaskExecution,
-    config: RequestConfig,
-    apiContext: APIContextValue
-) => ({
-    parentTaskExecution,
-    nodeExecutions: await fetchTaskExecutionChildren(
-        { config, taskExecutionId: parentTaskExecution.id },
+interface FetchGroupForTaskExecutionArgs {
+    apiContext: APIContextValue;
+    config: RequestConfig;
+    taskExecutionId: TaskExecutionIdentifier;
+}
+async function fetchGroupForTaskExecution({
+    apiContext,
+    config,
+    taskExecutionId
+}: FetchGroupForTaskExecutionArgs): Promise<NodeExecutionGroup> {
+    return {
+        // NodeExecutions created by a TaskExecution are grouped
+        // by the retry attempt of the task.
+        name: formatRetryAttempt(taskExecutionId.retryAttempt),
+        nodeExecutions: await fetchTaskExecutionChildren(
+            { config, taskExecutionId },
+            apiContext
+        )
+    };
+}
+
+interface FetchGroupForWorkflowExecutionArgs {
+    apiContext: APIContextValue;
+    config: RequestConfig;
+    workflowExecutionId: WorkflowExecutionIdentifier;
+}
+async function fetchGroupForWorkflowExecution({
+    apiContext,
+    config,
+    workflowExecutionId
+}: FetchGroupForWorkflowExecutionArgs): Promise<NodeExecutionGroup> {
+    return {
+        // NodeExecutions created by a workflow execution are grouped
+        // by the execution id, since workflow executions are not retryable.
+        name: workflowExecutionId.name,
+        nodeExecutions: await fetchNodeExecutions(
+            { config, id: workflowExecutionId },
+            apiContext
+        )
+    };
+}
+
+interface FetchNodeExecutionGroupArgs {
+    apiContext: APIContextValue;
+    config: RequestConfig;
+    nodeExecution: NodeExecution;
+}
+
+async function fetchGroupsForTaskExecutionNode({
+    apiContext,
+    config,
+    nodeExecution: { id: nodeExecutionId }
+}: FetchNodeExecutionGroupArgs): Promise<NodeExecutionGroup[]> {
+    const taskExecutions = await fetchTaskExecutions(
+        nodeExecutionId,
         apiContext
-    )
-});
+    );
+    // TODO: It's possible that one of these promises fails while the
+    // others succeed. We might want to handle that in a way that
+    // allows the user to see the groups that loaded, and maybe
+    // retry the ones that did not.
+    return await Promise.all(
+        taskExecutions.map(({ id: taskExecutionId }) =>
+            fetchGroupForTaskExecution({ apiContext, config, taskExecutionId })
+        )
+    );
+}
+
+async function fetchGroupsForWorkflowExecutionNode({
+    apiContext,
+    config,
+    nodeExecution
+}: FetchNodeExecutionGroupArgs): Promise<NodeExecutionGroup[]> {
+    if (!nodeExecution.closure.workflowNodeMetadata) {
+        throw new Error('Unexpected empty `workflowNodeMetadata`');
+    }
+    const {
+        executionId: workflowExecutionId
+    } = nodeExecution.closure.workflowNodeMetadata;
+    // We can only have one WorkflowExecution (no retries), so there is only
+    // one group to return. But calling code expects it as an array.
+    return [
+        await fetchGroupForWorkflowExecution({
+            apiContext,
+            config,
+            workflowExecutionId
+        })
+    ];
+}
 
 export function useChildNodeExecutions(
-    id: NodeExecutionIdentifier,
+    nodeExecution: NodeExecution,
     config: RequestConfig
 ) {
     const apiContext = useAPIContext();
-
-    // useTaskExecutions followed by useTaskExecutionChildren
-    // Need a way to compose fetchables, because we want the caching
-    // logic to be used in each of them
+    const { workflowNodeMetadata } = nodeExecution.closure;
+    const { execution: topExecution } = React.useContext(ExecutionContext);
     return useFetchableData<NodeExecutionGroup[], NodeExecutionIdentifier>(
         {
             debugName: 'ChildNodeExecutions',
             defaultValue: [],
-            doFetch: async (id: NodeExecutionIdentifier) => {
-                const taskExecutions = await fetchTaskExecutions(
-                    id,
-                    apiContext
-                );
-                // TODO: It's possible that one of these promises fails while the
-                // others succeed. We might want to handle that in a way that
-                // allows the user to see the groups that loaded, and maybe
-                // retry the ones that did not.
-                return await Promise.all(
-                    taskExecutions.map(taskExecution =>
-                        fetchDetailedNodeExecutionsGroup(
-                            taskExecution,
-                            config,
-                            apiContext
-                        )
-                    )
-                );
+            doFetch: async () => {
+                const fetchArgs = {
+                    apiContext,
+                    config,
+                    nodeExecution
+                };
+                // Nested NodeExecutions will sometimes have `workflowNodeMetadata` that
+                // points to the parent WorkflowExecution. We're only interested in
+                // showing children if this node is a sub-workflow.
+                if (
+                    workflowNodeMetadata &&
+                    !isEqual(workflowNodeMetadata.executionId, topExecution.id)
+                ) {
+                    return fetchGroupsForWorkflowExecutionNode(fetchArgs);
+                }
+                return fetchGroupsForTaskExecutionNode(fetchArgs);
             }
         },
-        id
+        nodeExecution.id
     );
 }

--- a/src/components/Executions/useTaskExecutions.ts
+++ b/src/components/Executions/useTaskExecutions.ts
@@ -16,6 +16,10 @@ import { useFetchableData } from '../hooks/useFetchableData';
 import { executionRefreshIntervalMs } from './constants';
 import { nodeExecutionIsTerminal, taskExecutionIsTerminal } from './utils';
 
+/** Fetches a list of `TaskExecution`s which are children of the given `NodeExecution`.
+ * This function is meant to be consumed by hooks which are composing data.
+ * If you're calling it from a component, consider using `useTaskExecutions` instead.
+ */
 export const fetchTaskExecutions = async (
     id: NodeExecutionIdentifier,
     apiContext: APIContextValue
@@ -64,6 +68,9 @@ export function useTaskExecutionData(
     );
 }
 
+/** Wraps the result of `useTaskExecutions` and will refresh the data as long
+ * as the given `NodeExecution` is still in a non-final state.
+ */
 export function useTaskExecutionsRefresher(
     nodeExecution: NodeExecution,
     taskExecutionsFetchable: ReturnType<typeof useTaskExecutions>

--- a/src/components/Executions/useTaskExecutions.ts
+++ b/src/components/Executions/useTaskExecutions.ts
@@ -1,4 +1,4 @@
-import { useAPIContext } from 'components/data/apiContext';
+import { APIContextValue, useAPIContext } from 'components/data/apiContext';
 import { every } from 'lodash';
 import {
     ExecutionData,
@@ -16,27 +16,34 @@ import { useFetchableData } from '../hooks/useFetchableData';
 import { executionRefreshIntervalMs } from './constants';
 import { nodeExecutionIsTerminal, taskExecutionIsTerminal } from './utils';
 
+export const fetchTaskExecutions = async (
+    id: NodeExecutionIdentifier,
+    apiContext: APIContextValue
+) => {
+    const { listTaskExecutions } = apiContext;
+    const { entities } = await listTaskExecutions(id, {
+        limit: limits.NONE,
+        sort: {
+            key: taskSortFields.createdAt,
+            direction: SortDirection.ASCENDING
+        }
+    });
+    return entities;
+};
+
 /** A hook for fetching the list of TaskExecutions associated with a
  * NodeExecution
  */
 export function useTaskExecutions(
     id: NodeExecutionIdentifier
 ): FetchableData<TaskExecution[]> {
-    const { listTaskExecutions } = useAPIContext();
+    const apiContext = useAPIContext();
     return useFetchableData<TaskExecution[], NodeExecutionIdentifier>(
         {
             debugName: 'TaskExecutions',
             defaultValue: [],
-            doFetch: async (id: NodeExecutionIdentifier) => {
-                const { entities } = await listTaskExecutions(id, {
-                    limit: limits.NONE,
-                    sort: {
-                        key: taskSortFields.createdAt,
-                        direction: SortDirection.ASCENDING
-                    }
-                });
-                return entities;
-            }
+            doFetch: async (id: NodeExecutionIdentifier) =>
+                fetchTaskExecutions(id, apiContext)
         },
         id
     );

--- a/src/components/Executions/useWorkflowExecutionState.ts
+++ b/src/components/Executions/useWorkflowExecutionState.ts
@@ -29,11 +29,15 @@ export function useWorkflowExecutionState(
         key: executionSortFields.createdAt,
         direction: SortDirection.ASCENDING
     };
-    const rawNodeExecutions = useNodeExecutions(execution.id, {
+    const nodeExecutionsRequestConfig = {
         filter,
         sort,
         limit: limits.NONE
-    });
+    };
+    const rawNodeExecutions = useNodeExecutions(
+        execution.id,
+        nodeExecutionsRequestConfig
+    );
     const workflow = useWorkflow(execution.closure.workflowId);
     const nodeExecutions = useDetailedNodeExecutions(
         rawNodeExecutions,
@@ -49,5 +53,5 @@ export function useWorkflowExecutionState(
             executionIsTerminal(execution)
     });
 
-    return { workflow, nodeExecutions };
+    return { workflow, nodeExecutions, nodeExecutionsRequestConfig };
 }

--- a/src/components/hooks/useNodeExecutions.ts
+++ b/src/components/hooks/useNodeExecutions.ts
@@ -1,3 +1,4 @@
+import { APIContextValue, useAPIContext } from 'components/data/apiContext';
 import {
     limits,
     listNodeExecutions,
@@ -19,10 +20,11 @@ interface TaskExecutionChildrenFetchData {
     config: RequestConfig;
 }
 
-const doFetchNodeExecutions = async ({
-    id,
-    config
-}: NodeExecutionsFetchData) => {
+export const fetchNodeExecutions = async (
+    { id, config }: NodeExecutionsFetchData,
+    apiContext: APIContextValue
+) => {
+    const { listNodeExecutions } = apiContext;
     const { entities } = await listNodeExecutions(id, {
         ...config,
         limit: limits.NONE
@@ -37,20 +39,22 @@ export function useNodeExecutions(
     id: WorkflowExecutionIdentifier,
     config: RequestConfig
 ) {
+    const apiContext = useAPIContext();
     return useFetchableData<NodeExecution[], NodeExecutionsFetchData>(
         {
             debugName: 'NodeExecutions',
             defaultValue: [],
-            doFetch: doFetchNodeExecutions
+            doFetch: data => fetchNodeExecutions(data, apiContext)
         },
         { id, config }
     );
 }
 
-const doFetchTaskExecutionChildren = async ({
-    taskExecutionId,
-    config
-}: TaskExecutionChildrenFetchData) => {
+export const fetchTaskExecutionChildren = async (
+    { taskExecutionId, config }: TaskExecutionChildrenFetchData,
+    apiContext: APIContextValue
+) => {
+    const { listTaskExecutionChildren } = apiContext;
     const { entities } = await listTaskExecutionChildren(taskExecutionId, {
         ...config,
         limit: limits.NONE
@@ -63,11 +67,12 @@ export function useTaskExecutionChildren(
     taskExecutionId: TaskExecutionIdentifier,
     config: RequestConfig
 ) {
+    const apiContext = useAPIContext();
     return useFetchableData<NodeExecution[], TaskExecutionChildrenFetchData>(
         {
             debugName: 'TaskExecutionChildren',
             defaultValue: [],
-            doFetch: doFetchTaskExecutionChildren
+            doFetch: data => fetchTaskExecutionChildren(data, apiContext)
         },
         { taskExecutionId, config }
     );

--- a/src/components/hooks/useNodeExecutions.ts
+++ b/src/components/hooks/useNodeExecutions.ts
@@ -1,8 +1,6 @@
 import { APIContextValue, useAPIContext } from 'components/data/apiContext';
 import {
     limits,
-    listNodeExecutions,
-    listTaskExecutionChildren,
     NodeExecution,
     RequestConfig,
     TaskExecutionIdentifier,
@@ -20,6 +18,10 @@ interface TaskExecutionChildrenFetchData {
     config: RequestConfig;
 }
 
+/** Fetches a list of `NodeExecution`s which are children of a WorkflowExecution.
+ * This function is meant to be consumed by hooks which are composing data.
+ * If you're calling it from a component, consider using `useNodeExecutions` instead.
+ */
 export const fetchNodeExecutions = async (
     { id, config }: NodeExecutionsFetchData,
     apiContext: APIContextValue
@@ -50,6 +52,10 @@ export function useNodeExecutions(
     );
 }
 
+/** Fetches a list of `NodeExecution`s which are children of the given `TaskExecution`.
+ * This function is meant to be consumed by hooks which are composing data.
+ * If you're calling it from a component, consider using `useTaskExecutionChildren` instead.
+ */
 export const fetchTaskExecutionChildren = async (
     { taskExecutionId, config }: TaskExecutionChildrenFetchData,
     apiContext: APIContextValue


### PR DESCRIPTION
One of the end goals of our dynamic task experience changes is that instead of the hierarchy in the table being `NodeExecution -> TaskExecution/WorkflowExecution -> NodeExecution`, we remove the intermediate entity and make it `NodeExecution -> NodeExecution`.

This creates some issues:
* To determine if a NodeExecution can be expanded, we need to know if it has any children. There is no property on a NodeExecution that tells us that it has children. To determine that information, we need different behavior based on the node type.
  * For Task nodes (dynamic tasks), we will need to fetch the TaskExecutions created by the given NodeExecution. For each TaskExecution, we need to fetch its child NodeExecutions.
  * For Workflow nodes (specifically those that launch a separate WorkflowExecution), we need to fetch all NodeExecutions which are children of the given WorkflowExecution identifier.
* For some types of Nodes, the children need to be grouped by retry attempt. At the moment, this only applies to Task nodes, but it's useful for the concept of "groups of children" to be generic across all types of Nodes, so that the rendering logic is reusable. Workflow nodes don't currently allow retries, but may in the future. So they will only ever yield one group of children.

To address those issues, I updated the rendering/fetching logic as follows:
* Added a `useChildNodeExecutions` hook which will implement the necessary logic to fetch and group children for a given NodeExecution, varying the logic based on the type of node.
  * For Task nodes, we fetch all of the task executions, and then the node executions for each of those
  * For workflow nodes, we fetch the NodeExecution children for the workflow execution id.
  * The RequestConfig is piped through from the top level and used for all nested requests for NodeExecutions. This means that any filtering/sorting will apply to all levels of the list.
* Updated `NodeExecutionRow` to only render an expander if the value returned from `useChildNodeExecutions` is an array with length greater than zero.
* Refactored and exported some of the work functions for fetching `NodeExecutions` and `TaskExecutions` so that they can be composed by other hooks.
