### PR TITLE
fix: cleanup for dynamic tasks refactoring

### DIFF
--- a/src/components/Executions/Tables/NodeExecutionChildren.tsx
+++ b/src/components/Executions/Tables/NodeExecutionChildren.tsx
@@ -1,37 +1,52 @@
 import { Typography } from '@material-ui/core';
 import * as classnames from 'classnames';
+import { useTheme } from 'components/Theme/useTheme';
 import * as React from 'react';
 import { DetailedNodeExecutionGroup } from '../types';
 import { NodeExecutionRow } from './NodeExecutionRow';
 import { useExecutionTableStyles } from './styles';
+import { calculateNodeExecutionRowLeftSpacing } from './utils';
 
 export interface NodeExecutionChildrenProps {
     childGroups: DetailedNodeExecutionGroup[];
+    level: number;
 }
 
 /** Renders a nested list of row items for children of a NodeExecution */
 export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
-    childGroups
+    childGroups,
+    level
 }) => {
     const showNames = childGroups.length > 1;
     const tableStyles = useExecutionTableStyles();
+    const theme = useTheme();
+    const childGroupLabelStyle = {
+        // The label is aligned with the parent above, so remove one level of spacing
+        marginLeft: `${calculateNodeExecutionRowLeftSpacing(
+            level - 1,
+            theme.spacing
+        )}px`
+    };
     return (
         <>
-            {childGroups.map(({ name, nodeExecutions }) => {
+            {childGroups.map(({ name, nodeExecutions }, groupIndex) => {
                 const rows = nodeExecutions.map(nodeExecution => (
                     <NodeExecutionRow
                         key={nodeExecution.cacheKey}
                         execution={nodeExecution}
+                        level={level}
                     />
                 ));
                 const key = `group-${name}`;
                 return showNames ? (
-                    <div className={tableStyles.childGroupContainer} key={key}>
+                    <div key={key}>
                         <div
                             className={classnames(
-                                tableStyles.row,
+                                { [tableStyles.borderTop]: groupIndex > 0 },
+                                tableStyles.borderBottom,
                                 tableStyles.childGroupLabel
                             )}
+                            style={childGroupLabelStyle}
                         >
                             <Typography
                                 variant="overline"
@@ -40,7 +55,7 @@ export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
                                 {name}
                             </Typography>
                         </div>
-                        <div className={tableStyles.childGroupRows}>{rows}</div>
+                        <div>{rows}</div>
                     </div>
                 ) : (
                     <div key={key}>{rows}</div>

--- a/src/components/Executions/Tables/NodeExecutionChildren.tsx
+++ b/src/components/Executions/Tables/NodeExecutionChildren.tsx
@@ -1,6 +1,5 @@
 import { Typography } from '@material-ui/core';
 import * as classnames from 'classnames';
-import { useExpandableMonospaceTextStyles } from 'components/common/ExpandableMonospaceText';
 import * as React from 'react';
 import { DetailedNodeExecutionGroup } from '../types';
 import { NodeExecutionRow } from './NodeExecutionRow';
@@ -16,7 +15,6 @@ export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
 }) => {
     const showNames = childGroups.length > 1;
     const tableStyles = useExecutionTableStyles();
-    const monospaceTextStyles = useExpandableMonospaceTextStyles();
     return (
         <>
             {childGroups.map(({ name, nodeExecutions }) => {
@@ -29,17 +27,20 @@ export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
                 const key = `group-${name}`;
                 return showNames ? (
                     <div key={key}>
-                        <div className={tableStyles.row}>
-                            <Typography variant="overline">{name}</Typography>
-                        </div>
                         <div
                             className={classnames(
-                                tableStyles.childrenContainer,
-                                monospaceTextStyles.nestedParent
+                                tableStyles.row,
+                                tableStyles.childGroupLabel
                             )}
                         >
-                            {rows}
+                            <Typography
+                                variant="overline"
+                                color="textSecondary"
+                            >
+                                {name}
+                            </Typography>
                         </div>
+                        <>{rows}</>
                     </div>
                 ) : (
                     <div key={key}>{rows}</div>

--- a/src/components/Executions/Tables/NodeExecutionChildren.tsx
+++ b/src/components/Executions/Tables/NodeExecutionChildren.tsx
@@ -30,9 +30,10 @@ export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
     return (
         <>
             {childGroups.map(({ name, nodeExecutions }, groupIndex) => {
-                const rows = nodeExecutions.map(nodeExecution => (
+                const rows = nodeExecutions.map((nodeExecution, index) => (
                     <NodeExecutionRow
                         key={nodeExecution.cacheKey}
+                        index={index}
                         execution={nodeExecution}
                         level={level}
                     />

--- a/src/components/Executions/Tables/NodeExecutionChildren.tsx
+++ b/src/components/Executions/Tables/NodeExecutionChildren.tsx
@@ -26,7 +26,7 @@ export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
                 ));
                 const key = `group-${name}`;
                 return showNames ? (
-                    <div key={key}>
+                    <div className={tableStyles.childGroupContainer} key={key}>
                         <div
                             className={classnames(
                                 tableStyles.row,
@@ -40,7 +40,7 @@ export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
                                 {name}
                             </Typography>
                         </div>
-                        <>{rows}</>
+                        <div className={tableStyles.childGroupRows}>{rows}</div>
                     </div>
                 ) : (
                     <div key={key}>{rows}</div>

--- a/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -16,6 +16,7 @@ import { selectedClassName, useExecutionTableStyles } from './styles';
 import { calculateNodeExecutionRowLeftSpacing } from './utils';
 
 interface NodeExecutionRowProps {
+    index: number;
     execution: DetailedNodeExecution;
     level?: number;
     style?: React.CSSProperties;
@@ -24,6 +25,7 @@ interface NodeExecutionRowProps {
 /** Renders a NodeExecution as a row inside a `NodeExecutionsTable` */
 export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     execution: nodeExecution,
+    index,
     level = 0,
     style
 }) => {
@@ -77,7 +79,11 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     ) : null;
 
     const extraContent = expanded ? (
-        <div className={classnames(tableStyles.childrenContainer)}>
+        <div
+            className={classnames(tableStyles.childrenContainer, {
+                [tableStyles.borderBottom]: level === 0
+            })}
+        >
             <NodeExecutionChildren
                 childGroups={detailedChildNodeExecutions}
                 level={level + 1}
@@ -92,7 +98,14 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
             })}
             style={style}
         >
-            <div className={tableStyles.rowContent} style={rowContentStyle}>
+            <div
+                className={classnames(tableStyles.rowContent, {
+                    [tableStyles.borderBottom]:
+                        level === 0 || (level > 0 && expanded),
+                    [tableStyles.borderTop]: level > 0 && index > 0
+                })}
+                style={rowContentStyle}
+            >
                 <div className={tableStyles.rowColumns}>
                     <div
                         className={classnames(

--- a/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -1,5 +1,5 @@
 import * as classnames from 'classnames';
-import { useExpandableMonospaceTextStyles } from 'components/common/ExpandableMonospaceText';
+import { useTheme } from 'components/Theme/useTheme';
 import * as React from 'react';
 import {
     ExecutionContext,
@@ -13,17 +13,21 @@ import { ExpandableExecutionError } from './ExpandableExecutionError';
 import { NodeExecutionChildren } from './NodeExecutionChildren';
 import { RowExpander } from './RowExpander';
 import { selectedClassName, useExecutionTableStyles } from './styles';
+import { calculateNodeExecutionRowLeftSpacing } from './utils';
 
 interface NodeExecutionRowProps {
     execution: DetailedNodeExecution;
+    level?: number;
     style?: React.CSSProperties;
 }
 
 /** Renders a NodeExecution as a row inside a `NodeExecutionsTable` */
 export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     execution: nodeExecution,
+    level = 0,
     style
 }) => {
+    const theme = useTheme();
     const { columns, state } = React.useContext(NodeExecutionsTableContext);
     const requestConfig = React.useContext(NodeExecutionsRequestConfigContext);
     const { execution: workflowExecution } = React.useContext(ExecutionContext);
@@ -31,6 +35,17 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     const [expanded, setExpanded] = React.useState(false);
     const toggleExpanded = () => {
         setExpanded(!expanded);
+    };
+
+    // For the first level, we want the borders to span the entire table,
+    // so we'll use padding to space the content. For nested rows, we want the
+    // border to start where the content does, so we'll use margin.
+    const spacingProp = level === 0 ? 'paddingLeft' : 'marginLeft';
+    const rowContentStyle = {
+        [spacingProp]: `${calculateNodeExecutionRowLeftSpacing(
+            level,
+            theme.spacing
+        )}px`
     };
 
     // TODO: Handle error case for loading children.
@@ -47,7 +62,6 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
 
     const isExpandable = detailedChildNodeExecutions.length > 0;
     const tableStyles = useExecutionTableStyles();
-    const monospaceTextStyles = useExpandableMonospaceTextStyles();
 
     const selected = state.selectedExecution
         ? state.selectedExecution === nodeExecution
@@ -63,18 +77,13 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     ) : null;
 
     const extraContent = expanded ? (
-        <div
-            className={classnames(
-                tableStyles.childrenContainer,
-                monospaceTextStyles.nestedParent
-            )}
-        >
-            {errorContent}
-            <NodeExecutionChildren childGroups={detailedChildNodeExecutions} />
+        <div className={classnames(tableStyles.childrenContainer)}>
+            <NodeExecutionChildren
+                childGroups={detailedChildNodeExecutions}
+                level={level + 1}
+            />
         </div>
-    ) : (
-        errorContent
-    );
+    ) : null;
 
     return (
         <div
@@ -83,19 +92,34 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
             })}
             style={style}
         >
-            <div className={tableStyles.rowColumns}>
-                <div className={tableStyles.expander}>{expanderContent}</div>
-                {columns.map(({ className, key: columnKey, cellRenderer }) => (
+            <div className={tableStyles.rowContent} style={rowContentStyle}>
+                <div className={tableStyles.rowColumns}>
                     <div
-                        key={columnKey}
-                        className={classnames(tableStyles.rowColumn, className)}
+                        className={classnames(
+                            tableStyles.rowColumn,
+                            tableStyles.expander
+                        )}
                     >
-                        {cellRenderer({
-                            state,
-                            execution: nodeExecution
-                        })}
+                        {expanderContent}
                     </div>
-                ))}
+                    {columns.map(
+                        ({ className, key: columnKey, cellRenderer }) => (
+                            <div
+                                key={columnKey}
+                                className={classnames(
+                                    tableStyles.rowColumn,
+                                    className
+                                )}
+                            >
+                                {cellRenderer({
+                                    state,
+                                    execution: nodeExecution
+                                })}
+                            </div>
+                        )
+                    )}
+                </div>
+                {errorContent}
             </div>
             {extraContent}
         </div>

--- a/src/components/Executions/Tables/NodeExecutionsTable.tsx
+++ b/src/components/Executions/Tables/NodeExecutionsTable.tsx
@@ -38,10 +38,11 @@ export const NodeExecutionsTable: React.FC<NodeExecutionsTableProps> = props => 
     const rowProps = { state, onHeightChange: () => {} };
     const content =
         state.executions.length > 0 ? (
-            state.executions.map(execution => {
+            state.executions.map((execution, index) => {
                 return (
                     <NodeExecutionRow
                         {...rowProps}
+                        index={index}
                         key={execution.cacheKey}
                         execution={execution}
                     />

--- a/src/components/Executions/Tables/WorkflowExecutionsTable.tsx
+++ b/src/components/Executions/Tables/WorkflowExecutionsTable.tsx
@@ -53,6 +53,9 @@ const useStyles = makeStyles((theme: Theme) => ({
         marginLeft: theme.spacing(2),
         marginRight: theme.spacing(2),
         textAlign: 'left'
+    },
+    row: {
+        paddingLeft: theme.spacing(2)
     }
 }));
 
@@ -199,7 +202,14 @@ export const WorkflowExecutionsTable: React.FC<WorkflowExecutionsTableProps> = p
         const { error } = execution.closure;
 
         return (
-            <div className={classnames(tableStyles.row)} style={style}>
+            <div
+                className={classnames(
+                    tableStyles.row,
+                    styles.row,
+                    tableStyles.borderBottom
+                )}
+                style={style}
+            >
                 <div className={tableStyles.rowColumns}>
                     {columns.map(
                         ({ className, key: columnKey, cellRenderer }) => (

--- a/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
+++ b/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
@@ -2,6 +2,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
+import { APIContext } from 'components/data/apiContext';
 import { createMockExecutionEntities } from 'components/Executions/__mocks__/createMockExecutionEntities';
 import { ExecutionDataCacheContext } from 'components/Executions/contexts';
 import { createExecutionDataCache } from 'components/Executions/useExecutionDataCache';
@@ -85,9 +86,11 @@ const props: NodeExecutionsTableProps = {
 const stories = storiesOf('Tables/NodeExecutionsTable', module);
 stories.addDecorator(story => {
     return (
-        <ExecutionDataCacheContext.Provider value={dataCache}>
-            <div className={useStyles().container}>{story()}</div>
-        </ExecutionDataCacheContext.Provider>
+        <APIContext.Provider value={apiContext}>
+            <ExecutionDataCacheContext.Provider value={dataCache}>
+                <div className={useStyles().container}>{story()}</div>
+            </ExecutionDataCacheContext.Provider>
+        </APIContext.Provider>
     );
 });
 stories.add('Basic', () => <NodeExecutionsTable {...props} />);

--- a/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
+++ b/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
@@ -45,6 +45,7 @@ const nodeRetryAttempts = {
 
 const apiContext = mockAPIContextValue({
     getExecution: () => Promise.resolve(workflowExecution),
+    getNodeExecutionData: () => Promise.resolve({ inputs: {}, outputs: {} }),
     listTaskExecutions: nodeExecutionId => {
         const length = nodeRetryAttempts[nodeExecutionId.nodeId] || 1;
         const entities = Array.from({ length }, (_, retryAttempt) =>

--- a/src/components/Executions/Tables/styles.ts
+++ b/src/components/Executions/Tables/styles.ts
@@ -21,6 +21,10 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
         minHeight: theme.spacing(7),
         paddingLeft: theme.spacing(3)
     },
+    childGroupLabel: {
+        marginLeft: theme.spacing(4),
+        padding: `${theme.spacing(2)}px 0`
+    },
     errorContainer: {
         padding: `0 ${theme.spacing(7)}px ${theme.spacing(2)}px`,
         '$childrenContainer > &': {

--- a/src/components/Executions/Tables/styles.ts
+++ b/src/components/Executions/Tables/styles.ts
@@ -24,7 +24,7 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
         borderTop: `1px solid ${theme.palette.divider}`
     },
     childrenContainer: {
-        borderBottom: `1px solid ${theme.palette.divider}`,
+        backgroundColor: nestedListColor,
         minHeight: theme.spacing(7)
     },
     childGroupLabel: {
@@ -90,17 +90,9 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
         justifyContent: 'center',
         [`&.${selectedClassName}`]: {
             backgroundColor: listhoverColor
-        },
-        '$childrenContainer &': {
-            backgroundColor: nestedListColor
         }
     },
-    rowContent: {
-        borderBottom: `1px solid ${theme.palette.divider}`,
-        '$childrenContainer $row:last-child &': {
-            borderBottom: 'none'
-        }
-    },
+    rowContent: {},
     rowColumns: {
         alignItems: 'center',
         display: 'flex',

--- a/src/components/Executions/Tables/styles.ts
+++ b/src/components/Executions/Tables/styles.ts
@@ -25,6 +25,14 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
         marginLeft: theme.spacing(4),
         padding: `${theme.spacing(2)}px 0`
     },
+    childGroupContainer: {},
+    childGroupRows: {
+        borderBottom: `2px solid ${theme.palette.divider}`,
+        borderTop: `2px solid ${theme.palette.divider}`,
+        '$childGroupContainer:last-child > &': {
+            borderBottom: 'none'
+        }
+    },
     errorContainer: {
         padding: `0 ${theme.spacing(7)}px ${theme.spacing(2)}px`,
         '$childrenContainer > &': {

--- a/src/components/Executions/Tables/styles.ts
+++ b/src/components/Executions/Tables/styles.ts
@@ -3,6 +3,7 @@ import { headerGridHeight } from 'components';
 import {
     headerFontFamily,
     listhoverColor,
+    nestedListColor,
     smallFontSize,
     tableHeaderColor,
     tablePlaceholderColor
@@ -16,35 +17,32 @@ export const selectedClassName = 'selected';
 // the columns styles in some cases. So the column styles should be defined
 // last.
 export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
+    borderBottom: {
+        borderBottom: `1px solid ${theme.palette.divider}`
+    },
+    borderTop: {
+        borderTop: `1px solid ${theme.palette.divider}`
+    },
     childrenContainer: {
-        borderTop: `1px solid ${theme.palette.divider}`,
-        minHeight: theme.spacing(7),
-        paddingLeft: theme.spacing(3)
+        borderBottom: `1px solid ${theme.palette.divider}`,
+        minHeight: theme.spacing(7)
     },
     childGroupLabel: {
-        marginLeft: theme.spacing(4),
+        borderWidth: '2px',
         padding: `${theme.spacing(2)}px 0`
     },
-    childGroupContainer: {},
-    childGroupRows: {
-        borderBottom: `2px solid ${theme.palette.divider}`,
-        borderTop: `2px solid ${theme.palette.divider}`,
-        '$childGroupContainer:last-child > &': {
-            borderBottom: 'none'
-        }
-    },
     errorContainer: {
-        padding: `0 ${theme.spacing(7)}px ${theme.spacing(2)}px`,
-        '$childrenContainer > &': {
+        padding: `0 ${theme.spacing(8)}px ${theme.spacing(2)}px`,
+        '$childrenContainer &': {
             paddingTop: theme.spacing(2),
-            paddingLeft: theme.spacing(4)
+            paddingLeft: theme.spacing(2)
         }
     },
     expander: {
         alignItems: 'center',
         display: 'flex',
         justifyContent: 'center',
-        marginLeft: theme.spacing(3),
+        marginLeft: theme.spacing(-4),
         marginRight: theme.spacing(1),
         width: theme.spacing(3)
     },
@@ -87,7 +85,6 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
         textAlign: 'center'
     },
     row: {
-        borderBottom: `1px solid ${theme.palette.divider}`,
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
@@ -95,10 +92,13 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
             backgroundColor: listhoverColor
         },
         '$childrenContainer &': {
-            borderBottom: 'none',
-            '&:not(:first-of-type)': {
-                borderTop: `1px solid ${theme.palette.divider}`
-            }
+            backgroundColor: nestedListColor
+        }
+    },
+    rowContent: {
+        borderBottom: `1px solid ${theme.palette.divider}`,
+        '$childrenContainer $row:last-child &': {
+            borderBottom: 'none'
         }
     },
     rowColumns: {
@@ -114,10 +114,7 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
         paddingBottom: theme.spacing(2),
         paddingTop: theme.spacing(2),
         textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        '&:first-of-type': {
-            marginLeft: theme.spacing(2)
-        }
+        whiteSpace: 'nowrap'
     },
     scrollContainer: {
         flex: '1 1 0',
@@ -130,6 +127,7 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
     }
 }));
 
+export const nameColumnLeftMarginGridWidth = 6;
 export const useColumnStyles = makeStyles((theme: Theme) => ({
     columnName: {
         flexGrow: 1,
@@ -138,7 +136,7 @@ export const useColumnStyles = makeStyles((theme: Theme) => ({
         flexBasis: 0,
         overflow: 'hidden',
         '&:first-of-type': {
-            marginLeft: theme.spacing(7)
+            marginLeft: theme.spacing(nameColumnLeftMarginGridWidth)
         }
     },
     columnType: {

--- a/src/components/Executions/Tables/utils.ts
+++ b/src/components/Executions/Tables/utils.ts
@@ -42,5 +42,5 @@ export function calculateNodeExecutionRowLeftSpacing(
     level: number,
     spacing: Spacing
 ) {
-    return spacing(nameColumnLeftMarginGridWidth + 2 * level);
+    return spacing(nameColumnLeftMarginGridWidth + 3 * level);
 }

--- a/src/components/Executions/Tables/utils.ts
+++ b/src/components/Executions/Tables/utils.ts
@@ -1,5 +1,7 @@
+import { Spacing } from '@material-ui/core/styles/createSpacing';
 import { measureText } from 'components/common/utils';
 import { TaskLog } from 'models';
+import { nameColumnLeftMarginGridWidth } from './styles';
 
 interface MeasuredTaskLog extends TaskLog {
     width: number;
@@ -34,4 +36,11 @@ export function splitLogLinksAtWidth(
         }
     );
     return [taken, left];
+}
+
+export function calculateNodeExecutionRowLeftSpacing(
+    level: number,
+    spacing: Spacing
+) {
+    return spacing(nameColumnLeftMarginGridWidth + 2 * level);
 }

--- a/src/components/Executions/utils.ts
+++ b/src/components/Executions/utils.ts
@@ -1,3 +1,13 @@
+import { log } from 'common/log';
+import { durationToMilliseconds, timestampToDate } from 'common/utils';
+import { getCacheKey } from 'components/Cache';
+import {
+    endNodeId,
+    Identifier,
+    startNodeId,
+    TaskTemplate,
+    TaskType
+} from 'models';
 import {
     BaseExecutionClosure,
     Execution,
@@ -7,27 +17,11 @@ import {
     terminalNodeExecutionStates,
     terminalTaskExecutionStates
 } from 'models/Execution';
-
 import {
     NodeExecutionPhase,
     TaskExecutionPhase,
     WorkflowExecutionPhase
 } from 'models/Execution/enums';
-
-import { log } from 'common/log';
-import { durationToMilliseconds, timestampToDate } from 'common/utils';
-import { getCacheKey } from 'components/Cache';
-import { extractTaskTemplates } from 'components/hooks/utils';
-import { keyBy } from 'lodash';
-import {
-    CompiledNode,
-    endNodeId,
-    Identifier,
-    startNodeId,
-    TaskTemplate,
-    TaskType,
-    Workflow
-} from 'models';
 import {
     nodeExecutionPhaseConstants,
     taskExecutionPhaseConstants,

--- a/src/components/hooks/test/utils.test.ts
+++ b/src/components/hooks/test/utils.test.ts
@@ -1,0 +1,79 @@
+import {
+    createMockWorkflow,
+    createMockWorkflowClosure
+} from 'models/__mocks__/workflowData';
+import { CompiledWorkflow, Workflow } from 'models/Workflow/types';
+import { extractAndIdentifyNodes, extractTaskTemplates } from '../utils';
+
+describe('hooks/utils', () => {
+    let workflow: Workflow;
+    let subWorkflow: CompiledWorkflow;
+
+    beforeEach(() => {
+        workflow = {
+            ...createMockWorkflow('SampleWorkflow'),
+            closure: createMockWorkflowClosure()
+        };
+        const { template } = workflow.closure!.compiledWorkflow!.primary;
+        subWorkflow = {
+            // We don't process connections in these functions, so it can be empty
+            connections: { downstream: {}, upstream: {} },
+            template: {
+                id: { ...template.id, name: `${template.id.name}_inner` },
+                nodes: template.nodes.map(node => ({
+                    ...node,
+                    id: `${node.id}_inner`
+                }))
+            }
+        };
+        workflow.closure!.compiledWorkflow!.subWorkflows = [subWorkflow];
+    });
+
+    describe('extractAndIdentifyNodes', () => {
+        it('returns empty for missing closure', () => {
+            delete workflow.closure;
+            expect(extractAndIdentifyNodes(workflow)).toEqual([]);
+        });
+
+        it('returns empty for missing compiledWorkflow', () => {
+            delete workflow.closure?.compiledWorkflow;
+            expect(extractAndIdentifyNodes(workflow)).toEqual([]);
+        });
+
+        it('includes nodes from subWorkflows', () => {
+            const nodes = extractAndIdentifyNodes(workflow);
+            subWorkflow.template.nodes.forEach(node =>
+                expect(nodes).toContainEqual(
+                    expect.objectContaining({
+                        id: { nodeId: node.id, workflowId: expect.anything() }
+                    })
+                )
+            );
+        });
+
+        it('assigns parent workflow id to subworkflow nodes', () => {
+            const nodes = extractAndIdentifyNodes(workflow);
+            subWorkflow.template.nodes.forEach(node =>
+                expect(nodes).toContainEqual(
+                    expect.objectContaining({
+                        id: {
+                            nodeId: expect.anything(),
+                            workflowId: workflow.id
+                        }
+                    })
+                )
+            );
+        });
+    });
+
+    describe('extractTaskTemplates', () => {
+        it('returns empty for missing closure', () => {
+            delete workflow.closure;
+            expect(extractTaskTemplates(workflow)).toEqual([]);
+        });
+        it('returns empty for missing compiledWorkflow', () => {
+            delete workflow.closure?.compiledWorkflow;
+            expect(extractTaskTemplates(workflow)).toEqual([]);
+        });
+    });
+});

--- a/src/components/hooks/useNodeExecution.ts
+++ b/src/components/hooks/useNodeExecution.ts
@@ -1,11 +1,5 @@
-import {
-    ExecutionData,
-    getNodeExecution,
-    getNodeExecutionData,
-    NodeExecution,
-    NodeExecutionIdentifier
-} from 'models';
-
+import { useAPIContext } from 'components/data/apiContext';
+import { ExecutionData, NodeExecution, NodeExecutionIdentifier } from 'models';
 import { FetchableData } from './types';
 import { useFetchableData } from './useFetchableData';
 
@@ -13,6 +7,7 @@ import { useFetchableData } from './useFetchableData';
 export function useNodeExecution(
     id: NodeExecutionIdentifier
 ): FetchableData<NodeExecution> {
+    const { getNodeExecution } = useAPIContext();
     return useFetchableData<NodeExecution, NodeExecutionIdentifier>(
         {
             debugName: 'NodeExecution',
@@ -27,6 +22,7 @@ export function useNodeExecution(
 export function useNodeExecutionData(
     id: NodeExecutionIdentifier
 ): FetchableData<ExecutionData> {
+    const { getNodeExecutionData } = useAPIContext();
     return useFetchableData<ExecutionData, NodeExecutionIdentifier>(
         {
             debugName: 'NodeExecutionData',

--- a/src/components/hooks/utils.ts
+++ b/src/components/hooks/utils.ts
@@ -13,13 +13,25 @@ export function extractAndIdentifyNodes(
     if (!workflow.closure || !workflow.closure.compiledWorkflow) {
         return [];
     }
-    return workflow.closure.compiledWorkflow.primary.template.nodes.map(
-        node => ({
-            node,
-            id: {
-                nodeId: node.id,
-                workflowId: workflow.id
-            }
-        })
+    const { primary, subWorkflows = [] } = workflow.closure.compiledWorkflow;
+    const nodes = subWorkflows.reduce(
+        (out, subWorkflow) => [...out, ...subWorkflow.template.nodes],
+        primary.template.nodes
     );
+
+    return nodes.map(node => ({
+        node,
+        id: {
+            nodeId: node.id,
+            // TODO: This is technically incorrect, as sub-workflow nodes
+            // will use the wrong parent workflow id. This is done intentionally
+            // to make sure that looking up the node information for a NodeExecution
+            // finds the entry successfully.
+            // When we are rendering sub-workflow nodes correctly, this should
+            // be updated to use the proper parent workflow id
+            // (subWorkflow.template.id)
+            // See https://github.com/lyft/flyte/issues/357
+            workflowId: workflow.id
+        }
+    }));
 }

--- a/src/models/Common/types.ts
+++ b/src/models/Common/types.ts
@@ -35,7 +35,10 @@ export interface RetryStrategy extends Core.IRetryStrategy {}
 export interface RuntimeMetadata extends Core.IRuntimeMetadata {}
 export interface Schedule extends Admin.ISchedule {}
 export type MessageFormat = Core.TaskLog.MessageFormat;
-export type TaskLog = RequiredNonNullable<Core.ITaskLog>;
+export interface TaskLog extends Core.ITaskLog {
+    name: string;
+    uri: string;
+}
 
 /*** Literals ****/
 export interface Binary extends RequiredNonNullable<Core.IBinary> {}

--- a/src/models/Workflow/types.ts
+++ b/src/models/Workflow/types.ts
@@ -5,6 +5,7 @@ import { CompiledTask } from 'models/Task';
 
 /** Holds information about all nodes existing in a Workflow graph */
 export interface WorkflowTemplate extends Core.IWorkflowTemplate {
+    id: Identifier;
     interface?: TypedInterface;
     nodes: CompiledNode[];
 }


### PR DESCRIPTION
This is a general cleanup PR for leftover small tasks related to our Dynamic Tasks refactor. The bulk of the work is:
* Styling logic updates to `NodeExecutionsTable` and its children.
* Getting the stories for `NodeExecutionsTable` functional again.

Detailed breakdown:
* Refactored classes/containers for `NodeExecutionRow` and `NodeExecutionChildren` to better support dynamic left spacing based on nesting level.
* Added props for `level` and `index` to row components
* Added logic to adjust left padding/margin for rows to accomplish the spacing/border scheme shown in the screenshot below
* Fixed styling on child group labels to render them with padding and thicker top/bottom borders
* Fixed a few direct usages of api calls without apiContext which were causing real network requests in the storybook environment.
* Updated/simplified the logic used in the stories to support nested NodeExecutionChildren cases for both single and multiple groups.
* Updated our processing of workflow closures to also extract nodes from sub-workflows. We don't currently show the hierarchical relationship correctly (see [this issue](https://github.com/lyft/flyte/issues/357)). But we at least want to render the correct node information in the table.
* General code cleanup

![image](https://user-images.githubusercontent.com/1815175/85781582-b55b3280-b6da-11ea-913c-92b823973e25.png)
