### PR TITLE
fix: show full millisecond values for subsecond durations

### DIFF
--- a/src/common/formatters.ts
+++ b/src/common/formatters.ts
@@ -71,7 +71,7 @@ export function millisecondsToHMS(valueMS: number): string {
     }
 
     if (valueMS < 1000) {
-        return subSecondString;
+        return `${valueMS}ms`;
     }
 
     const duration = moment.duration(valueMS);

--- a/src/common/test/formatters.spec.ts
+++ b/src/common/test/formatters.spec.ts
@@ -102,8 +102,8 @@ describe('formatDateLocalTimezone', () => {
 const millisecondToHMSTestCases: [number, string][] = [
     [-1, unknownValueString],
     [0, zeroSecondsString],
-    [1, subSecondString],
-    [999, subSecondString],
+    [1, '1ms'],
+    [999, '999ms'],
     [1000, '1s'],
     [60000, '1m'],
     [61000, '1m 1s'],


### PR DESCRIPTION
lyft/flyte#97
For values that are less than 1 second, we can/should show `(value)ms` instead of just showing `<1s`. The exact millisecond value is preferable when rendering inputs/outputs.