### PR TITLE
fix: show info message for un-launchable workflows

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -99,3 +99,20 @@ export function sortedObjectKeys(
 ): ReturnType<typeof Object.keys> {
     return Object.keys(object).sort((a, b) => a.localeCompare(b));
 }
+
+/**
+ * Helper function for exhaustive checks of discriminated unions.
+ * https://basarat.gitbooks.io/typescript/docs/types/discriminated-unions.html
+ */
+export function assertNever(
+    value: never,
+    { noThrow }: { noThrow?: boolean } = {}
+): never {
+    if (noThrow) {
+        return value;
+    }
+
+    throw new Error(
+        `Unhandled discriminated union member: ${JSON.stringify(value)}`
+    );
+}

--- a/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowForm.tsx
@@ -16,12 +16,13 @@ import {
     workflowSortFields
 } from 'models';
 import * as React from 'react';
-import { formStrings } from './constants';
+import { formStrings, unsupportedRequiredInputsString } from './constants';
 import { InputValueCacheContext } from './inputValueCache';
 import { LaunchWorkflowFormInputs } from './LaunchWorkflowFormInputs';
 import { SearchableSelector } from './SearchableSelector';
 import { useStyles } from './styles';
 import { LaunchWorkflowFormProps } from './types';
+import { UnsupportedRequiredInputsError } from './UnsupportedRequiredInputsError';
 import { useLaunchWorkflowFormState } from './useLaunchWorkflowFormState';
 import { workflowsToSearchableSelectorOptions } from './utils';
 
@@ -66,6 +67,11 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
         event.preventDefault();
         state.onSubmit();
     };
+
+    const preventSubmit =
+        submissionState.loading ||
+        !state.inputLoadingState.hasLoaded ||
+        state.unsupportedRequiredInputs.length > 0;
 
     return (
         <InputValueCacheContext.Provider value={state.inputValueCache}>
@@ -114,12 +120,18 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                             {...state.inputLoadingState}
                         >
                             <section title={formStrings.inputs}>
-                                <LaunchWorkflowFormInputs
-                                    key={state.formKey}
-                                    inputs={state.inputs}
-                                    ref={state.formInputsRef}
-                                    showErrors={state.showErrors}
-                                />
+                                {state.unsupportedRequiredInputs.length > 0 ? (
+                                    <UnsupportedRequiredInputsError
+                                        inputs={state.unsupportedRequiredInputs}
+                                    />
+                                ) : (
+                                    <LaunchWorkflowFormInputs
+                                        key={state.formKey}
+                                        inputs={state.inputs}
+                                        ref={state.formInputsRef}
+                                        showErrors={state.showErrors}
+                                    />
+                                )}
                             </section>
                         </WaitForData>
                     ) : null}
@@ -143,10 +155,7 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                     </Button>
                     <Button
                         color="primary"
-                        disabled={
-                            submissionState.loading ||
-                            !state.inputLoadingState.hasLoaded
-                        }
+                        disabled={preventSubmit}
                         id="launch-workflow-submit"
                         onClick={submit}
                         type="submit"

--- a/src/components/Launch/LaunchWorkflowForm/UnsupportedRequiredInputsError.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/UnsupportedRequiredInputsError.tsx
@@ -1,0 +1,32 @@
+import { NonIdealState } from 'components/common';
+import { useCommonStyles } from 'components/common/styles';
+import * as React from 'react';
+import {
+    cannotLaunchWorkflowString,
+    unsupportedRequiredInputsString
+} from './constants';
+import { ParsedInput } from './types';
+
+export interface UnsupportedRequiredInputsErrorProps {
+    inputs: ParsedInput[];
+}
+export const UnsupportedRequiredInputsError: React.FC<UnsupportedRequiredInputsErrorProps> = ({
+    inputs
+}) => {
+    const commonStyles = useCommonStyles();
+    return (
+        <NonIdealState
+            size="small"
+            title={cannotLaunchWorkflowString}
+            description={unsupportedRequiredInputsString}
+        >
+            <ul className={commonStyles.listUnstyled}>
+                {inputs.map(input => (
+                    <li key={input.name} className={commonStyles.textMonospace}>
+                        {input.label}
+                    </li>
+                ))}
+            </ul>
+        </NonIdealState>
+    );
+};

--- a/src/components/Launch/LaunchWorkflowForm/UnsupportedRequiredInputsError.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/UnsupportedRequiredInputsError.tsx
@@ -1,11 +1,30 @@
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import ErrorOutline from '@material-ui/icons/ErrorOutline';
 import { NonIdealState } from 'components/common';
 import { useCommonStyles } from 'components/common/styles';
 import * as React from 'react';
 import {
     cannotLaunchWorkflowString,
+    requiredInputSuffix,
     unsupportedRequiredInputsString
 } from './constants';
 import { ParsedInput } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    contentContainer: {
+        whiteSpace: 'pre-line',
+        textAlign: 'left'
+    },
+    errorContainer: {
+        marginBottom: theme.spacing(2)
+    }
+}));
+
+function formatLabel(label: string) {
+    return label.endsWith(requiredInputSuffix)
+        ? label.substring(0, label.length - 1)
+        : label;
+}
 
 export interface UnsupportedRequiredInputsErrorProps {
     inputs: ParsedInput[];
@@ -13,20 +32,28 @@ export interface UnsupportedRequiredInputsErrorProps {
 export const UnsupportedRequiredInputsError: React.FC<UnsupportedRequiredInputsErrorProps> = ({
     inputs
 }) => {
+    const styles = useStyles();
     const commonStyles = useCommonStyles();
     return (
         <NonIdealState
-            size="small"
+            className={styles.errorContainer}
+            icon={ErrorOutline}
+            size="medium"
             title={cannotLaunchWorkflowString}
-            description={unsupportedRequiredInputsString}
         >
-            <ul className={commonStyles.listUnstyled}>
-                {inputs.map(input => (
-                    <li key={input.name} className={commonStyles.textMonospace}>
-                        {input.label}
-                    </li>
-                ))}
-            </ul>
+            <div className={styles.contentContainer}>
+                <p>{unsupportedRequiredInputsString}</p>
+                <ul className={commonStyles.listUnstyled}>
+                    {inputs.map(input => (
+                        <li
+                            key={input.name}
+                            className={commonStyles.textMonospace}
+                        >
+                            {formatLabel(input.label)}
+                        </li>
+                    ))}
+                </ul>
+            </div>
         </NonIdealState>
     );
 };

--- a/src/components/Launch/LaunchWorkflowForm/UnsupportedRequiredInputsError.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/UnsupportedRequiredInputsError.tsx
@@ -29,6 +29,9 @@ function formatLabel(label: string) {
 export interface UnsupportedRequiredInputsErrorProps {
     inputs: ParsedInput[];
 }
+/** An informational error to be shown if a Workflow cannot be launch due to
+ * required inputs for which we will not be able to provide a value.
+ */
 export const UnsupportedRequiredInputsError: React.FC<UnsupportedRequiredInputsErrorProps> = ({
     inputs
 }) => {

--- a/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
@@ -31,6 +31,7 @@ import {
     SimpleVariableKey
 } from '../__mocks__/mockInputs';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
+import { binaryInputName, errorInputName } from '../test/constants';
 import { useExecutionLaunchConfiguration } from '../useExecutionLaunchConfiguration';
 import { getWorkflowInputs } from '../utils';
 
@@ -199,4 +200,11 @@ stories.add('Launched from Execution', () => {
         id: mockWorkflowExecutionResponse.id
     } as Execution;
     return renderForm({ mocks, execution });
+});
+stories.add('Unsupported Required Values', () => {
+    const mocks = generateMocks(mockSimpleVariables);
+    const parameters = mocks.mockLaunchPlan.closure!.expectedInputs.parameters;
+    parameters[binaryInputName].required = true;
+    parameters[errorInputName].required = true;
+    return renderForm({ mocks });
 });

--- a/src/components/Launch/LaunchWorkflowForm/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/constants.ts
@@ -55,6 +55,6 @@ export const simpleTypeToInputType: { [k in SimpleType]: InputType } = {
     [SimpleType.STRUCT]: InputType.Struct
 };
 
-export const cannotLaunchWorkflowString = 'This workflow cannot be launched';
-export const unsupportedRequiredInputsString = `This Workflow version contains one or more required inputs which are not supported by Flyte Console and do not have default values specified in the workflow definition or the selected Launch Plan.\n
-You can launch this Workflow version with the Flyte CLI or by selecting a Launch Plan which provides values for the unsupported inputs.\nThe inputs are listed below:`;
+export const requiredInputSuffix = '*';
+export const cannotLaunchWorkflowString = 'Workflow cannot be launched';
+export const unsupportedRequiredInputsString = `This Workflow version contains one or more required inputs which are not supported by Flyte Console and do not have default values specified in the Workflow definition or the selected Launch Plan.\n\nYou can launch this Workflow version with the Flyte CLI or by selecting a Launch Plan which provides values for the unsupported inputs.\n\nThe required inputs are :`;

--- a/src/components/Launch/LaunchWorkflowForm/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/constants.ts
@@ -54,3 +54,7 @@ export const simpleTypeToInputType: { [k in SimpleType]: InputType } = {
     [SimpleType.STRING]: InputType.String,
     [SimpleType.STRUCT]: InputType.Struct
 };
+
+export const cannotLaunchWorkflowString = 'This workflow cannot be launched';
+export const unsupportedRequiredInputsString = `This Workflow version contains one or more required inputs which are not supported by Flyte Console and do not have default values specified in the workflow definition or the selected Launch Plan.\n
+You can launch this Workflow version with the Flyte CLI or by selecting a Launch Plan which provides values for the unsupported inputs.\nThe inputs are listed below:`;

--- a/src/components/Launch/LaunchWorkflowForm/getInputs.ts
+++ b/src/components/Launch/LaunchWorkflowForm/getInputs.ts
@@ -1,5 +1,6 @@
 import { sortedObjectEntries } from 'common/utils';
 import { LaunchPlan, Workflow } from 'models';
+import { requiredInputSuffix } from './constants';
 import { LiteralValueMap, ParsedInput } from './types';
 import {
     createInputCacheKey,
@@ -36,7 +37,9 @@ export function getInputs(
             parameter.var.type
         );
         const typeLabel = formatLabelWithType(name, typeDefinition);
-        const label = required ? `${typeLabel}*` : typeLabel;
+        const label = required
+            ? `${typeLabel}${requiredInputSuffix}`
+            : typeLabel;
         const inputKey = createInputCacheKey(name, typeDefinition);
         const defaultVaue =
             parameter.default != null ? parameter.default : undefined;

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -12,6 +12,8 @@ import { collectionChildToString } from '../utils';
 import {
     literalTestCases,
     literalToInputTestCases,
+    supportedPrimitives,
+    unsupportedTypes,
     validityTestCases
 } from './testCases';
 
@@ -58,14 +60,7 @@ describe('literalToInputValue', () => {
             })
         );
 
-        [
-            InputType.Collection,
-            InputType.Datetime,
-            InputType.Duration,
-            InputType.Float,
-            InputType.Integer,
-            InputType.String
-        ].map(type =>
+        supportedPrimitives.map(type =>
             it(`should convert None value for ${type} to undefined`, () => {
                 expect(
                     literalToInputValue({ type }, literalNone())
@@ -176,16 +171,7 @@ describe('inputToLiteral', () => {
     });
 
     describe('Unsupported Types', () => {
-        [
-            InputType.Binary,
-            InputType.Blob,
-            InputType.Error,
-            InputType.Map,
-            InputType.None,
-            InputType.Schema,
-            InputType.Struct,
-            InputType.Unknown
-        ].map(type =>
+        unsupportedTypes.map(type =>
             it(`should return empty value for type: ${type}`, () => {
                 expect(
                     inputToLiteral(makeSimpleInput(type, '')).scalar

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
@@ -9,6 +9,24 @@ type PrimitiveTestParams = [InputType, any, Core.IPrimitive];
 
 const validDateString = '2019-01-10T00:00:00.000Z'; // Dec 1, 2019
 
+export const supportedPrimitives = [
+    InputType.Boolean,
+    InputType.Datetime,
+    InputType.Duration,
+    InputType.Float,
+    InputType.Integer
+];
+
+export const unsupportedTypes = [
+    InputType.Binary,
+    InputType.Blob,
+    InputType.Error,
+    InputType.Map,
+    InputType.None,
+    InputType.Schema,
+    InputType.Struct
+];
+
 export const validityTestCases = {
     boolean: {
         invalid: ['randomString', {}, new Date()],

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/utils.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/utils.test.ts
@@ -1,0 +1,51 @@
+import { InputType, InputTypeDefinition } from '../../types';
+import { typeIsSupported } from '../utils';
+import { supportedPrimitives, unsupportedTypes } from './testCases';
+
+type TypeIsSupportedTestCase = [string, InputTypeDefinition, boolean];
+describe('Launch/inputHelpers/utils', () => {
+    describe('typeIsSupported', () => {
+        const cases: TypeIsSupportedTestCase[] = [
+            ...supportedPrimitives.map<TypeIsSupportedTestCase>(type => [
+                `supports type ${type}`,
+                { type },
+                true
+            ]),
+            ...supportedPrimitives.map<TypeIsSupportedTestCase>(type => [
+                `supports 1-dimension collection of type ${type}`,
+                { type: InputType.Collection, subtype: { type } },
+                true
+            ]),
+            ...supportedPrimitives.map<TypeIsSupportedTestCase>(type => [
+                `supports 2-dimension collection of type: ${type}`,
+                {
+                    type: InputType.Collection,
+                    subtype: { type: InputType.Collection, subtype: { type } }
+                },
+                true
+            ]),
+            ...unsupportedTypes.map<TypeIsSupportedTestCase>(type => [
+                `does NOT support type ${type}`,
+                { type },
+                false
+            ]),
+            ...unsupportedTypes.map<TypeIsSupportedTestCase>(type => [
+                `does NOT support 1-dimension collection of type ${type}`,
+                { type: InputType.Collection, subtype: { type } },
+                false
+            ]),
+            ...unsupportedTypes.map<TypeIsSupportedTestCase>(type => [
+                `does NOT support 2-dimension collection of type: ${type}`,
+                {
+                    type: InputType.Collection,
+                    subtype: { type: InputType.Collection, subtype: { type } }
+                },
+                false
+            ])
+        ];
+
+        cases.forEach(([description, value, expected]) =>
+            it(description, () => expect(typeIsSupported(value)).toBe(expected))
+        );
+    });
+});

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -1,6 +1,6 @@
 import { Core } from 'flyteidl';
 import { get } from 'lodash';
-import { InputType } from '../types';
+import { InputType, InputTypeDefinition } from '../types';
 
 /** Performs a deep get of `path` on the given `Core.ILiteral`. Will throw
  * if the given property doesn't exist.
@@ -24,4 +24,37 @@ export function collectionChildToString(type: InputType, value: any) {
         return '';
     }
     return type === InputType.Integer ? `${value}` : JSON.stringify(value);
+}
+
+/** Determines if a given input type, including all levels of nested types, is
+ * supported for use in the Launch form.
+ */
+export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
+    const { type, subtype } = typeDefinition;
+    switch (type) {
+        case InputType.Map:
+        case InputType.None:
+        case InputType.Schema:
+        case InputType.Unknown:
+            return false;
+        case InputType.Boolean:
+        case InputType.Datetime:
+        case InputType.Duration:
+        case InputType.Float:
+        case InputType.Integer:
+        case InputType.String:
+            return true;
+        case InputType.Collection: {
+            if (!subtype) {
+                console.error(
+                    'Unexpected missing subtype for collection input',
+                    typeDefinition
+                );
+                return false;
+            }
+            return typeIsSupported(subtype);
+        }
+        default:
+            return false;
+    }
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -1,3 +1,4 @@
+import { assertNever } from 'common/utils';
 import { Core } from 'flyteidl';
 import { get } from 'lodash';
 import { InputType, InputTypeDefinition } from '../types';
@@ -32,9 +33,13 @@ export function collectionChildToString(type: InputType, value: any) {
 export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
     const { type, subtype } = typeDefinition;
     switch (type) {
+        case InputType.Binary:
+        case InputType.Blob:
+        case InputType.Error:
         case InputType.Map:
         case InputType.None:
         case InputType.Schema:
+        case InputType.Struct:
         case InputType.Unknown:
             return false;
         case InputType.Boolean:
@@ -55,6 +60,9 @@ export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
             return typeIsSupported(subtype);
         }
         default:
+            // This will cause a compiler error if new types are added and there is
+            // no case for them listed above.
+            assertNever(type, { noThrow: true });
             return false;
     }
 }

--- a/src/components/Launch/LaunchWorkflowForm/styles.ts
+++ b/src/components/Launch/LaunchWorkflowForm/styles.ts
@@ -14,7 +14,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
         width: '100%'
     },
     inputsSection: {
-        minHeight: theme.spacing(59),
         padding: theme.spacing(2)
     },
     inputLabel: {

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -37,7 +37,11 @@ import {
     mockSimpleVariables,
     simpleVariableDefaults
 } from '../__mocks__/mockInputs';
-import { cannotLaunchWorkflowString, formStrings } from '../constants';
+import {
+    cannotLaunchWorkflowString,
+    formStrings,
+    requiredInputSuffix
+} from '../constants';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
 import { InitialLaunchParameters, LaunchWorkflowFormProps } from '../types';
 import { createInputCacheKey, getInputDefintionForLiteralType } from '../utils';
@@ -778,6 +782,14 @@ describe('LaunchWorkflowForm', () => {
                 getByText(binaryInputName, { exact: false })
             );
             expect(inputElement).toBeInTheDocument();
+        });
+
+        it('should print input labels without decoration', async () => {
+            const { getByText } = renderForm();
+            const inputElement = await waitFor(() =>
+                getByText(binaryInputName, { exact: false })
+            );
+            expect(inputElement.textContent).not.toContain(requiredInputSuffix);
         });
 
         it('should disable submission', async () => {

--- a/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/test/LaunchWorkflowForm.test.tsx
@@ -34,13 +34,15 @@ import * as React from 'react';
 import { delayedPromise, pendingPromise } from 'test/utils';
 import {
     createMockWorkflowInputsInterface,
-    mockSimpleVariables
+    mockSimpleVariables,
+    simpleVariableDefaults
 } from '../__mocks__/mockInputs';
-import { formStrings } from '../constants';
+import { cannotLaunchWorkflowString, formStrings } from '../constants';
 import { LaunchWorkflowForm } from '../LaunchWorkflowForm';
 import { InitialLaunchParameters, LaunchWorkflowFormProps } from '../types';
 import { createInputCacheKey, getInputDefintionForLiteralType } from '../utils';
 import {
+    binaryInputName,
     booleanInputName,
     integerInputName,
     stringInputName,
@@ -746,6 +748,74 @@ describe('LaunchWorkflowForm', () => {
                     expect.anything()
                 );
             });
+        });
+    });
+
+    describe('With Unsupported Required Inputs', () => {
+        beforeEach(() => {
+            variables = mockSimpleVariables;
+            createMocks();
+            // Binary is currently unsupported, setting the binary input to
+            // required and removing the default value will trigger our use case
+            const parameters = mockLaunchPlans[0].closure!.expectedInputs
+                .parameters;
+            parameters[binaryInputName].required = true;
+            delete parameters[binaryInputName].default;
+            mockGetLaunchPlan.mockResolvedValue(mockLaunchPlans[0]);
+        });
+
+        it('should render error message', async () => {
+            const { getByText } = renderForm();
+            const errorElement = await waitFor(() =>
+                getByText(cannotLaunchWorkflowString)
+            );
+            expect(errorElement).toBeInTheDocument();
+        });
+
+        it('should show unsupported inputs', async () => {
+            const { getByText } = renderForm();
+            const inputElement = await waitFor(() =>
+                getByText(binaryInputName, { exact: false })
+            );
+            expect(inputElement).toBeInTheDocument();
+        });
+
+        it('should disable submission', async () => {
+            const { getByRole } = renderForm();
+
+            const submitButton = await waitFor(() =>
+                getByRole('button', { name: formStrings.submit })
+            );
+
+            expect(submitButton).toBeDisabled();
+        });
+
+        it('should not show error if launch plan has default value', async () => {
+            mockLaunchPlans[0].closure!.expectedInputs.parameters[
+                binaryInputName
+            ].default = simpleVariableDefaults.simpleBinary as Literal;
+            const { queryByText } = renderForm();
+            await waitFor(() => queryByText(binaryInputName, { exact: false }));
+            expect(queryByText(cannotLaunchWorkflowString)).toBeNull();
+        });
+
+        it('should not show error if initial value is provided', async () => {
+            const parameters = mockLaunchPlans[0].closure!.expectedInputs
+                .parameters;
+            const values = new Map();
+            const cacheKey = createInputCacheKey(
+                binaryInputName,
+                getInputDefintionForLiteralType(
+                    parameters[binaryInputName].var.type
+                )
+            );
+            values.set(cacheKey, simpleVariableDefaults.simpleBinary);
+            const { queryByText } = renderForm({
+                initialParameters: { values }
+            });
+
+            await waitFor(() => queryByText(binaryInputName, { exact: false }));
+            expect(queryByText(cannotLaunchWorkflowString)).toBeNull();
         });
     });
 });

--- a/src/components/Launch/LaunchWorkflowForm/test/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/test/constants.ts
@@ -2,3 +2,4 @@ export const booleanInputName = 'simpleBoolean';
 export const stringInputName = 'simpleString';
 export const stringNoLabelName = 'stringNoLabel';
 export const integerInputName = 'simpleInteger';
+export const binaryInputName = 'simpleBinary';

--- a/src/components/Launch/LaunchWorkflowForm/test/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/test/constants.ts
@@ -3,3 +3,4 @@ export const stringInputName = 'simpleString';
 export const stringNoLabelName = 'stringNoLabel';
 export const integerInputName = 'simpleInteger';
 export const binaryInputName = 'simpleBinary';
+export const errorInputName = 'simpleError';

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -42,6 +42,7 @@ export interface LaunchWorkflowFormState {
     selectedWorkflow?: SearchableSelectorOption<WorkflowId>;
     showErrors: boolean;
     submissionState: FetchableData<WorkflowExecutionIdentifier>;
+    unsupportedRequiredInputs: ParsedInput[];
     workflowName: string;
     workflowOptionsLoadingState: MultiFetchableState;
     workflowSelectorOptions: SearchableSelectorOption<WorkflowId>[];

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -51,8 +51,6 @@ function useLaunchPlanSelectorOptions(launchPlans: LaunchPlan[]) {
     ]);
 }
 
-function useUnsupportedRequiredInputs() {}
-
 interface UseLaunchPlansForWorkflowArgs {
     workflowId?: WorkflowId | null;
     preferredLaunchPlanId?: Identifier;

--- a/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchWorkflowForm/useLaunchWorkflowFormState.ts
@@ -30,6 +30,7 @@ import {
     ParsedInput
 } from './types';
 import {
+    getUnsupportedRequiredInputs,
     launchPlansToSearchableSelectorOptions,
     workflowsToSearchableSelectorOptions
 } from './utils';
@@ -49,6 +50,8 @@ function useLaunchPlanSelectorOptions(launchPlans: LaunchPlan[]) {
         launchPlans
     ]);
 }
+
+function useUnsupportedRequiredInputs() {}
 
 interface UseLaunchPlansForWorkflowArgs {
     workflowId?: WorkflowId | null;
@@ -248,6 +251,11 @@ export function useLaunchWorkflowFormState({
 
     const [parsedInputs, setParsedInputs] = useState<ParsedInput[]>([]);
 
+    const unsupportedRequiredInputs = useMemo(
+        () => getUnsupportedRequiredInputs(parsedInputs),
+        [parsedInputs]
+    );
+
     // Any time the inputs change (even if it's just re-ordering), we must
     // change the form key so that the inputs component will re-mount.
     const formKey = useMemo<string>(() => {
@@ -421,6 +429,7 @@ export function useLaunchWorkflowFormState({
         selectedWorkflow,
         showErrors,
         submissionState,
+        unsupportedRequiredInputs,
         workflowName,
         workflowOptionsLoadingState,
         workflowSelectorOptions,

--- a/src/components/Launch/LaunchWorkflowForm/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/utils.ts
@@ -10,8 +10,14 @@ import {
 import * as moment from 'moment';
 import { simpleTypeToInputType, typeLabels } from './constants';
 import { inputToLiteral } from './inputHelpers/inputHelpers';
+import { typeIsSupported } from './inputHelpers/utils';
 import { SearchableSelectorOption } from './SearchableSelector';
-import { InputProps, InputType, InputTypeDefinition } from './types';
+import {
+    InputProps,
+    InputType,
+    InputTypeDefinition,
+    ParsedInput
+} from './types';
 
 /** Creates a unique cache key for an input based on its name and type.
  * Note: This will not be *globally* unique, only unique within a single workflow
@@ -151,4 +157,15 @@ export function getInputDefintionForLiteralType(
 
 export function getLaunchInputId(name: string): string {
     return `launch-input-${name}`;
+}
+
+export function getUnsupportedRequiredInputs(
+    inputs: ParsedInput[]
+): ParsedInput[] {
+    return inputs.filter(
+        input =>
+            !typeIsSupported(input.typeDefinition) &&
+            input.required &&
+            input.initialValue === undefined
+    );
 }

--- a/src/components/Launch/LaunchWorkflowForm/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/utils.ts
@@ -159,6 +159,9 @@ export function getLaunchInputId(name: string): string {
     return `launch-input-${name}`;
 }
 
+/** Given an array of `ParsedInput`s, returns the subset which are required
+ * and of a type which cannot be provided via our form.
+ */
 export function getUnsupportedRequiredInputs(
     inputs: ParsedInput[]
 ): ParsedInput[] {


### PR DESCRIPTION
lyft/flyte#291

This change improves the experience when a user is attempting to launch a Workflow for which it is impossible to specify a required value.
This can happen if the Workflow defines a required input with a type that the Console doesn't support yet (such as Schema, Binary, etc). If the Launch Plan specifies a default value, or we are re-launching an execution from which we can copy the value, it is still possible to proceed. Otherwise, we won't be able to successfully launch.
The previous experience was a little confusing, because we would only show a generic error at the bottom of the form after attempting to submit. The new experience is to show the user an error message indicating which inputs are unsupported, and directing them to either select a Launch Plan which provides a value, or to use the CLI to launch the workflow

![image](https://user-images.githubusercontent.com/1815175/87591197-d3460280-c69c-11ea-931a-1d5aee772826.png)
