### PR TITLE
feat: Enables support for Blobs on the Launch form

### DIFF
--- a/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
@@ -1,28 +1,133 @@
+import {
+    FormControl,
+    FormHelperText,
+    InputLabel,
+    MenuItem,
+    Select,
+    TextField,
+    Typography
+} from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import { BlobDimensionality } from 'models';
 import * as React from 'react';
-import { InputProps } from './types';
+import {
+    blobFormatHelperText,
+    blobUriHelperText,
+    defaultBlobValue
+} from './constants';
+import { BlobValue, InputProps } from './types';
 import { getLaunchInputId } from './utils';
 
-/** A micro form for entering the values related to a Blob Literal
- */
+const useStyles = makeStyles((theme: Theme) => ({
+    dimensionalityInput: {
+        flex: '1 1 auto',
+        marginLeft: theme.spacing(2)
+    },
+    formatInput: {
+        flex: '1 1 auto'
+    },
+    inputContainer: {
+        borderLeft: `1px solid ${theme.palette.divider}`,
+        marginTop: theme.spacing(1),
+        paddingLeft: theme.spacing(1)
+    },
+    metadataContainer: {
+        display: 'flex',
+        marginTop: theme.spacing(1),
+        width: '100%'
+    }
+}));
+
+/** A micro form for entering the values related to a Blob Literal */
 export const BlobInput: React.FC<InputProps> = props => {
+    const styles = useStyles();
     const { error, label, name, onChange, value: propValue } = props;
-    const blobValue = typeof propValue === 'object' ? propValue : {};
+    const blobValue =
+        typeof propValue === 'object'
+            ? (propValue as BlobValue)
+            : defaultBlobValue;
     const hasError = !!error;
     // TODO: We might want a way to pass errors that are specific to a sub-field
     // of an input. Right now, a string error assumes that an input has a single
     // control that can be labeled with the error string.
     const helperText = hasError ? error : props.helperText;
 
-    const handleChange = () => {
-        // TODO
-        onChange(
-            {
-                uri: '',
-                dimensionality: BlobDimensionality.SINGLE
-            } /* BlobValue */
-        );
+    const handleUriChange = ({
+        target: { value: uri }
+    }: React.ChangeEvent<HTMLInputElement>) => {
+        onChange({
+            ...blobValue,
+            uri
+        });
     };
-    // TODO:
-    return <div />;
+
+    const handleFormatChange = ({
+        target: { value: format }
+    }: React.ChangeEvent<HTMLInputElement>) => {
+        onChange({
+            ...blobValue,
+            format
+        });
+    };
+
+    const handleDimensionalityChange = ({
+        target: { value }
+    }: React.ChangeEvent<{ value: unknown }>) => {
+        onChange({
+            ...blobValue,
+            dimensionality: value as BlobDimensionality
+        });
+    };
+
+    const selectId = getLaunchInputId(`${name}-select`);
+
+    return (
+        <div>
+            <Typography variant="body1" component="label">
+                {label}
+            </Typography>
+            <FormHelperText error={hasError}>{helperText}</FormHelperText>
+            <div className={styles.inputContainer}>
+                <TextField
+                    id={getLaunchInputId(`${name}-uri`)}
+                    // TODO: Error here for required
+                    helperText={blobUriHelperText}
+                    fullWidth={true}
+                    label="uri"
+                    onChange={handleUriChange}
+                    value={blobValue.uri}
+                    variant="outlined"
+                />
+                <div className={styles.metadataContainer}>
+                    <TextField
+                        className={styles.formatInput}
+                        id={getLaunchInputId(`${name}-format`)}
+                        helperText={blobFormatHelperText}
+                        label="format"
+                        onChange={handleFormatChange}
+                        value={blobValue.format}
+                        variant="outlined"
+                    />
+                    <FormControl className={styles.dimensionalityInput}>
+                        <InputLabel id={`${selectId}-label`}>
+                            Dimensionality
+                        </InputLabel>
+                        <Select
+                            labelId={`${selectId}-label`}
+                            id={selectId}
+                            value={blobValue.dimensionality}
+                            onChange={handleDimensionalityChange}
+                        >
+                            <MenuItem value={BlobDimensionality.SINGLE}>
+                                Single
+                            </MenuItem>
+                            <MenuItem value={BlobDimensionality.MULTIPART}>
+                                Multipart
+                            </MenuItem>
+                        </Select>
+                    </FormControl>
+                </div>
+            </div>
+        </div>
+    );
 };

--- a/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
@@ -115,10 +115,10 @@ export const BlobInput: React.FC<InputProps> = props => {
                             onChange={handleDimensionalityChange}
                         >
                             <MenuItem value={BlobDimensionality.SINGLE}>
-                                Single
+                                Single (File)
                             </MenuItem>
                             <MenuItem value={BlobDimensionality.MULTIPART}>
-                                Multipart
+                                Multipart (Directory)
                             </MenuItem>
                         </Select>
                     </FormControl>

--- a/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
@@ -8,7 +8,6 @@ import {
     Typography
 } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { isObject } from 'lodash';
 import { BlobDimensionality } from 'models';
 import * as React from 'react';
 import {
@@ -16,8 +15,8 @@ import {
     blobUriHelperText,
     defaultBlobValue
 } from './constants';
-import { BlobValue, InputProps } from './types';
-import { getLaunchInputId } from './utils';
+import { InputProps } from './types';
+import { getLaunchInputId, isBlobValue } from './utils';
 
 const useStyles = makeStyles((theme: Theme) => ({
     dimensionalityInput: {
@@ -43,9 +42,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export const BlobInput: React.FC<InputProps> = props => {
     const styles = useStyles();
     const { error, label, name, onChange, value: propValue } = props;
-    const blobValue = isObject(propValue)
-        ? (propValue as BlobValue)
-        : defaultBlobValue;
+    const blobValue = isBlobValue(propValue) ? propValue : defaultBlobValue;
     const hasError = !!error;
     const helperText = hasError ? error : props.helperText;
 

--- a/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
@@ -8,6 +8,7 @@ import {
     Typography
 } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import { isObject } from 'lodash';
 import { BlobDimensionality } from 'models';
 import * as React from 'react';
 import {
@@ -42,14 +43,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 export const BlobInput: React.FC<InputProps> = props => {
     const styles = useStyles();
     const { error, label, name, onChange, value: propValue } = props;
-    const blobValue =
-        typeof propValue === 'object'
-            ? (propValue as BlobValue)
-            : defaultBlobValue;
+    const blobValue = isObject(propValue)
+        ? (propValue as BlobValue)
+        : defaultBlobValue;
     const hasError = !!error;
-    // TODO: We might want a way to pass errors that are specific to a sub-field
-    // of an input. Right now, a string error assumes that an input has a single
-    // control that can be labeled with the error string.
     const helperText = hasError ? error : props.helperText;
 
     const handleUriChange = ({
@@ -90,7 +87,6 @@ export const BlobInput: React.FC<InputProps> = props => {
             <div className={styles.inputContainer}>
                 <TextField
                     id={getLaunchInputId(`${name}-uri`)}
-                    // TODO: Error here for required
                     helperText={blobUriHelperText}
                     fullWidth={true}
                     label="uri"

--- a/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/BlobInput.tsx
@@ -1,0 +1,28 @@
+import { BlobDimensionality } from 'models';
+import * as React from 'react';
+import { InputProps } from './types';
+import { getLaunchInputId } from './utils';
+
+/** A micro form for entering the values related to a Blob Literal
+ */
+export const BlobInput: React.FC<InputProps> = props => {
+    const { error, label, name, onChange, value: propValue } = props;
+    const blobValue = typeof propValue === 'object' ? propValue : {};
+    const hasError = !!error;
+    // TODO: We might want a way to pass errors that are specific to a sub-field
+    // of an input. Right now, a string error assumes that an input has a single
+    // control that can be labeled with the error string.
+    const helperText = hasError ? error : props.helperText;
+
+    const handleChange = () => {
+        // TODO
+        onChange(
+            {
+                uri: '',
+                dimensionality: BlobDimensionality.SINGLE
+            } /* BlobValue */
+        );
+    };
+    // TODO:
+    return <div />;
+};

--- a/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowFormInputs.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/LaunchWorkflowFormInputs.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { BlobInput } from './BlobInput';
 import { CollectionInput } from './CollectionInput';
 import { SimpleInput } from './SimpleInput';
 import { useStyles } from './styles';
@@ -14,6 +15,8 @@ import { useFormInputsState } from './useFormInputsState';
 function getComponentForInput(input: InputProps, showErrors: boolean) {
     const props = { ...input, error: showErrors ? input.error : undefined };
     switch (input.typeDefinition.type) {
+        case InputType.Blob:
+            return <BlobInput {...props} />;
         case InputType.Collection:
             return <CollectionInput {...props} />;
         case InputType.Map:

--- a/src/components/Launch/LaunchWorkflowForm/__mocks__/mockInputs.ts
+++ b/src/components/Launch/LaunchWorkflowForm/__mocks__/mockInputs.ts
@@ -2,7 +2,12 @@ import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
 import { Core } from 'flyteidl';
 import { mapValues } from 'lodash';
 import * as Long from 'long';
-import { SimpleType, TypedInterface, Variable } from 'models/Common';
+import {
+    BlobDimensionality,
+    SimpleType,
+    TypedInterface,
+    Variable
+} from 'models/Common';
 import { literalNone } from '../inputHelpers/constants';
 import { primitiveLiteral } from './utils';
 
@@ -23,6 +28,7 @@ export type SimpleVariableKey =
     | 'simpleInteger'
     | 'simpleFloat'
     | 'simpleBoolean'
+    | 'simpleBlob'
     | 'simpleDuration'
     | 'simpleDatetime'
     | 'simpleBinary'
@@ -39,11 +45,14 @@ export const mockSimpleVariables: Record<SimpleVariableKey, Variable> = {
     simpleDatetime: simpleType(SimpleType.DATETIME, 'a simple datetime value'),
     simpleBinary: simpleType(SimpleType.BINARY, 'a simple binary value'),
     simpleError: simpleType(SimpleType.ERROR, 'a simple error value'),
-    simpleStruct: simpleType(SimpleType.STRUCT, 'a simple struct value')
+    simpleStruct: simpleType(SimpleType.STRUCT, 'a simple struct value'),
+    simpleBlob: {
+        description: 'a simple single-dimensional blob',
+        type: { blob: { dimensionality: BlobDimensionality.SINGLE } }
+    }
     // schema: {},
     // collection: {},
-    // mapValue: {},
-    // blob: {}
+    // mapValue: {}
 };
 
 export const simpleVariableDefaults: Record<
@@ -63,7 +72,20 @@ export const simpleVariableDefaults: Record<
     simpleError: literalNone(),
     simpleFloat: primitiveLiteral({ floatValue: 1.5 }),
     simpleInteger: primitiveLiteral({ integer: Long.fromNumber(12345) }),
-    simpleStruct: literalNone()
+    simpleStruct: literalNone(),
+    simpleBlob: {
+        scalar: {
+            blob: {
+                uri: 's3://someBlobUri/goesHere',
+                metadata: {
+                    type: {
+                        format: 'csv',
+                        dimensionality: BlobDimensionality.SINGLE
+                    }
+                }
+            }
+        }
+    }
 };
 
 export const mockCollectionVariables: Record<string, Variable> = mapValues(

--- a/src/components/Launch/LaunchWorkflowForm/__mocks__/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/__mocks__/utils.ts
@@ -1,5 +1,22 @@
 import { Core } from 'flyteidl';
+import { BlobDimensionality } from 'models';
 
 export function primitiveLiteral(primitive: Core.IPrimitive): Core.ILiteral {
     return { scalar: { primitive } };
+}
+
+export function blobLiteral({
+    uri,
+    format,
+    dimensionality
+}: {
+    uri?: string;
+    format?: string;
+    dimensionality?: BlobDimensionality;
+}): Core.ILiteral {
+    return {
+        scalar: {
+            blob: { uri, metadata: { type: { format, dimensionality } } }
+        }
+    };
 }

--- a/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
+++ b/src/components/Launch/LaunchWorkflowForm/__stories__/LaunchWorkflowForm.stories.tsx
@@ -36,6 +36,7 @@ import { useExecutionLaunchConfiguration } from '../useExecutionLaunchConfigurat
 import { getWorkflowInputs } from '../utils';
 
 const booleanInputName = 'simpleBoolean';
+const blobInputName = 'simpleBlob';
 const stringInputName = 'simpleString';
 const integerInputName = 'simpleInteger';
 const submitAction = action('createWorkflowExecution');
@@ -168,6 +169,7 @@ stories.add('Required Inputs', () => {
     parameters[stringInputName].required = true;
     parameters[integerInputName].required = true;
     parameters[booleanInputName].required = true;
+    parameters[blobInputName].required = true;
     return renderForm({ mocks });
 });
 stories.add('Default Values', () => {

--- a/src/components/Launch/LaunchWorkflowForm/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/constants.ts
@@ -1,5 +1,5 @@
-import { SimpleType } from 'models';
-import { InputType } from './types';
+import { BlobDimensionality, SimpleType } from 'models';
+import { BlobValue, InputType } from './types';
 
 export const launchPlansTableRowHeight = 40;
 export const launchPlansTableColumnWidths = {
@@ -55,6 +55,13 @@ export const simpleTypeToInputType: { [k in SimpleType]: InputType } = {
     [SimpleType.STRUCT]: InputType.Struct
 };
 
+export const defaultBlobValue: BlobValue = {
+    uri: '',
+    dimensionality: BlobDimensionality.SINGLE
+};
+
 export const requiredInputSuffix = '*';
 export const cannotLaunchWorkflowString = 'Workflow cannot be launched';
 export const unsupportedRequiredInputsString = `This Workflow version contains one or more required inputs which are not supported by Flyte Console and do not have default values specified in the Workflow definition or the selected Launch Plan.\n\nYou can launch this Workflow version with the Flyte CLI or by selecting a Launch Plan which provides values for the unsupported inputs.\n\nThe required inputs are :`;
+export const blobUriHelperText = '(required) location of the data';
+export const blobFormatHelperText = '(optional) csv, parquet, etc...';

--- a/src/components/Launch/LaunchWorkflowForm/constants.ts
+++ b/src/components/Launch/LaunchWorkflowForm/constants.ts
@@ -25,7 +25,7 @@ export const formStrings = {
 /** Maps any valid InputType enum to a display string */
 export const typeLabels: { [k in InputType]: string } = {
     [InputType.Binary]: 'binary',
-    [InputType.Blob]: 'blob',
+    [InputType.Blob]: 'file/blob',
     [InputType.Boolean]: 'boolean',
     [InputType.Collection]: '',
     [InputType.Datetime]: 'datetime - UTC',

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
@@ -1,0 +1,67 @@
+import { Core } from 'flyteidl';
+import { BlobDimensionality } from 'models';
+import { BlobValue, InputValue } from '../types';
+import { literalNone } from './constants';
+import { ConverterInput, InputHelper } from './types';
+
+function fromLiteral(literal: Core.ILiteral): InputValue {
+    if (!literal.scalar || !literal.scalar.blob) {
+        throw new Error('Literal blob missing scalar.blob property');
+    }
+    const { blob } = literal.scalar;
+    const uri = blob.uri ?? '';
+    const format = blob.metadata?.type?.format ?? '';
+    const dimensionality =
+        blob.metadata?.type?.dimensionality ?? BlobDimensionality.SINGLE;
+
+    return {
+        dimensionality,
+        format,
+        uri
+    };
+}
+
+function toLiteral({ value }: ConverterInput): Core.ILiteral {
+    if (typeof value !== 'object') {
+        return literalNone();
+    }
+    const { dimensionality, format, uri } = value as BlobValue;
+    if (!uri) {
+        return literalNone();
+    }
+
+    return {
+        scalar: {
+            blob: { uri, metadata: { type: { dimensionality, format } } }
+        }
+    };
+}
+
+function validate({ value }: ConverterInput) {
+    if (typeof value !== 'object') {
+        throw new Error('Value must be an object');
+    }
+
+    const blobValue = value as BlobValue;
+    if (typeof blobValue.uri !== 'string' || blobValue.uri.length === 0) {
+        throw new Error('Value is not a valid Blob: uri is required');
+    }
+    if (
+        ![BlobDimensionality.SINGLE, BlobDimensionality.MULTIPART].includes(
+            blobValue.dimensionality
+        )
+    ) {
+        throw new Error(
+            `Value is not a valid Blob: unknown dimensionality value: ${blobValue.dimensionality}`
+        );
+    }
+    if (blobValue.format != null && typeof blobValue !== 'string') {
+        throw new Error('Value is not a valid Blob: format must be a string');
+    }
+}
+
+export const blobHelper: InputHelper = {
+    fromLiteral,
+    toLiteral,
+    validate
+};

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
@@ -4,6 +4,7 @@ import { BlobDimensionality } from 'models';
 import { BlobValue, InputValue } from '../types';
 import { literalNone } from './constants';
 import { ConverterInput, InputHelper, InputValidatorParams } from './types';
+import { isKeyOfBlobDimensionality } from './utils';
 
 function fromLiteral(literal: Core.ILiteral): InputValue {
     if (!literal.scalar || !literal.scalar.blob) {
@@ -25,11 +26,13 @@ function fromLiteral(literal: Core.ILiteral): InputValue {
 
 // Allows for string values ('single'/'multipart') when specifying blobs manually in collections
 function getDimensionality(value: string | number) {
-    return typeof value === 'number'
-        ? value
-        : BlobDimensionality[
-              value.toUpperCase() as keyof typeof BlobDimensionality
-          ];
+    if (typeof value === 'number') {
+        return value;
+    }
+    if (isKeyOfBlobDimensionality(value)) {
+        return BlobDimensionality[value];
+    }
+    return BlobDimensionality.SINGLE;
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
@@ -1,4 +1,5 @@
 import { Core } from 'flyteidl';
+import { isObject } from 'lodash';
 import { BlobDimensionality } from 'models';
 import { BlobValue, InputValue } from '../types';
 import { literalNone } from './constants';
@@ -32,7 +33,7 @@ function getDimensionality(value: string | number) {
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {
-    if (typeof value !== 'object') {
+    if (!isObject(value)) {
         return literalNone();
     }
     const {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
@@ -63,8 +63,8 @@ function validate({ value, required }: InputValidatorParams) {
 
     const blobValue = value as BlobValue;
     if (
-        (required && typeof blobValue.uri !== 'string') ||
-        blobValue.uri.length === 0
+        (required || !!blobValue) &&
+        (typeof blobValue.uri !== 'string' || blobValue.uri.length === 0)
     ) {
         throw new Error('uri is required');
     }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
@@ -25,11 +25,17 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
     if (typeof value !== 'object') {
         return literalNone();
     }
-    const { dimensionality, format, uri } = value as BlobValue;
+    const {
+        dimensionality = BlobDimensionality.SINGLE,
+        format: rawFormat,
+        uri
+    } = value as BlobValue;
     if (!uri) {
         return literalNone();
     }
 
+    // Send null for empty string values of format
+    const format = rawFormat ? rawFormat : null;
     return {
         scalar: {
             blob: { uri, metadata: { type: { dimensionality, format } } }
@@ -55,7 +61,7 @@ function validate({ value }: ConverterInput) {
             `Value is not a valid Blob: unknown dimensionality value: ${blobValue.dimensionality}`
         );
     }
-    if (blobValue.format != null && typeof blobValue !== 'string') {
+    if (blobValue.format != null && typeof blobValue.format !== 'string') {
         throw new Error('Value is not a valid Blob: format must be a string');
     }
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
@@ -2,7 +2,7 @@ import { Core } from 'flyteidl';
 import { BlobDimensionality } from 'models';
 import { BlobValue, InputValue } from '../types';
 import { literalNone } from './constants';
-import { ConverterInput, InputHelper } from './types';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
 
 function fromLiteral(literal: Core.ILiteral): InputValue {
     if (!literal.scalar || !literal.scalar.blob) {
@@ -55,14 +55,17 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
     };
 }
 
-function validate({ value }: ConverterInput) {
+function validate({ value, required }: InputValidatorParams) {
     if (typeof value !== 'object') {
         throw new Error('Value must be an object');
     }
 
     const blobValue = value as BlobValue;
-    if (typeof blobValue.uri !== 'string' || blobValue.uri.length === 0) {
-        throw new Error('Value is not a valid Blob: uri is required');
+    if (
+        (required && typeof blobValue.uri !== 'string') ||
+        blobValue.uri.length === 0
+    ) {
+        throw new Error('uri is required');
     }
     if (!(getDimensionality(blobValue.dimensionality) in BlobDimensionality)) {
         throw new Error(

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
@@ -47,7 +47,7 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
 
     const dimensionality = getDimensionality(rawDimensionality);
 
-    // Send null for empty string values of format
+    // Send undefined for empty string values of format
     const format = rawFormat ? rawFormat : undefined;
     return {
         scalar: {
@@ -62,19 +62,22 @@ function validate({ value, required }: InputValidatorParams) {
     }
 
     const blobValue = value as BlobValue;
-    if (
-        (required || !!blobValue) &&
-        (typeof blobValue.uri !== 'string' || blobValue.uri.length === 0)
-    ) {
+    if (required && (typeof blobValue.uri == null || !blobValue.uri.length)) {
         throw new Error('uri is required');
+    }
+    if (blobValue != null && typeof blobValue.uri !== 'string') {
+        throw new Error('uri must be a string');
+    }
+    if (blobValue.dimensionality == null) {
+        throw new Error('dimensionality is required');
     }
     if (!(getDimensionality(blobValue.dimensionality) in BlobDimensionality)) {
         throw new Error(
-            `Value is not a valid Blob: unknown dimensionality value: ${blobValue.dimensionality}`
+            `unknown dimensionality value: ${blobValue.dimensionality}`
         );
     }
     if (blobValue.format != null && typeof blobValue.format !== 'string') {
-        throw new Error('Value is not a valid Blob: format must be a string');
+        throw new Error('format must be a string');
     }
 }
 

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/blob.ts
@@ -29,10 +29,11 @@ function getDimensionality(value: string | number) {
     if (typeof value === 'number') {
         return value;
     }
-    if (isKeyOfBlobDimensionality(value)) {
-        return BlobDimensionality[value];
+    const normalizedValue = value.toUpperCase();
+    if (isKeyOfBlobDimensionality(normalizedValue)) {
+        return BlobDimensionality[normalizedValue];
     }
-    return BlobDimensionality.SINGLE;
+    return -1;
 }
 
 function toLiteral({ value }: ConverterInput): Core.ILiteral {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/boolean.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/boolean.ts
@@ -1,7 +1,7 @@
 import { Core } from 'flyteidl';
 import { InputValue } from '../types';
 import { primitiveLiteralPaths } from './constants';
-import { ConverterInput, InputHelper } from './types';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
 import { extractLiteralWithCheck } from './utils';
 
 /** Checks that a value is an acceptable boolean value. These can be
@@ -47,7 +47,7 @@ function fromLiteral(literal: Core.ILiteral): InputValue {
     );
 }
 
-function validate({ value }: ConverterInput) {
+function validate({ value }: InputValidatorParams) {
     if (!isValidBoolean(value)) {
         throw new Error('Value is not a valid boolean');
     }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/collection.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/collection.ts
@@ -1,9 +1,9 @@
 import { Core } from 'flyteidl';
-import { InputType, InputTypeDefinition, InputValue } from '../types';
+import { InputTypeDefinition, InputValue } from '../types';
 import { literalNone } from './constants';
 import { getHelperForInput } from './getHelperForInput';
 import { parseJSON } from './parseJson';
-import { ConverterInput, InputHelper } from './types';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
 import { collectionChildToString } from './utils';
 
 const missingSubTypeError = 'Unexpected missing subtype for collection';
@@ -81,7 +81,7 @@ function toLiteral({
     };
 }
 
-function validate({ value }: ConverterInput) {
+function validate({ value }: InputValidatorParams) {
     if (typeof value !== 'string') {
         throw new Error('Value must be a string');
     }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/datetime.ts
@@ -3,7 +3,7 @@ import { Core, Protobuf } from 'flyteidl';
 import { utc as moment } from 'moment';
 import { InputValue } from '../types';
 import { allowedDateFormats, primitiveLiteralPaths } from './constants';
-import { ConverterInput, InputHelper } from './types';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
 import { extractLiteralWithCheck } from './utils';
 
 function parseDate(value: InputValue) {
@@ -27,7 +27,7 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
     };
 }
 
-function validate({ value }: ConverterInput) {
+function validate({ value }: InputValidatorParams) {
     const parsed = parseDate(value);
     if (Number.isNaN(parsed.getTime())) {
         throw new Error('Value is not a valid Date');

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/duration.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/duration.ts
@@ -3,7 +3,7 @@ import { Core, Protobuf } from 'flyteidl';
 import { InputValue } from '../types';
 import { primitiveLiteralPaths } from './constants';
 import { isValidFloat } from './float';
-import { ConverterInput, InputHelper } from './types';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
 import { extractLiteralWithCheck } from './utils';
 
 function fromLiteral(literal: Core.ILiteral): InputValue {
@@ -23,7 +23,7 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
     };
 }
 
-function validate({ value }: ConverterInput) {
+function validate({ value }: InputValidatorParams) {
     if (!isValidFloat(value)) {
         throw new Error('Value is not a valid duration');
     }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/float.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/float.ts
@@ -1,7 +1,7 @@
 import { Core } from 'flyteidl';
 import { InputValue } from '../types';
 import { primitiveLiteralPaths } from './constants';
-import { ConverterInput, InputHelper } from './types';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
 import { extractLiteralWithCheck } from './utils';
 
 function fromLiteral(literal: Core.ILiteral): InputValue {
@@ -29,7 +29,7 @@ export function isValidFloat(value: InputValue): boolean {
     return false;
 }
 
-function validate({ value }: ConverterInput) {
+function validate({ value }: InputValidatorParams) {
     if (!isValidFloat(value)) {
         throw new Error('Value is not a valid floating point number');
     }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/getHelperForInput.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/getHelperForInput.ts
@@ -1,4 +1,5 @@
 import { InputType } from '../types';
+import { blobHelper } from './blob';
 import { booleanHelper } from './boolean';
 import { collectionHelper } from './collection';
 import { datetimeHelper } from './datetime';
@@ -14,7 +15,7 @@ const unsupportedHelper = noneHelper;
 /** Maps an `InputType` to a function which will convert its value into a `Literal` */
 const inputHelpers: Record<InputType, InputHelper> = {
     [InputType.Binary]: noneHelper,
-    [InputType.Blob]: unsupportedHelper,
+    [InputType.Blob]: blobHelper,
     [InputType.Boolean]: booleanHelper,
     [InputType.Collection]: collectionHelper,
     [InputType.Datetime]: datetimeHelper,

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/inputHelpers.ts
@@ -3,6 +3,7 @@ import { Core } from 'flyteidl';
 import { InputProps, InputTypeDefinition, InputValue } from '../types';
 import { literalNone } from './constants';
 import { getHelperForInput } from './getHelperForInput';
+import { InputValidatorParams, ValidationParams } from './types';
 
 type ToLiteralParams = Pick<
     InputProps,
@@ -56,20 +57,12 @@ export function literalToInputValue(
     }
 }
 
-type ValidationParams = Pick<
-    InputProps,
-    'initialValue' | 'name' | 'required' | 'typeDefinition' | 'value'
->;
 /** Validates a given InputValue based on rules for the provided type. Returns
  * void if no errors, throws an error otherwise.
  */
-export function validateInput({
-    initialValue,
-    name,
-    required,
-    typeDefinition,
-    value
-}: ValidationParams) {
+export function validateInput(params: ValidationParams) {
+    const { initialValue, name, required, typeDefinition, value } = params;
+    const { validate } = getHelperForInput(typeDefinition.type);
     if (value == null) {
         if (required && initialValue == null) {
             throw new ValueError(name, 'Value is required');
@@ -77,9 +70,8 @@ export function validateInput({
         return;
     }
 
-    const { validate } = getHelperForInput(typeDefinition.type);
     try {
-        validate({ value, typeDefinition });
+        validate(params as InputValidatorParams);
     } catch (e) {
         const error = e as Error;
         throw new ValueError(name, error.message);

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/integer.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/integer.ts
@@ -2,7 +2,7 @@ import { Core } from 'flyteidl';
 import * as Long from 'long';
 import { InputValue } from '../types';
 import { primitiveLiteralPaths } from './constants';
-import { ConverterInput, InputHelper } from './types';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
 import { extractLiteralWithCheck } from './utils';
 
 const integerRegexPattern = /^-?[0-9]+$/;
@@ -35,7 +35,7 @@ export function isValidInteger(value: InputValue): boolean {
     return false;
 }
 
-function validate({ value }: ConverterInput) {
+function validate({ value }: InputValidatorParams) {
     if (!isValidInteger(value)) {
         throw new Error('Value is not a valid integer');
     }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/string.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/string.ts
@@ -1,7 +1,7 @@
 import { Core } from 'flyteidl';
 import { InputValue } from '../types';
 import { primitiveLiteralPaths } from './constants';
-import { ConverterInput, InputHelper } from './types';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
 import { extractLiteralWithCheck } from './utils';
 
 function fromLiteral(literal: Core.ILiteral): InputValue {
@@ -16,7 +16,7 @@ function toLiteral({ value }: ConverterInput): Core.ILiteral {
     return { scalar: { primitive: { stringValue } } };
 }
 
-function validate({ value }: ConverterInput) {
+function validate({ value }: InputValidatorParams) {
     if (typeof value !== 'string') {
         throw new Error('Value is not a string');
     }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -1,4 +1,5 @@
 import { Core } from 'flyteidl';
+import * as Long from 'long';
 import { primitiveLiteral } from '../../__mocks__/utils';
 import { InputProps, InputType } from '../../types';
 import { literalNone } from '../constants';
@@ -53,38 +54,28 @@ describe('literalToInputValue', () => {
     describe('Primitives', () => {
         literalToInputTestCases.map(([type, input, output]) =>
             it(`should correctly convert ${type}: ${JSON.stringify(
-                input.scalar!.primitive
-            )}`, () => {
-                const result = literalToInputValue({ type }, input);
-                expect(result).toEqual(output);
-            })
+                input
+            )}`, () =>
+                expect(literalToInputValue({ type }, input)).toEqual(output))
         );
 
         supportedPrimitives.map(type =>
-            it(`should convert None value for ${type} to undefined`, () => {
+            it(`should convert None value for ${type} to undefined`, () =>
                 expect(
                     literalToInputValue({ type }, literalNone())
-                ).toBeUndefined();
-            })
+                ).toBeUndefined())
         );
 
-        it('should correctly convert noneType to undefined', () => {
+        it('should correctly convert noneType to undefined', () =>
             expect(
                 literalToInputValue({ type: InputType.None }, literalNone())
-            ).toEqual(undefined);
-        });
-    });
-
-    describe('Blob', () => {
-        // TODO: blob test cases
-        it('should correctly convert ____', () => {});
-        it('should correctly convert noneType', () => {});
+            ).toEqual(undefined));
     });
 
     describe('Collections', () => {
-        literalToInputTestCases.map(([type, input, output]) =>
+        literalToInputTestCases.map(([type, input, output]) => {
             it(`should correctly convert collection of ${type}: ${JSON.stringify(
-                input.scalar!.primitive
+                input
             )}`, () => {
                 const collection: Core.ILiteral = {
                     collection: {
@@ -99,11 +90,7 @@ describe('literalToInputValue', () => {
                     collection
                 );
                 expect(result).toEqual(expectedString);
-            })
-        );
-
-        it('should correctly convert collection of Blob', () => {
-            // TODO
+            });
         });
 
         it('should return empty for noneType literals', () => {
@@ -139,51 +126,52 @@ describe('literalToInputValue', () => {
 });
 
 describe('inputToLiteral', () => {
-    describe('Primitives', () => {
-        literalTestCases.map(([type, input, output]) =>
-            it(`should correctly convert ${type}: ${input} (${typeof input})`, () => {
-                const result = inputToLiteral(makeSimpleInput(type, input));
-                expect(result.scalar!.primitive).toEqual(output);
-            })
-        );
+    describe('Scalars', () => {
+        literalTestCases.map(([type, input, output]) => {
+            it(`should correctly convert ${type}: ${JSON.stringify(
+                input
+            )} (${typeof input})`, () =>
+                expect(inputToLiteral(makeSimpleInput(type, input))).toEqual(
+                    output
+                ));
+        });
     });
-
-    describe('Blob', () => {});
 
     describe('Collections', () => {
         literalTestCases.map(([type, input, output]) => {
             let value: any;
             if (['boolean', 'number'].includes(typeof input)) {
                 value = input;
+            } else if (input == null) {
+                value = 'null';
+            } else if (typeof input === 'string' || Long.isLong(input)) {
+                value = `"${input}"`;
             } else if (input instanceof Date) {
                 value = `"${input.toISOString()}"`;
             } else {
-                value = `"${input}"`;
+                value = JSON.stringify(input);
             }
 
-            it(`should correctly convert collection of type ${type}: [${value}] (${typeof input})`, () => {
+            it(`should correctly convert collection of type ${type}: [${JSON.stringify(
+                value
+            )}] (${typeof input})`, () => {
                 const result = inputToLiteral(
                     makeCollectionInput(type, `[${value}]`)
                 );
-                expect(
-                    result.collection!.literals![0].scalar!.primitive
-                ).toEqual(output);
+                expect(result.collection!.literals![0]).toEqual(output);
             });
 
-            it(`should correctly convert nested collection of type ${type}: [[${value}]] (${typeof input})`, () => {
+            it(`should correctly convert nested collection of type ${type}: [[${JSON.stringify(
+                value
+            )}]] (${typeof input})`, () => {
                 const result = inputToLiteral(
                     makeNestedCollectionInput(type, `[[${value}]]`)
                 );
                 expect(
                     result.collection!.literals![0].collection!.literals![0]
-                        .scalar!.primitive
                 ).toEqual(output);
             });
         });
-
-        it('should correctly convert collection of Blob', () => {});
-
-        it('should correctly convert nested collection of Blob ', () => {});
     });
 
     describe('Unsupported Types', () => {
@@ -230,7 +218,7 @@ describe('validateInput', () => {
     describe('boolean', () => {
         generateValidityTests(InputType.Boolean, validityTestCases.boolean);
     });
-
+    // TODO-NOW:
     describe('blob', () => {
         // TODO
     });
@@ -263,9 +251,8 @@ describe('validateInput', () => {
         expect(() => validateInput(simpleInput)).toThrowError();
     });
 
-    it('should throw errors for missing required Blob values', () => {
-        // TODO
-    });
+    // TODO-NOW:
+    it('should throw errors for missing required Blob values', () => {});
 
     it('should not throw an error for a required input with an initial value and no value', () => {
         const simpleInput = makeSimpleInput(

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -1,5 +1,6 @@
 import { Core } from 'flyteidl';
 import * as Long from 'long';
+import { BlobDimensionality } from 'models';
 import { primitiveLiteral } from '../../__mocks__/utils';
 import { InputProps, InputType } from '../../types';
 import { literalNone } from '../constants';
@@ -218,9 +219,9 @@ describe('validateInput', () => {
     describe('boolean', () => {
         generateValidityTests(InputType.Boolean, validityTestCases.boolean);
     });
-    // TODO-NOW:
+
     describe('blob', () => {
-        // TODO
+        generateValidityTests(InputType.Blob, validityTestCases.blob);
     });
 
     describe('datetime', () => {
@@ -251,8 +252,15 @@ describe('validateInput', () => {
         expect(() => validateInput(simpleInput)).toThrowError();
     });
 
-    // TODO-NOW:
-    it('should throw errors for missing required Blob values', () => {});
+    it('should throw errors for missing required Blob values', () => {
+        // URI is the only required, user-provided value with no default
+        const simpleInput = makeSimpleInput(InputType.Blob, {
+            format: 'csv',
+            dimensionality: BlobDimensionality.SINGLE
+        });
+        simpleInput.required = true;
+        expect(() => validateInput(simpleInput)).toThrowError();
+    });
 
     it('should not throw an error for a required input with an initial value and no value', () => {
         const simpleInput = makeSimpleInput(

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -75,6 +75,12 @@ describe('literalToInputValue', () => {
         });
     });
 
+    describe('Blob', () => {
+        // TODO: blob test cases
+        it('should correctly convert ____', () => {});
+        it('should correctly convert noneType', () => {});
+    });
+
     describe('Collections', () => {
         literalToInputTestCases.map(([type, input, output]) =>
             it(`should correctly convert collection of ${type}: ${JSON.stringify(
@@ -95,6 +101,10 @@ describe('literalToInputValue', () => {
                 expect(result).toEqual(expectedString);
             })
         );
+
+        it('should correctly convert collection of Blob', () => {
+            // TODO
+        });
 
         it('should return empty for noneType literals', () => {
             const collection: Core.ILiteral = {
@@ -138,6 +148,8 @@ describe('inputToLiteral', () => {
         );
     });
 
+    describe('Blob', () => {});
+
     describe('Collections', () => {
         literalTestCases.map(([type, input, output]) => {
             let value: any;
@@ -168,6 +180,10 @@ describe('inputToLiteral', () => {
                 ).toEqual(output);
             });
         });
+
+        it('should correctly convert collection of Blob', () => {});
+
+        it('should correctly convert nested collection of Blob ', () => {});
     });
 
     describe('Unsupported Types', () => {
@@ -215,6 +231,10 @@ describe('validateInput', () => {
         generateValidityTests(InputType.Boolean, validityTestCases.boolean);
     });
 
+    describe('blob', () => {
+        // TODO
+    });
+
     describe('datetime', () => {
         generateValidityTests(InputType.Datetime, validityTestCases.datetime);
     });
@@ -235,12 +255,16 @@ describe('validateInput', () => {
         generateValidityTests(InputType.String, validityTestCases.string);
     });
 
-    it('should throw errors for missing required values', () => {
+    it('should throw errors for missing required simple values', () => {
         const [type, input] = literalTestCases[0];
         const simpleInput = makeSimpleInput(type, input);
         simpleInput.required = true;
         delete simpleInput.value;
         expect(() => validateInput(simpleInput)).toThrowError();
+    });
+
+    it('should throw errors for missing required Blob values', () => {
+        // TODO
     });
 
     it('should not throw an error for a required input with an initial value and no value', () => {

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/inputHelpers.test.ts
@@ -203,13 +203,17 @@ function generateValidityTests(
     { valid, invalid }: { valid: any[]; invalid: any[] }
 ) {
     valid.map(value =>
-        it(`should treat ${value} (${typeof value}) as valid`, () => {
+        it(`should treat ${JSON.stringify(
+            value
+        )} (${typeof value}) as valid`, () => {
             const input = makeSimpleInput(type, value);
             expect(() => validateInput(input)).not.toThrowError();
         })
     );
     invalid.map(value =>
-        it(`should treat ${value} (${typeof value}) as invalid`, () => {
+        it(`should treat ${JSON.stringify(
+            value
+        )} (${typeof value}) as invalid`, () => {
             const input = makeSimpleInput(type, value);
             expect(() => validateInput(input)).toThrowError();
         })

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
@@ -11,6 +11,7 @@ const validDateString = '2019-01-10T00:00:00.000Z'; // Dec 1, 2019
 
 export const supportedPrimitives = [
     InputType.Boolean,
+    InputType.Blob,
     InputType.Datetime,
     InputType.Duration,
     InputType.Float,
@@ -19,7 +20,6 @@ export const supportedPrimitives = [
 
 export const unsupportedTypes = [
     InputType.Binary,
-    InputType.Blob,
     InputType.Error,
     InputType.Map,
     InputType.None,
@@ -31,6 +31,10 @@ export const validityTestCases = {
     boolean: {
         invalid: ['randomString', {}, new Date()],
         valid: [true, 'true', 't', '1', 1, false, 'false', 'f', '0', 0]
+    },
+    blob: {
+        invalid: [],
+        valid: []
     },
     datetime: {
         invalid: ['abc', true],
@@ -69,6 +73,7 @@ export const validityTestCases = {
     string: { invalid: [123, true, new Date(), {}], valid: ['', 'abcdefg'] }
 };
 
+// TODO: These are actually just primitive literals
 export const literalTestCases: PrimitiveTestParams[] = [
     [InputType.Boolean, true, { boolean: true }],
     [InputType.Boolean, 'true', { boolean: true }],

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
@@ -48,7 +48,6 @@ export const validityTestCases = {
             },
             { uri: 'path', dimensionality: 'notAnEnumValue' },
             { uri: 'path', dimensionality: 1000 },
-            { uri: '', dimensionality: BlobDimensionality.SINGLE },
             { uri: 'path' }
         ],
         valid: [

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
@@ -34,10 +34,45 @@ export const validityTestCases = {
         invalid: ['randomString', {}, new Date()],
         valid: [true, 'true', 't', '1', 1, false, 'false', 'f', '0', 0]
     },
-    // TODO-NOW:
     blob: {
-        invalid: [],
-        valid: []
+        invalid: [
+            {
+                uri: 5,
+                format: 'csv',
+                dimensionality: BlobDimensionality.SINGLE
+            },
+            {
+                uri: 'path',
+                format: 5,
+                dimensionality: BlobDimensionality.SINGLE
+            },
+            { uri: 'path', dimensionality: 'notAnEnumValue' },
+            { uri: 'path', dimensionality: 1000 },
+            { uri: '', dimensionality: BlobDimensionality.SINGLE },
+            { uri: 'path' }
+        ],
+        valid: [
+            {
+                uri: 'path',
+                format: 'csv',
+                dimensionality: BlobDimensionality.SINGLE
+            },
+            {
+                uri: 'path',
+                format: 'csv',
+                dimensionality: BlobDimensionality.MULTIPART
+            },
+            { uri: 'path', format: 'csv', dimensionality: 'single' },
+            { uri: 'path', format: 'csv', dimensionality: 'SINGLE' },
+            { uri: 'path', format: 'csv', dimensionality: 'multipart' },
+            { uri: 'path', format: 'csv', dimensionality: 'MULTIPART' },
+            {
+                uri: 'path',
+                format: '',
+                dimensionality: BlobDimensionality.SINGLE
+            },
+            { uri: 'path', dimensionality: BlobDimensionality.SINGLE }
+        ]
     },
     datetime: {
         invalid: ['abc', true],

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/test/testCases.ts
@@ -1,11 +1,13 @@
 import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
 import { Core } from 'flyteidl';
 import * as Long from 'long';
-import { primitiveLiteral } from '../../__mocks__/utils';
+import { BlobDimensionality } from 'models';
+import { blobLiteral, primitiveLiteral } from '../../__mocks__/utils';
 import { InputType, InputValue } from '../../types';
+import { literalNone } from '../constants';
 
-// Defines type of value, input, and expected value of innermost `IScalar`
-type PrimitiveTestParams = [InputType, any, Core.IPrimitive];
+// Defines type of value, input, and expected value of a `Core.ILiteral`
+type LiteralTestParams = [InputType, any, Core.ILiteral];
 
 const validDateString = '2019-01-10T00:00:00.000Z'; // Dec 1, 2019
 
@@ -32,6 +34,7 @@ export const validityTestCases = {
         invalid: ['randomString', {}, new Date()],
         valid: [true, 'true', 't', '1', 1, false, 'false', 'f', '0', 0]
     },
+    // TODO-NOW:
     blob: {
         invalid: [],
         valid: []
@@ -73,53 +76,206 @@ export const validityTestCases = {
     string: { invalid: [123, true, new Date(), {}], valid: ['', 'abcdefg'] }
 };
 
-// TODO: These are actually just primitive literals
-export const literalTestCases: PrimitiveTestParams[] = [
-    [InputType.Boolean, true, { boolean: true }],
-    [InputType.Boolean, 'true', { boolean: true }],
-    [InputType.Boolean, 't', { boolean: true }],
-    [InputType.Boolean, '1', { boolean: true }],
-    [InputType.Boolean, 1, { boolean: true }],
-    [InputType.Boolean, false, { boolean: false }],
-    [InputType.Boolean, 'false', { boolean: false }],
-    [InputType.Boolean, 'f', { boolean: false }],
-    [InputType.Boolean, '0', { boolean: false }],
-    [InputType.Boolean, 0, { boolean: false }],
+export const literalTestCases: LiteralTestParams[] = [
+    [InputType.Boolean, true, primitiveLiteral({ boolean: true })],
+    [InputType.Boolean, 'true', primitiveLiteral({ boolean: true })],
+    [InputType.Boolean, 't', primitiveLiteral({ boolean: true })],
+    [InputType.Boolean, '1', primitiveLiteral({ boolean: true })],
+    [InputType.Boolean, 1, primitiveLiteral({ boolean: true })],
+    [InputType.Boolean, false, primitiveLiteral({ boolean: false })],
+    [InputType.Boolean, 'false', primitiveLiteral({ boolean: false })],
+    [InputType.Boolean, 'f', primitiveLiteral({ boolean: false })],
+    [InputType.Boolean, '0', primitiveLiteral({ boolean: false })],
+    [InputType.Boolean, 0, primitiveLiteral({ boolean: false })],
     [
         InputType.Datetime,
         new Date(validDateString),
-        { datetime: dateToTimestamp(new Date(validDateString)) }
+        primitiveLiteral({
+            datetime: dateToTimestamp(new Date(validDateString))
+        })
     ],
     [
         InputType.Datetime,
         validDateString,
-        { datetime: dateToTimestamp(new Date(validDateString)) }
+        primitiveLiteral({
+            datetime: dateToTimestamp(new Date(validDateString))
+        })
     ],
-    [InputType.Duration, 0, { duration: millisecondsToDuration(0) }],
-    [InputType.Duration, 10000, { duration: millisecondsToDuration(10000) }],
-    [InputType.Float, 0, { floatValue: 0 }],
-    [InputType.Float, '0', { floatValue: 0 }],
-    [InputType.Float, -1.5, { floatValue: -1.5 }],
-    [InputType.Float, '-1.5', { floatValue: -1.5 }],
-    [InputType.Float, 1.5, { floatValue: 1.5 }],
-    [InputType.Float, '1.5', { floatValue: 1.5 }],
-    [InputType.Float, 1.25e10, { floatValue: 1.25e10 }],
-    [InputType.Float, '1.25e10', { floatValue: 1.25e10 }],
-    [InputType.Integer, 0, { integer: Long.fromNumber(0) }],
-    [InputType.Integer, Long.fromNumber(0), { integer: Long.fromNumber(0) }],
-    [InputType.Integer, '0', { integer: Long.fromNumber(0) }],
-    [InputType.Integer, 1, { integer: Long.fromNumber(1) }],
-    [InputType.Integer, Long.fromNumber(1), { integer: Long.fromNumber(1) }],
-    [InputType.Integer, '1', { integer: Long.fromNumber(1) }],
-    [InputType.Integer, -1, { integer: Long.fromNumber(-1) }],
-    [InputType.Integer, Long.fromNumber(-1), { integer: Long.fromNumber(-1) }],
-    [InputType.Integer, '-1', { integer: Long.fromNumber(-1) }],
-    [InputType.Integer, Long.MAX_VALUE.toString(), { integer: Long.MAX_VALUE }],
-    [InputType.Integer, Long.MAX_VALUE, { integer: Long.MAX_VALUE }],
-    [InputType.Integer, Long.MIN_VALUE.toString(), { integer: Long.MIN_VALUE }],
-    [InputType.Integer, Long.MIN_VALUE, { integer: Long.MIN_VALUE }],
-    [InputType.String, '', { stringValue: '' }],
-    [InputType.String, 'abcdefg', { stringValue: 'abcdefg' }]
+    [
+        InputType.Duration,
+        0,
+        primitiveLiteral({ duration: millisecondsToDuration(0) })
+    ],
+    [
+        InputType.Duration,
+        10000,
+        primitiveLiteral({ duration: millisecondsToDuration(10000) })
+    ],
+    [InputType.Float, 0, primitiveLiteral({ floatValue: 0 })],
+    [InputType.Float, '0', primitiveLiteral({ floatValue: 0 })],
+    [InputType.Float, -1.5, primitiveLiteral({ floatValue: -1.5 })],
+    [InputType.Float, '-1.5', primitiveLiteral({ floatValue: -1.5 })],
+    [InputType.Float, 1.5, primitiveLiteral({ floatValue: 1.5 })],
+    [InputType.Float, '1.5', primitiveLiteral({ floatValue: 1.5 })],
+    [InputType.Float, 1.25e10, primitiveLiteral({ floatValue: 1.25e10 })],
+    [InputType.Float, '1.25e10', primitiveLiteral({ floatValue: 1.25e10 })],
+    [InputType.Integer, 0, primitiveLiteral({ integer: Long.fromNumber(0) })],
+    [
+        InputType.Integer,
+        Long.fromNumber(0),
+        primitiveLiteral({ integer: Long.fromNumber(0) })
+    ],
+    [InputType.Integer, '0', primitiveLiteral({ integer: Long.fromNumber(0) })],
+    [InputType.Integer, 1, primitiveLiteral({ integer: Long.fromNumber(1) })],
+    [
+        InputType.Integer,
+        Long.fromNumber(1),
+        primitiveLiteral({ integer: Long.fromNumber(1) })
+    ],
+    [InputType.Integer, '1', primitiveLiteral({ integer: Long.fromNumber(1) })],
+    [InputType.Integer, -1, primitiveLiteral({ integer: Long.fromNumber(-1) })],
+    [
+        InputType.Integer,
+        Long.fromNumber(-1),
+        primitiveLiteral({ integer: Long.fromNumber(-1) })
+    ],
+    [
+        InputType.Integer,
+        '-1',
+        primitiveLiteral({ integer: Long.fromNumber(-1) })
+    ],
+    [
+        InputType.Integer,
+        Long.MAX_VALUE.toString(),
+        primitiveLiteral({ integer: Long.MAX_VALUE })
+    ],
+    [
+        InputType.Integer,
+        Long.MAX_VALUE,
+        primitiveLiteral({ integer: Long.MAX_VALUE })
+    ],
+    [
+        InputType.Integer,
+        Long.MIN_VALUE.toString(),
+        primitiveLiteral({ integer: Long.MIN_VALUE })
+    ],
+    [
+        InputType.Integer,
+        Long.MIN_VALUE,
+        primitiveLiteral({ integer: Long.MIN_VALUE })
+    ],
+    [InputType.String, '', primitiveLiteral({ stringValue: '' })],
+    [InputType.String, 'abcdefg', primitiveLiteral({ stringValue: 'abcdefg' })],
+    // Standard Blob
+    [
+        InputType.Blob,
+        {
+            uri: 's3://somePath',
+            format: 'csv',
+            dimensionality: BlobDimensionality.SINGLE
+        },
+        blobLiteral({
+            dimensionality: BlobDimensionality.SINGLE,
+            format: 'csv',
+            uri: 's3://somePath'
+        })
+    ],
+    // Multi-part blob
+    [
+        InputType.Blob,
+        {
+            dimensionality: BlobDimensionality.MULTIPART,
+            format: 'csv',
+            uri: 's3://somePath'
+        },
+        blobLiteral({
+            dimensionality: BlobDimensionality.MULTIPART,
+            format: 'csv',
+            uri: 's3://somePath'
+        })
+    ],
+    // Blob with missing format
+    [
+        InputType.Blob,
+        {
+            dimensionality: BlobDimensionality.SINGLE,
+            uri: 's3://somePath'
+        },
+        blobLiteral({
+            dimensionality: BlobDimensionality.SINGLE,
+            uri: 's3://somePath'
+        })
+    ],
+    // Blob with empty format string
+    [
+        InputType.Blob,
+        {
+            dimensionality: BlobDimensionality.SINGLE,
+            format: '',
+            uri: 's3://somePath'
+        },
+        blobLiteral({
+            dimensionality: BlobDimensionality.SINGLE,
+            uri: 's3://somePath'
+        })
+    ],
+    // Blobs using lowercase string for dimensionality
+    [
+        InputType.Blob,
+        {
+            dimensionality: 'single',
+            uri: 's3://somePath'
+        },
+        blobLiteral({
+            dimensionality: BlobDimensionality.SINGLE,
+            uri: 's3://somePath'
+        })
+    ],
+    [
+        InputType.Blob,
+        {
+            dimensionality: 'multipart',
+            uri: 's3://somePath'
+        },
+        blobLiteral({
+            dimensionality: BlobDimensionality.MULTIPART,
+            uri: 's3://somePath'
+        })
+    ],
+    // Blobs using uppercase string for dimensionality
+    [
+        InputType.Blob,
+        {
+            dimensionality: 'SINGLE',
+            uri: 's3://somePath'
+        },
+        blobLiteral({
+            dimensionality: BlobDimensionality.SINGLE,
+            uri: 's3://somePath'
+        })
+    ],
+    [
+        InputType.Blob,
+        {
+            dimensionality: 'MULTIPART',
+            uri: 's3://somePath'
+        },
+        blobLiteral({
+            dimensionality: BlobDimensionality.MULTIPART,
+            uri: 's3://somePath'
+        })
+    ],
+    // Blob missing URI (results in None)
+    [
+        InputType.Blob,
+        {
+            format: 'csv',
+            dimensionality: 'MULTIPART'
+        },
+        literalNone()
+    ],
+    // Blob which is not an object (results in None)
+    [InputType.Blob, undefined, literalNone()]
 ];
 
 type InputToLiteralTestParams = [
@@ -175,5 +331,72 @@ export const literalToInputTestCases: InputToLiteralTestParams[] = [
         Long.MIN_VALUE.toString()
     ],
     [InputType.String, primitiveLiteral({ stringValue: '' }), ''],
-    [InputType.String, primitiveLiteral({ stringValue: 'abcdefg' }), 'abcdefg']
+    [InputType.String, primitiveLiteral({ stringValue: 'abcdefg' }), 'abcdefg'],
+    // Standard Blob case
+    [
+        InputType.Blob,
+        blobLiteral({
+            dimensionality: BlobDimensionality.SINGLE,
+            format: 'csv',
+            uri: 's3://somePath'
+        }),
+        {
+            dimensionality: BlobDimensionality.SINGLE,
+            format: 'csv',
+            uri: 's3://somePath'
+        }
+    ],
+    // Multipart blob
+    [
+        InputType.Blob,
+        blobLiteral({
+            dimensionality: BlobDimensionality.MULTIPART,
+            format: 'csv',
+            uri: 's3://somePath'
+        }),
+        {
+            dimensionality: BlobDimensionality.MULTIPART,
+            format: 'csv',
+            uri: 's3://somePath'
+        }
+    ],
+    // Empty uri
+    [
+        InputType.Blob,
+        blobLiteral({
+            dimensionality: BlobDimensionality.SINGLE,
+            format: 'csv'
+        }),
+        {
+            dimensionality: BlobDimensionality.SINGLE,
+            format: 'csv',
+            uri: ''
+        }
+    ],
+    // Empty format string
+    [
+        InputType.Blob,
+        blobLiteral({
+            dimensionality: BlobDimensionality.SINGLE,
+            format: '',
+            uri: 's3://somePath'
+        }),
+        {
+            dimensionality: BlobDimensionality.SINGLE,
+            uri: 's3://somePath'
+        }
+    ],
+    // Missing dimensionality
+    [
+        InputType.Blob,
+        blobLiteral({
+            format: 'csv',
+            uri: 's3://somePath'
+        }),
+        {
+            dimensionality: BlobDimensionality.SINGLE,
+            format: 'csv',
+            uri: 's3://somePath'
+        }
+    ]
 ];

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/types.ts
@@ -1,5 +1,5 @@
 import { Core } from 'flyteidl';
-import { InputTypeDefinition, InputValue } from '../types';
+import { InputProps, InputTypeDefinition, InputValue } from '../types';
 
 export interface ConverterInput {
     value: InputValue;
@@ -13,10 +13,18 @@ export type LiteralToInputConterterFn = (
     literal: Core.ILiteral,
     typeDefinition: InputTypeDefinition
 ) => InputValue | undefined;
+
+export type ValidationParams = Pick<
+    InputProps,
+    'initialValue' | 'name' | 'required' | 'typeDefinition' | 'value'
+>;
+
+export type InputValidatorParams = ValidationParams & { value: InputValue };
+
 export interface InputHelper {
     defaultValue?: InputValue;
     toLiteral: InputToLiteralConverterFn;
     fromLiteral: LiteralToInputConterterFn;
     /** Will throw in the case of a failed validation */
-    validate: (input: ConverterInput) => void;
+    validate: (params: InputValidatorParams) => void;
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -1,6 +1,7 @@
 import { assertNever } from 'common/utils';
 import { Core } from 'flyteidl';
 import { get } from 'lodash';
+import { BlobDimensionality } from 'models';
 import { InputType, InputTypeDefinition } from '../types';
 
 /** Performs a deep get of `path` on the given `Core.ILiteral`. Will throw
@@ -65,4 +66,10 @@ export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
             assertNever(type, { noThrow: true });
             return false;
     }
+}
+
+export function isKeyOfBlobDimensionality(
+    value: string
+): value is keyof typeof BlobDimensionality {
+    return Object.keys(BlobDimensionality).indexOf(value) >= 0;
 }

--- a/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/inputHelpers/utils.ts
@@ -34,7 +34,6 @@ export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
     const { type, subtype } = typeDefinition;
     switch (type) {
         case InputType.Binary:
-        case InputType.Blob:
         case InputType.Error:
         case InputType.Map:
         case InputType.None:
@@ -43,6 +42,7 @@ export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
         case InputType.Unknown:
             return false;
         case InputType.Boolean:
+        case InputType.Blob:
         case InputType.Datetime:
         case InputType.Duration:
         case InputType.Float:

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -1,5 +1,6 @@
 import { FetchableData, MultiFetchableState } from 'components/hooks';
 import { Core } from 'flyteidl';
+import { isObject } from 'lodash';
 import {
     BlobDimensionality,
     Identifier,

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -81,7 +81,7 @@ export interface ObjectValue {
 }
 
 export interface BlobValue {
-    dimensionality: BlobDimensionality;
+    dimensionality: BlobDimensionality | string;
     format?: string;
     uri: string;
 }

--- a/src/components/Launch/LaunchWorkflowForm/types.ts
+++ b/src/components/Launch/LaunchWorkflowForm/types.ts
@@ -1,6 +1,7 @@
 import { FetchableData, MultiFetchableState } from 'components/hooks';
 import { Core } from 'flyteidl';
 import {
+    BlobDimensionality,
     Identifier,
     LaunchPlan,
     NamedEntityIdentifier,
@@ -75,7 +76,17 @@ export interface InputTypeDefinition {
     subtype?: InputTypeDefinition;
 }
 
-export type InputValue = string | number | boolean | Date;
+export interface ObjectValue {
+    type: InputType;
+}
+
+export interface BlobValue {
+    dimensionality: BlobDimensionality;
+    format?: string;
+    uri: string;
+}
+
+export type InputValue = string | number | boolean | Date | BlobValue;
 export type InputChangeHandler = (newValue: InputValue) => void;
 
 export interface InputProps {

--- a/src/components/Launch/LaunchWorkflowForm/utils.ts
+++ b/src/components/Launch/LaunchWorkflowForm/utils.ts
@@ -1,5 +1,6 @@
 import { timestampToDate } from 'common/utils';
 import { Core } from 'flyteidl';
+import { isObject } from 'lodash';
 import {
     LaunchPlan,
     LiteralType,
@@ -13,6 +14,7 @@ import { inputToLiteral } from './inputHelpers/inputHelpers';
 import { typeIsSupported } from './inputHelpers/utils';
 import { SearchableSelectorOption } from './SearchableSelector';
 import {
+    BlobValue,
     InputProps,
     InputType,
     InputTypeDefinition,
@@ -171,4 +173,8 @@ export function getUnsupportedRequiredInputs(
             input.required &&
             input.initialValue === undefined
     );
+}
+
+export function isBlobValue(value: unknown): value is BlobValue {
+    return isObject(value);
 }

--- a/src/components/Theme/constants.ts
+++ b/src/components/Theme/constants.ts
@@ -24,7 +24,7 @@ export const mutedPrimaryTextColor = '#4A4A4A';
 export const tableHeaderColor = COLOR_SPECTRUM.gray40.color;
 export const tablePlaceholderColor = COLOR_SPECTRUM.gray40.color;
 
-export const selectedActionColor = primaryColor;
+export const selectedActionColor = COLOR_SPECTRUM.gray10.color;
 
 export const warningHighlightColor = COLOR_SPECTRUM.sunset50.color;
 export const cautionHighlightColor = COLOR_SPECTRUM.amber50.color;

--- a/src/components/Theme/muiTheme.ts
+++ b/src/components/Theme/muiTheme.ts
@@ -140,7 +140,6 @@ export const muiTheme = {
                 }
             }
         },
-        MuiSelect: {},
         MuiTab: {
             labelIcon: {
                 minHeight: '64px',

--- a/src/components/Theme/muiTheme.ts
+++ b/src/components/Theme/muiTheme.ts
@@ -140,6 +140,7 @@ export const muiTheme = {
                 }
             }
         },
+        MuiSelect: {},
         MuiTab: {
             labelIcon: {
                 minHeight: '64px',

--- a/src/models/Common/types.ts
+++ b/src/models/Common/types.ts
@@ -68,6 +68,13 @@ export interface Literal extends Core.Literal {
     scalar?: Scalar;
 }
 
+/** A Core.ILiteral guaranteed to have all subproperties necessary to specify
+ * a Blob.
+ */
+export interface BlobLiteral extends Core.ILiteral {
+    scalar: BlobScalar;
+}
+
 export interface LiteralCollection
     extends RequiredNonNullable<Core.ILiteralCollection> {}
 
@@ -80,6 +87,9 @@ export interface LiteralMapBlob extends Admin.ILiteralMapBlob {
 export interface Scalar extends Core.IScalar {
     primitive?: Primitive;
     value: keyof Core.IScalar;
+}
+export interface BlobScalar extends Core.IScalar {
+    blob: Blob;
 }
 
 export interface Schema extends Core.ISchema {


### PR DESCRIPTION
lyft/flyte#378

This adds basic input support for blobs by rendering a micro form containing `uri`, `format` and `dimensionality` sub-inputs. The only required input from a user is the `uri` field. Dimensionality is technically required, but is implemented with a select control that defaults to a value. So it's not possible for a user to specific an empty dimensionality in the simple case.

Collections of Blobs are also supported, following the same rules as other input types (it is specified with a JSON array string). In this case, each value must include a `uri` and `dimensionality`.

`format` is always optional and must be a string.

![image](https://user-images.githubusercontent.com/1815175/87991417-058ba180-ca9b-11ea-81f0-ea82168676d4.png)

![image](https://user-images.githubusercontent.com/1815175/87991507-310e8c00-ca9b-11ea-84d1-e2f94fdb2c01.png)
