### PR TITLE
feat: Authentication can be optionally disabled

### DIFF
--- a/env.js
+++ b/env.js
@@ -24,6 +24,8 @@ const PLUGINS_MODULE = process.env.PLUGINS_MODULE;
 // If it has no protocol, it will be treated as relative to window.location.origin
 const STATUS_URL = process.env.STATUS_URL;
 
+const ENABLE_AUTH = process.env.ENABLE_AUTH || true ;
+
 module.exports = {
     ADMIN_API_URL,
     BASE_URL,
@@ -39,6 +41,7 @@ module.exports = {
         BASE_URL,
         CORS_PROXY_PREFIX,
         NODE_ENV,
-        STATUS_URL
+        STATUS_URL,
+        ENABLE_AUTH
     }
 };

--- a/env.js
+++ b/env.js
@@ -24,7 +24,8 @@ const PLUGINS_MODULE = process.env.PLUGINS_MODULE;
 // If it has no protocol, it will be treated as relative to window.location.origin
 const STATUS_URL = process.env.STATUS_URL;
 
-const ENABLE_AUTH = toBoolean(process.env.ENABLE_AUTH) || true ;
+const enable_auth_string = process.env.ENABLE_AUTH || 'true';
+const ENABLE_AUTH = (enable_auth_string == 'false');
 
 module.exports = {
     ADMIN_API_URL,
@@ -46,6 +47,3 @@ module.exports = {
         STATUS_URL
     }
 };
-
-const toBoolean = (value: string | number | boolean): boolean =>
-    [true, 'true', 'True', 'TRUE', '1', 1].includes(value);

--- a/env.js
+++ b/env.js
@@ -25,7 +25,7 @@ const PLUGINS_MODULE = process.env.PLUGINS_MODULE;
 const STATUS_URL = process.env.STATUS_URL;
 
 const enable_auth_string = process.env.ENABLE_AUTH || 'true';
-const ENABLE_AUTH = (enable_auth_string == 'false');
+const ENABLE_AUTH = process.env.ENABLE_AUTH || 'true';
 
 module.exports = {
     ADMIN_API_URL,

--- a/env.js
+++ b/env.js
@@ -24,8 +24,7 @@ const PLUGINS_MODULE = process.env.PLUGINS_MODULE;
 // If it has no protocol, it will be treated as relative to window.location.origin
 const STATUS_URL = process.env.STATUS_URL;
 
-const enable_auth_string = process.env.ENABLE_AUTH || 'true';
-const ENABLE_AUTH = process.env.ENABLE_AUTH || 'true';
+const DISABLE_AUTH = process.env.DISABLE_AUTH;
 
 module.exports = {
     ADMIN_API_URL,
@@ -34,7 +33,7 @@ module.exports = {
     CONFIG_CACHE_TTL_SECONDS,
     CONFIG_DIR,
     CORS_PROXY_PREFIX,
-    ENABLE_AUTH,
+    DISABLE_AUTH,
     NODE_ENV,
     PLUGINS_MODULE,
     STATUS_URL,
@@ -42,7 +41,7 @@ module.exports = {
         ADMIN_API_URL,
         BASE_URL,
         CORS_PROXY_PREFIX,
-        ENABLE_AUTH,
+        DISABLE_AUTH,
         NODE_ENV,
         STATUS_URL
     }

--- a/env.js
+++ b/env.js
@@ -33,6 +33,7 @@ module.exports = {
     CONFIG_CACHE_TTL_SECONDS,
     CONFIG_DIR,
     CORS_PROXY_PREFIX,
+    ENABLE_AUTH,
     NODE_ENV,
     PLUGINS_MODULE,
     STATUS_URL,
@@ -40,9 +41,9 @@ module.exports = {
         ADMIN_API_URL,
         BASE_URL,
         CORS_PROXY_PREFIX,
+        ENABLE_AUTH,
         NODE_ENV,
-        STATUS_URL,
-        ENABLE_AUTH
+        STATUS_URL
     }
 };
 

--- a/env.js
+++ b/env.js
@@ -24,7 +24,7 @@ const PLUGINS_MODULE = process.env.PLUGINS_MODULE;
 // If it has no protocol, it will be treated as relative to window.location.origin
 const STATUS_URL = process.env.STATUS_URL;
 
-const ENABLE_AUTH = process.env.ENABLE_AUTH || true ;
+const ENABLE_AUTH = toBoolean(process.env.ENABLE_AUTH) || true ;
 
 module.exports = {
     ADMIN_API_URL,
@@ -45,3 +45,6 @@ module.exports = {
         ENABLE_AUTH
     }
 };
+
+const toBoolean = (value: string | number | boolean): boolean =>
+    [true, 'true', 'True', 'TRUE', '1', 1].includes(value);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -116,3 +116,15 @@ export function assertNever(
         `Unhandled discriminated union member: ${JSON.stringify(value)}`
     );
 }
+
+/**
+ * Function that returns boolean value for the string or number representation
+ */
+export function toBoolean(value?: string): boolean {
+    if (value == null) {
+        return false;
+    }
+    return ['true', 'True', 'TRUE', '1'].includes(value);
+}
+
+

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -126,5 +126,3 @@ export function toBoolean(value?: string): boolean {
     }
     return ['true', 'True', 'TRUE', '1'].includes(value);
 }
-
-

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -13,4 +13,5 @@ export interface Env extends NodeJS.ProcessEnv {
     CORS_PROXY_PREFIX: string;
     DISABLE_ANALYTICS?: string;
     STATUS_URL?: string;
+    ENABLE_AUTH?: string;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -13,5 +13,5 @@ export interface Env extends NodeJS.ProcessEnv {
     CORS_PROXY_PREFIX: string;
     DISABLE_ANALYTICS?: string;
     STATUS_URL?: string;
-    ENABLE_AUTH?: string;
+    DISABLE_AUTH?: string;
 }

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -19,11 +19,11 @@ import {
 /**
  * Function that returns boolean value for the string or number representation
  */
-const toBoolean = (value?: string | number | boolean): boolean =>
+const toBoolean = (value?: string): boolean =>
     if (value == null) {
       return false;
     }
-    [true, 'true', 'True', 'TRUE', '1', 1].includes(value);
+    ['true', 'True', 'TRUE', '1'].includes(value);
 
 /** Base work function used by the HTTP verb methods below. It does not handle
  * encoding/decoding of protobuf.

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -44,7 +44,7 @@ async function request(
     const finalOptions = {
         ...options,
         url: adminApiUrl(endpoint),
-        withCredentials: true
+        withCredentials: false
     };
 
     try {

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -1,8 +1,9 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { env } from 'common/env';
+import { toBoolean } from 'common/utils';
 
 import { generateAdminApiQuery } from './AdminApiQuery';
-import { toBoolean } from 'common/utils'
+
 import { transformRequestError } from './transformRequestError';
 import {
     AdminEntityTransformer,

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -1,3 +1,4 @@
+import { env } from 'common/env';
 import axios, { AxiosRequestConfig } from 'axios';
 
 import { generateAdminApiQuery } from './AdminApiQuery';
@@ -44,7 +45,7 @@ async function request(
     const finalOptions = {
         ...options,
         url: adminApiUrl(endpoint),
-        withCredentials: false
+        withCredentials: env.ENABLE_AUTH
     };
 
     try {
@@ -70,7 +71,7 @@ export async function getProtobufObject<ResponseType>(
         headers,
         method: 'get',
         responseType: 'arraybuffer',
-        withCredentials: true
+        withCredentials: env.ENABLE_AUTH
     };
 
     const { data } = await axios.request(options);

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -19,11 +19,12 @@ import {
 /**
  * Function that returns boolean value for the string or number representation
  */
-function toBoolean(value?: string): boolean =>
+function toBoolean(value?: string): boolean {
     if (value == null) {
       return false;
     }
-    ['true', 'True', 'TRUE', '1'].includes(value);
+    return ['true', 'True', 'TRUE', '1'].includes(value);
+}
 
 /** Base work function used by the HTTP verb methods below. It does not handle
  * encoding/decoding of protobuf.

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -1,5 +1,5 @@
-import { env } from 'common/env';
 import axios, { AxiosRequestConfig } from 'axios';
+import { env } from 'common/env';
 
 import { generateAdminApiQuery } from './AdminApiQuery';
 import { transformRequestError } from './transformRequestError';
@@ -20,10 +20,10 @@ import {
  * Function that returns boolean value for the string or number representation
  */
 function toBoolean(value?: string): boolean {
-    if (value == null) {
-      return false;
-    }
-    return ['true', 'True', 'TRUE', '1'].includes(value);
+  if (value == null) {
+    return false;
+  }
+  return ['true', 'True', 'TRUE', '1'].includes(value);
 }
 
 /** Base work function used by the HTTP verb methods below. It does not handle

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -2,6 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import { env } from 'common/env';
 
 import { generateAdminApiQuery } from './AdminApiQuery';
+import { toBoolean } from 'common/utils'
 import { transformRequestError } from './transformRequestError';
 import {
     AdminEntityTransformer,
@@ -13,8 +14,7 @@ import {
     adminApiUrl,
     decodeProtoResponse,
     encodeProtoPayload,
-    logProtoResponse,
-    toBoolean
+    logProtoResponse
 } from './utils';
 
 /** Base work function used by the HTTP verb methods below. It does not handle

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -19,7 +19,7 @@ import {
 /**
  * Function that returns boolean value for the string or number representation
  */
-const toBoolean = (value?: string): boolean =>
+function toBoolean(value?: string): boolean =>
     if (value == null) {
       return false;
     }

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -13,18 +13,9 @@ import {
     adminApiUrl,
     decodeProtoResponse,
     encodeProtoPayload,
-    logProtoResponse
+    logProtoResponse,
+    toBoolean
 } from './utils';
-
-/**
- * Function that returns boolean value for the string or number representation
- */
-function toBoolean(value?: string): boolean {
-    if (value == null) {
-        return false;
-    }
-    return ['true', 'True', 'TRUE', '1'].includes(value);
-}
 
 /** Base work function used by the HTTP verb methods below. It does not handle
  * encoding/decoding of protobuf.

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -20,10 +20,10 @@ import {
  * Function that returns boolean value for the string or number representation
  */
 function toBoolean(value?: string): boolean {
-  if (value == null) {
-    return false;
-  }
-  return ['true', 'True', 'TRUE', '1'].includes(value);
+    if (value == null) {
+        return false;
+    }
+    return ['true', 'True', 'TRUE', '1'].includes(value);
 }
 
 /** Base work function used by the HTTP verb methods below. It does not handle

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -19,7 +19,10 @@ import {
 /**
  * Function that returns boolean value for the string or number representation
  */
-const toBoolean = (value: string | number | boolean): boolean =>
+const toBoolean = (value?: string | number | boolean): boolean =>
+    if (value == null) {
+      return false;
+    }
     [true, 'true', 'True', 'TRUE', '1', 1].includes(value);
 
 /** Base work function used by the HTTP verb methods below. It does not handle
@@ -51,7 +54,7 @@ async function request(
     const finalOptions = {
         ...options,
         url: adminApiUrl(endpoint),
-        withCredentials: toBoolean(env.ENABLE_AUTH)
+        withCredentials: !toBoolean(env.DISABLE_AUTH)
     };
 
     try {
@@ -77,7 +80,7 @@ export async function getProtobufObject<ResponseType>(
         headers,
         method: 'get',
         responseType: 'arraybuffer',
-        withCredentials: toBoolean(env.ENABLE_AUTH)
+        withCredentials: !toBoolean(env.DISABLE_AUTH)
     };
 
     const { data } = await axios.request(options);

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -16,6 +16,12 @@ import {
     logProtoResponse
 } from './utils';
 
+/**
+ * Function that returns boolean value for the string or number representation
+ */
+const toBoolean = (value: string | number | boolean): boolean =>
+    [true, 'true', 'True', 'TRUE', '1', 1].includes(value);
+
 /** Base work function used by the HTTP verb methods below. It does not handle
  * encoding/decoding of protobuf.
  */
@@ -45,7 +51,7 @@ async function request(
     const finalOptions = {
         ...options,
         url: adminApiUrl(endpoint),
-        withCredentials: env.ENABLE_AUTH
+        withCredentials: toBoolean(env.ENABLE_AUTH)
     };
 
     try {
@@ -71,7 +77,7 @@ export async function getProtobufObject<ResponseType>(
         headers,
         method: 'get',
         responseType: 'arraybuffer',
-        withCredentials: env.ENABLE_AUTH
+        withCredentials: toBoolean(env.ENABLE_AUTH)
     };
 
     const { data } = await axios.request(options);


### PR DESCRIPTION
# TL;DR
FlyteConsole enables authentication by default. This has a weird side-effect in Sandbox, where the console enables secure cookies, even if we actually do not have authN. in this situation, Chrome does not allow CORS with a wild card of `*`. This PR allows disabling authN and which should allow working with CORs

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [-] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Disable credentials in case when authn is not used / required. This will allow CORs wildcard. Particularly helpful in sandbox testing.

## Tracking Issue
https://github.com/lyft/flyte/issues/416

## Follow-up issue
_NA_

