### PR TITLE
feat: Allow cloning of running executions

### DIFF
--- a/src/components/Errors/test/DataError.test.tsx
+++ b/src/components/Errors/test/DataError.test.tsx
@@ -13,13 +13,13 @@ describe('DataError', () => {
         const { container } = render(
             <DataError {...defaultProps} error={new NotAuthorizedError()} />
         );
-        expect(container).toBeEmpty();
+        expect(container).toBeEmptyDOMElement();
     });
 
     it('renders not found for NotFound errors', () => {
         const { getByText } = render(
             <DataError {...defaultProps} error={new NotFoundError('')} />
         );
-        expect(getByText('Not found')).not.toBeEmpty();
+        expect(getByText('Not found')).not.toBeEmptyDOMElement();
     });
 });

--- a/src/components/Executions/ExecutionDetails/constants.ts
+++ b/src/components/Executions/ExecutionDetails/constants.ts
@@ -16,3 +16,7 @@ export const tabs = {
         label: 'Graph'
     }
 };
+
+export const executionActionStrings = {
+    clone: 'Clone Execution'
+};

--- a/src/components/Executions/ExecutionDetails/test/ExecutionDetailsAppBarContent.test.tsx
+++ b/src/components/Executions/ExecutionDetails/test/ExecutionDetailsAppBarContent.test.tsx
@@ -1,0 +1,98 @@
+import {
+    fireEvent,
+    render,
+    RenderResult,
+    waitFor
+} from '@testing-library/react';
+import { labels as commonLabels } from 'components/common/constants';
+import {
+    ExecutionContext,
+    ExecutionContextData
+} from 'components/Executions/contexts';
+import { Execution } from 'models';
+import { createMockExecution } from 'models/__mocks__/executionsData';
+import { WorkflowExecutionPhase } from 'models/Execution/enums';
+import * as React from 'react';
+import { MemoryRouter } from 'react-router';
+import { delayedPromise, DelayedPromiseResult } from 'test/utils';
+import { executionActionStrings } from '../constants';
+import { ExecutionDetailsAppBarContent } from '../ExecutionDetailsAppBarContent';
+
+jest.mock('components/Navigation/NavBarContent', () => ({
+    NavBarContent: ({ children }: React.Props<any>) => children
+}));
+
+describe('ExecutionDetailsAppBarContent', () => {
+    let execution: Execution;
+    let executionContext: ExecutionContextData;
+    let mockTerminateExecution: jest.Mock<Promise<void>>;
+    let terminatePromise: DelayedPromiseResult<void>;
+
+    beforeEach(() => {
+        execution = createMockExecution();
+        mockTerminateExecution = jest.fn().mockImplementation(() => {
+            terminatePromise = delayedPromise();
+            return terminatePromise;
+        });
+        executionContext = {
+            execution,
+            terminateExecution: mockTerminateExecution
+        };
+    });
+
+    const renderContent = () =>
+        render(
+            <MemoryRouter>
+                <ExecutionContext.Provider value={executionContext}>
+                    <ExecutionDetailsAppBarContent execution={execution} />
+                </ExecutionContext.Provider>
+            </MemoryRouter>
+        );
+
+    describe('for running executions', () => {
+        beforeEach(() => {
+            execution.closure.phase = WorkflowExecutionPhase.RUNNING;
+        });
+
+        it('renders an overflow menu', async () => {
+            const { getByLabelText } = renderContent();
+            await waitFor(() => getByLabelText(commonLabels.moreOptionsButton));
+        });
+
+        describe('in overflow menu', () => {
+            let renderResult: RenderResult;
+            let buttonEl: HTMLElement;
+            let menuEl: HTMLElement;
+
+            beforeEach(async () => {
+                renderResult = renderContent();
+                const { getByLabelText } = renderResult;
+                buttonEl = await waitFor(() =>
+                    getByLabelText(commonLabels.moreOptionsButton)
+                );
+                fireEvent.click(buttonEl);
+                menuEl = await waitFor(() =>
+                    getByLabelText(commonLabels.moreOptionsMenu)
+                );
+            });
+
+            it('renders a clone option', () => {
+                const { getByText } = renderResult;
+                expect(
+                    getByText(executionActionStrings.clone)
+                ).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('for terminal executions', () => {
+        beforeEach(() => {
+            execution.closure.phase = WorkflowExecutionPhase.SUCCEEDED;
+        });
+
+        it('does not render an overflow menu', async () => {
+            const { queryByLabelText } = renderContent();
+            expect(queryByLabelText(commonLabels.moreOptionsButton)).toBeNull();
+        });
+    });
+});

--- a/src/components/common/MoreOptionsMenu.tsx
+++ b/src/components/common/MoreOptionsMenu.tsx
@@ -1,0 +1,79 @@
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import MoreVert from '@material-ui/icons/MoreVert';
+import * as React from 'react';
+import { labels } from './constants';
+
+export interface MoreOptionsMenuItem {
+    label: string;
+    onClick: () => void;
+}
+
+export interface MoreOptionsMenuProps {
+    className?: string;
+    options: MoreOptionsMenuItem[];
+}
+/** Renders a vertical three-dots menu button with the provided options.
+ * Each option should have a label and corresponding onClick handler, which will
+ * be invoked when the item is clicked.
+ */
+export const MoreOptionsMenu: React.FC<MoreOptionsMenuProps> = ({
+    className,
+    options
+}) => {
+    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+    const {
+        handleClose,
+        handleClickMenuButton,
+        listItems
+    } = React.useMemo(() => {
+        const handleClickMenuButton = (
+            event: React.MouseEvent<HTMLButtonElement>
+        ) => {
+            setAnchorEl(event.currentTarget);
+        };
+
+        const handleClose = () => {
+            setAnchorEl(null);
+        };
+
+        const listItems = options.map(({ label, onClick: handleItemClick }) => {
+            const onClick = () => {
+                setAnchorEl(null);
+                handleItemClick();
+            };
+
+            return (
+                <MenuItem key={label} onClick={onClick}>
+                    {label}
+                </MenuItem>
+            );
+        });
+
+        return { handleClickMenuButton, handleClose, listItems };
+    }, [options, setAnchorEl]);
+
+    return (
+        <div className={className}>
+            <IconButton
+                aria-controls="more-options-menu"
+                aria-haspopup="true"
+                aria-label={labels.moreOptionsButton}
+                color="inherit"
+                onClick={handleClickMenuButton}
+            >
+                <MoreVert />
+            </IconButton>
+            <Menu
+                aria-label={labels.moreOptionsMenu}
+                id="more-options-menu"
+                anchorEl={anchorEl}
+                open={!!anchorEl}
+                onClose={handleClose}
+            >
+                {listItems}
+            </Menu>
+        </div>
+    );
+};

--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -1,1 +1,6 @@
 export const detailsPanelWidth = 432;
+
+export const labels = {
+    moreOptionsButton: 'Display more options',
+    moreOptionsMenu: 'More options menu'
+};

--- a/src/components/common/test/MoreOptionsMenu.test.tsx
+++ b/src/components/common/test/MoreOptionsMenu.test.tsx
@@ -1,0 +1,72 @@
+import {
+    fireEvent,
+    getByText,
+    render,
+    RenderResult,
+    waitFor,
+    waitForElementToBeRemoved
+} from '@testing-library/react';
+import * as React from 'react';
+import { labels } from '../constants';
+import { MoreOptionsMenu, MoreOptionsMenuItem } from '../MoreOptionsMenu';
+
+describe('MoreOptionsMenu', () => {
+    let options: MoreOptionsMenuItem[];
+    beforeEach(() => {
+        options = [
+            {
+                label: 'Option 1',
+                onClick: jest.fn()
+            },
+            {
+                label: 'Option 2',
+                onClick: jest.fn()
+            }
+        ];
+    });
+
+    const renderMenu = () => render(<MoreOptionsMenu options={options} />);
+
+    const getMenu = async (renderResult: RenderResult) => {
+        const { getByLabelText } = renderResult;
+        const buttonEl = await waitFor(() =>
+            getByLabelText(labels.moreOptionsButton)
+        );
+        fireEvent.click(buttonEl);
+        return waitFor(() => getByLabelText(labels.moreOptionsMenu));
+    };
+
+    it('shows menu when button is clicked', async () => {
+        await getMenu(renderMenu());
+    });
+
+    it('renders element for each option', async () => {
+        const result = renderMenu();
+        const menuEl = await getMenu(result);
+        expect(getByText(menuEl, options[0].label)).toBeInTheDocument();
+        expect(getByText(menuEl, options[1].label)).toBeInTheDocument();
+    });
+
+    it('calls handler for item when clicked', async () => {
+        const result = renderMenu();
+        const menuEl = await getMenu(result);
+        const itemEl = getByText(menuEl, options[0].label);
+        fireEvent.click(itemEl);
+        expect(options[0].onClick).toHaveBeenCalled();
+    });
+
+    it('hides menu when item is selected', async () => {
+        const result = renderMenu();
+        const menuEl = await getMenu(result);
+        const itemEl = getByText(menuEl, options[0].label);
+        fireEvent.click(itemEl);
+        await waitForElementToBeRemoved(menuEl);
+    });
+
+    it('hides menu on escape', async () => {
+        const result = renderMenu();
+        const menuEl = await getMenu(result);
+        fireEvent.keyDown(menuEl, { key: 'Escape', code: 'Escape' });
+        await waitForElementToBeRemoved(menuEl);
+    });
+});

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -6,7 +6,7 @@ export function pendingPromise<T = any>(): Promise<T> {
     return new Promise(() => {});
 }
 
-interface DelayedPromiseResult<T> {
+export interface DelayedPromiseResult<T> {
     promise: Promise<T>;
     resolve: (value: T) => void;
     reject: (value: any) => void;


### PR DESCRIPTION
lyft/flyte#468

This allows "relaunch" functionality for an execution which hasn't yet finished. This is helpful for some users who would like to launch multiple copies of an execution with slightly different input parameters.

Also fixed a warning from a test using a deprecated jest-dom method.

![image](https://user-images.githubusercontent.com/1815175/91916409-ee32fd00-ec71-11ea-9bdd-04833c021743.png)

![image](https://user-images.githubusercontent.com/1815175/91916423-f854fb80-ec71-11ea-8079-fd035d0b05cc.png)
