### PR TITLE
ci: dont push docker images for PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,29 +2,10 @@ name: Pull Request
 on: pull_request
 
 jobs:
-  build_push_github:
-    name: Build and push to Github
+  test_image_build:
+    name: Test build Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Push Docker Image to Github Registry
-        uses: whoan/docker-build-with-cache-action@v5
-        with:
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ secrets.package_name }}
-          image_tag: ${{ github.sha }}
-          registry: docker.pkg.github.com
-  build_push_dockerhub:
-    name: Build and push to Dockerhub
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Push Docker Image to Dockerhub
-        uses: whoan/docker-build-with-cache-action@v5
-        with:
-          username: "${{ secrets.DOCKERHUB_USERNAME }}"
-          password: "${{ secrets.DOCKERHUB_PASSWORD }}"
-          image_name: ${{ secrets.DOCKERHUB_IMAGE_NAME }}
-          image_tag: ${{ github.sha }}
-          build_extra_args: "--compress=true"
+      - name: Build image
+        run: docker build .


### PR DESCRIPTION
lyft/flyte#495

We don't need images for every PR and it breaks checks on forks. So I'm removing the pushing from the PR checks and just doing a simple build to verify that the Dockerfile isn't broken.