### PR TITLE
feat: adding route and navigation to the task details page

### DIFF
--- a/src/components/Entities/EntityDetails.tsx
+++ b/src/components/Entities/EntityDetails.tsx
@@ -52,46 +52,44 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({ id }) => {
     const onCancelLaunch = () => setShowLaunchForm(false);
 
     return (
-        <>
-            <WaitForData {...project}>
-                <EntityDetailsHeader
-                    project={project.value}
-                    id={id}
-                    launchable={!!sections.launch}
-                    onClickLaunch={onLaunch}
-                />
-                <div className={styles.metadataContainer}>
-                    {!!sections.description ? (
-                        <div className={styles.descriptionContainer}>
-                            <EntityDescription id={id} />
-                        </div>
-                    ) : null}
-                    {!!sections.schedules ? (
-                        <div className={styles.schedulesContainer}>
-                            <EntitySchedules id={id} />
-                        </div>
-                    ) : null}
-                </div>
-                {!!sections.executions ? (
-                    <div className={styles.executionsContainer}>
-                        <EntityExecutions id={id} />
+        <WaitForData {...project}>
+            <EntityDetailsHeader
+                project={project.value}
+                id={id}
+                launchable={!!sections.launch}
+                onClickLaunch={onLaunch}
+            />
+            <div className={styles.metadataContainer}>
+                {!!sections.description ? (
+                    <div className={styles.descriptionContainer}>
+                        <EntityDescription id={id} />
                     </div>
                 ) : null}
-                {/* TODO: LaunchWorkflowForm needs to be made generic */}
-                {!!sections.launch ? (
-                    <Dialog
-                        scroll="paper"
-                        maxWidth="sm"
-                        fullWidth={true}
-                        open={showLaunchForm}
-                    >
-                        <LaunchWorkflowForm
-                            onClose={onCancelLaunch}
-                            workflowId={id}
-                        />
-                    </Dialog>
+                {!!sections.schedules ? (
+                    <div className={styles.schedulesContainer}>
+                        <EntitySchedules id={id} />
+                    </div>
                 ) : null}
-            </WaitForData>
-        </>
+            </div>
+            {!!sections.executions ? (
+                <div className={styles.executionsContainer}>
+                    <EntityExecutions id={id} />
+                </div>
+            ) : null}
+            {/* TODO: LaunchWorkflowForm needs to be made generic */}
+            {!!sections.launch ? (
+                <Dialog
+                    scroll="paper"
+                    maxWidth="sm"
+                    fullWidth={true}
+                    open={showLaunchForm}
+                >
+                    <LaunchWorkflowForm
+                        onClose={onCancelLaunch}
+                        workflowId={id}
+                    />
+                </Dialog>
+            ) : null}
+        </WaitForData>
     );
 };

--- a/src/components/Entities/EntityDetailsHeader.tsx
+++ b/src/components/Entities/EntityDetailsHeader.tsx
@@ -7,8 +7,8 @@ import { Project, ResourceIdentifier } from 'models';
 import { getProjectDomain } from 'models/Project/utils';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Routes } from 'routes';
 import { launchStrings } from './constants';
+import { backUrlGenerator } from './generators';
 
 const useStyles = makeStyles((theme: Theme) => ({
     actionsContainer: {},
@@ -36,7 +36,7 @@ interface EntityDetailsHeaderProps {
     onClickLaunch?(): void;
 }
 
-/** Renders the workflow name and actions shown on the workflow details page */
+/** Renders the entity name and any applicable actions.  */
 export const EntityDetailsHeader: React.FC<EntityDetailsHeaderProps> = ({
     id,
     onClickLaunch,
@@ -57,10 +57,7 @@ export const EntityDetailsHeader: React.FC<EntityDetailsHeaderProps> = ({
             >
                 <Link
                     className={commonStyles.linkUnstyled}
-                    to={Routes.ProjectDetails.sections.workflows.makeUrl(
-                        project.id,
-                        id.domain
-                    )}
+                    to={backUrlGenerator[id.resourceType](id)}
                 >
                     <ArrowBack color="inherit" />
                 </Link>

--- a/src/components/Entities/EntityExecutions.tsx
+++ b/src/components/Entities/EntityExecutions.tsx
@@ -10,7 +10,7 @@ import { ResourceIdentifier } from 'models';
 import { SortDirection } from 'models/AdminEntity';
 import { executionSortFields } from 'models/Execution';
 import * as React from 'react';
-import { executionFilterGenerator } from './executionFilterGenerator';
+import { executionFilterGenerator } from './generators';
 
 const useStyles = makeStyles((theme: Theme) => ({
     filtersContainer: {

--- a/src/components/Entities/generators.ts
+++ b/src/components/Entities/generators.ts
@@ -4,6 +4,7 @@ import {
     ResourceIdentifier,
     ResourceType
 } from 'models';
+import { Routes } from 'routes/routes';
 
 const noFilters = () => [];
 
@@ -27,4 +28,19 @@ export const executionFilterGenerator: {
             value: name
         }
     ]
+};
+
+const workflowListGenerator = ({ project, domain }: ResourceIdentifier) =>
+    Routes.ProjectDetails.sections.workflows.makeUrl(project, domain);
+const taskListGenerator = ({ project, domain }: ResourceIdentifier) =>
+    Routes.ProjectDetails.sections.tasks.makeUrl(project, domain);
+
+export const backUrlGenerator: {
+    [k in ResourceType]: (id: ResourceIdentifier) => string;
+} = {
+    [ResourceType.DATASET]: workflowListGenerator,
+    [ResourceType.LAUNCH_PLAN]: workflowListGenerator,
+    [ResourceType.TASK]: taskListGenerator,
+    [ResourceType.UNSPECIFIED]: workflowListGenerator,
+    [ResourceType.WORKFLOW]: workflowListGenerator
 };

--- a/src/components/Task/SearchableTaskNameList.tsx
+++ b/src/components/Task/SearchableTaskNameList.tsx
@@ -1,5 +1,6 @@
 import { Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import ChevronRight from '@material-ui/icons/ChevronRight';
 import ErrorOutline from '@material-ui/icons/ErrorOutline';
 import * as classnames from 'classnames';
 import { noDescriptionString } from 'common/constants';
@@ -15,6 +16,8 @@ import { NamedEntity } from 'models';
 import * as React from 'react';
 import { IntersectionOptions, useInView } from 'react-intersection-observer';
 import reactLoadingSkeleton from 'react-loading-skeleton';
+import { Link } from 'react-router-dom';
+import { Routes } from 'routes/routes';
 import { SimpleTaskInterface } from './SimpleTaskInterface';
 import { useLatestTaskVersion } from './useLatestTask';
 const Skeleton = reactLoadingSkeleton;
@@ -91,6 +94,7 @@ const TaskNameRow: React.FC<TaskNameRowProps> = ({ label, entityName }) => {
                 </Typography>
                 {!!inView && <TaskInterface taskName={entityName} />}
             </div>
+            <ChevronRight className={listStyles.itemChevron} />
         </div>
     );
 };
@@ -100,14 +104,23 @@ export const SearchableTaskNameList: React.FC<Omit<
     SearchableNamedEntityListProps,
     'renderItem'
 >> = props => {
+    const commonStyles = useCommonStyles();
     const renderItem = ({
         key,
         value,
         content
     }: SearchResult<SearchableNamedEntity>) => (
-        <li key={key}>
+        <Link
+            key={key}
+            className={commonStyles.linkUnstyled}
+            to={Routes.TaskDetails.makeUrl(
+                value.id.project,
+                value.id.domain,
+                value.id.name
+            )}
+        >
             <TaskNameRow label={content} entityName={value} />
-        </li>
+        </Link>
     );
     return <SearchableNamedEntityList {...props} renderItem={renderItem} />;
 };

--- a/src/routes/ApplicationRouter.tsx
+++ b/src/routes/ApplicationRouter.tsx
@@ -45,6 +45,10 @@ export const ApplicationRouter: React.FC<{}> = () => (
                 )}
             />
             <Route
+                path={Routes.TaskDetails.path}
+                component={withSideNavigation(components.taskDetails)}
+            />
+            <Route
                 path={Routes.WorkflowDetails.path}
                 component={withSideNavigation(components.workflowDetails)}
             />

--- a/src/routes/components.ts
+++ b/src/routes/components.ts
@@ -3,6 +3,7 @@ import { TaskExecutionDetails } from 'components/Executions/TaskExecutionDetails
 import { NotFound } from 'components/NotFound';
 import { ProjectDetails } from 'components/Project';
 import { SelectProject } from 'components/SelectProject';
+import { TaskDetails } from 'components/Task/TaskDetails';
 import { WorkflowVersionDetails } from 'components/Workflow';
 import { WorkflowDetails } from 'components/Workflow/WorkflowDetails';
 
@@ -15,6 +16,7 @@ export const components = {
     projectDetails: ProjectDetails,
     selectProject: SelectProject,
     taskExecutionDetails: TaskExecutionDetails,
+    taskDetails: TaskDetails,
     workflowDetails: WorkflowDetails,
     workflowVersionDetails: WorkflowVersionDetails
 };


### PR DESCRIPTION
This adds plumbing and interaction to allow users to navigate to the details page for a Task. It works pretty much the same as the behavior for Workflows.

* Wrapped items in SearchableTaskList in `Link`s, and added chevrons to indicate that they navigate to details upon click.
* Added necessary items in `routes` to allow navigating to TaskDetails view.
* Updated `EntityDetailsHeader` so that the back link changes depending on what type of entity we are rendering (so that clicking back from a Task takes you to the Tasks section instead of Workflows)
* (chore) Removed an unnecessary fragment in EntityDetailsHeader

![TaskDetailsNavigation](https://user-images.githubusercontent.com/1815175/92958051-6d68c380-f41e-11ea-9013-8abbebe22e54.gif)

