### PR TITLE
fix: Render timestamp of protobuf in UTC

### DIFF
--- a/src/components/Literals/Scalar/PrimitiveValue.tsx
+++ b/src/components/Literals/Scalar/PrimitiveValue.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { formatDate, protobufDurationToHMS } from 'common/formatters';
+import { formatDateUTC, protobufDurationToHMS } from 'common/formatters';
 import { timestampToDate } from 'common/utils';
 import { Primitive } from 'models';
 
@@ -10,7 +10,7 @@ function primitiveToString(primitive: Primitive): string {
         case 'boolean':
             return !!primitive.boolean ? 'true' : 'false';
         case 'datetime':
-            return formatDate(timestampToDate(primitive.datetime!));
+            return formatDateUTC(timestampToDate(primitive.datetime!));
         case 'duration':
             return protobufDurationToHMS(primitive.duration!);
         default:

--- a/src/components/Literals/Scalar/test/PrimitiveValue.test.tsx
+++ b/src/components/Literals/Scalar/test/PrimitiveValue.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { Primitive } from 'models';
+import { PrimitiveValue } from '../PrimitiveValue';
+
+import { long } from 'test/utils';
+
+describe('PrimitiveValue', () => {
+    it('renders datetime', () => {
+        const primitive: Primitive = {
+            value: 'datetime',
+            datetime: {
+                seconds: long(3600),
+                nanos: 0
+            },
+            boolean: false,
+            integer: long(0),
+            floatValue: 0,
+            stringValue: ''
+        };
+        const { getByText } = render(<PrimitiveValue primitive={primitive} />);
+        expect(getByText('1/1/1970 1:00:00 AM UTC')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
# TL;DR
Render timestamp of protobuf in UTC.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
When rendering a timestamp field of protobuf, local time instead of UTC is used. This is not consistent with other part of the UI. This PR switches to UTC instead of local timezone.

## Tracking Issue
https://github.com/lyft/flyte/issues/80

## Follow-up issue
_NA_
