### PR TITLE
feat: Add Task support to Launch form

### DIFF
--- a/src/components/Launch/LaunchForm/LaunchForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchForm.tsx
@@ -3,6 +3,7 @@ import {
     createInputValueCache,
     InputValueCacheContext
 } from './inputValueCache';
+import { LaunchTaskForm } from './LaunchTaskForm';
 import { LaunchWorkflowForm } from './LaunchWorkflowForm';
 import { LaunchFormProps, LaunchWorkflowFormProps } from './types';
 
@@ -21,7 +22,9 @@ export const LaunchForm: React.FC<LaunchFormProps> = props => {
         <InputValueCacheContext.Provider value={inputValueCache}>
             {isWorkflowPropsObject(props) ? (
                 <LaunchWorkflowForm {...props} />
-            ) : null}
+            ) : (
+                <LaunchTaskForm {...props} />
+            )}
         </InputValueCacheContext.Provider>
     );
 };

--- a/src/components/Launch/LaunchForm/LaunchFormInputs.tsx
+++ b/src/components/Launch/LaunchForm/LaunchFormInputs.tsx
@@ -34,12 +34,13 @@ function getComponentForInput(input: InputProps, showErrors: boolean) {
 
 export interface LaunchFormInputsProps {
     state: BaseInterpretedLaunchState;
+    variant: 'workflow' | 'task';
 }
 
 export const LaunchFormInputsImpl: React.RefForwardingComponent<
     LaunchFormInputsRef,
     LaunchFormInputsProps
-> = ({ state }, ref) => {
+> = ({ state, variant }, ref) => {
     const {
         parsedInputs,
         unsupportedRequiredInputs,
@@ -68,6 +69,7 @@ export const LaunchFormInputsImpl: React.RefForwardingComponent<
             {state.matches(LaunchState.UNSUPPORTED_INPUTS) ? (
                 <UnsupportedRequiredInputsError
                     inputs={unsupportedRequiredInputs}
+                    variant={variant}
                 />
             ) : (
                 <>

--- a/src/components/Launch/LaunchForm/LaunchTaskForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchTaskForm.tsx
@@ -1,0 +1,82 @@
+import { DialogContent } from '@material-ui/core';
+import { getCacheKey } from 'components/Cache/utils';
+import * as React from 'react';
+import { formStrings } from './constants';
+import { LaunchFormActions } from './LaunchFormActions';
+import { LaunchFormHeader } from './LaunchFormHeader';
+import { LaunchFormInputs } from './LaunchFormInputs';
+import { LaunchState } from './launchMachine';
+import { SearchableSelector } from './SearchableSelector';
+import { useStyles } from './styles';
+import {
+    BaseInterpretedLaunchState,
+    BaseLaunchService,
+    LaunchTaskFormProps
+} from './types';
+import { useLaunchTaskFormState } from './useLaunchTaskFormState';
+
+/** Renders the form for initiating a Launch request based on a Task */
+export const LaunchTaskForm: React.FC<LaunchTaskFormProps> = props => {
+    const {
+        formInputsRef,
+        state,
+        service,
+        taskSourceSelectorState
+    } = useLaunchTaskFormState(props);
+    const styles = useStyles();
+    const baseState = state as BaseInterpretedLaunchState;
+    const baseService = service as BaseLaunchService;
+
+    // Any time the inputs change (even if it's just re-ordering), we must
+    // change the form key so that the inputs component will re-mount.
+    const formKey = React.useMemo<string>(() => {
+        return getCacheKey(state.context.parsedInputs);
+    }, [state.context.parsedInputs]);
+
+    const {
+        fetchSearchResults,
+        onSelectTaskVersion,
+        selectedTask,
+        taskSelectorOptions
+    } = taskSourceSelectorState;
+
+    const showTaskSelector = ![
+        LaunchState.LOADING_TASK_VERSIONS,
+        LaunchState.FAILED_LOADING_TASK_VERSIONS
+    ].some(state.matches);
+
+    // TODO: We removed all loading indicators here. Decide if we want skeletons
+    // instead.
+    return (
+        <>
+            <LaunchFormHeader title={state.context.sourceId?.name} />
+            <DialogContent dividers={true} className={styles.inputsSection}>
+                {showTaskSelector ? (
+                    <section
+                        title={formStrings.taskVersion}
+                        className={styles.formControl}
+                    >
+                        <SearchableSelector
+                            id="launch-task-selector"
+                            label={formStrings.taskVersion}
+                            onSelectionChanged={onSelectTaskVersion}
+                            options={taskSelectorOptions}
+                            fetchSearchResults={fetchSearchResults}
+                            selectedItem={selectedTask}
+                        />
+                    </section>
+                ) : null}
+                <LaunchFormInputs
+                    key={formKey}
+                    ref={formInputsRef}
+                    state={baseState}
+                />
+            </DialogContent>
+            <LaunchFormActions
+                state={baseState}
+                service={baseService}
+                onClose={props.onClose}
+            />
+        </>
+    );
+};

--- a/src/components/Launch/LaunchForm/LaunchTaskForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchTaskForm.tsx
@@ -70,6 +70,7 @@ export const LaunchTaskForm: React.FC<LaunchTaskFormProps> = props => {
                     key={formKey}
                     ref={formInputsRef}
                     state={baseState}
+                    variant="task"
                 />
             </DialogContent>
             <LaunchFormActions

--- a/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
@@ -93,6 +93,7 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                     key={formKey}
                     ref={formInputsRef}
                     state={baseState}
+                    variant="workflow"
                 />
             </DialogContent>
             <LaunchFormActions

--- a/src/components/Launch/LaunchForm/UnsupportedRequiredInputsError.tsx
+++ b/src/components/Launch/LaunchForm/UnsupportedRequiredInputsError.tsx
@@ -4,9 +4,11 @@ import { NonIdealState } from 'components/common';
 import { useCommonStyles } from 'components/common/styles';
 import * as React from 'react';
 import {
+    cannotLaunchTaskString,
     cannotLaunchWorkflowString,
     requiredInputSuffix,
-    unsupportedRequiredInputsString
+    taskUnsupportedRequiredInputsString,
+    workflowUnsupportedRequiredInputsString
 } from './constants';
 import { ParsedInput } from './types';
 
@@ -28,24 +30,33 @@ function formatLabel(label: string) {
 
 export interface UnsupportedRequiredInputsErrorProps {
     inputs: ParsedInput[];
+    variant: 'workflow' | 'task';
 }
 /** An informational error to be shown if a Workflow cannot be launch due to
  * required inputs for which we will not be able to provide a value.
  */
 export const UnsupportedRequiredInputsError: React.FC<UnsupportedRequiredInputsErrorProps> = ({
-    inputs
+    inputs,
+    variant
 }) => {
     const styles = useStyles();
     const commonStyles = useCommonStyles();
+    const [titleString, errorString] =
+        variant === 'workflow'
+            ? [
+                  cannotLaunchWorkflowString,
+                  workflowUnsupportedRequiredInputsString
+              ]
+            : [cannotLaunchTaskString, taskUnsupportedRequiredInputsString];
     return (
         <NonIdealState
             className={styles.errorContainer}
             icon={ErrorOutline}
             size="medium"
-            title={cannotLaunchWorkflowString}
+            title={titleString}
         >
             <div className={styles.contentContainer}>
-                <p>{unsupportedRequiredInputsString}</p>
+                <p>{errorString}</p>
                 <ul className={commonStyles.listUnstyled}>
                     {inputs.map(input => (
                         <li

--- a/src/components/Launch/LaunchForm/__mocks__/mockInputs.ts
+++ b/src/components/Launch/LaunchForm/__mocks__/mockInputs.ts
@@ -104,7 +104,7 @@ export const mockNestedCollectionVariables: Record<
     type: { collectionType: v.type }
 }));
 
-export function createMockWorkflowInputsInterface(
+export function createMockInputsInterface(
     variables: Record<string, Variable>
 ): TypedInterface {
     return {

--- a/src/components/Launch/LaunchForm/__stories__/LaunchForm.stories.tsx
+++ b/src/components/Launch/LaunchForm/__stories__/LaunchForm.stories.tsx
@@ -23,7 +23,7 @@ import {
 import { mockWorkflowExecutionResponse } from 'models/Execution/__mocks__/mockWorkflowExecutionsData';
 import * as React from 'react';
 import {
-    createMockWorkflowInputsInterface,
+    createMockInputsInterface,
     mockCollectionVariables,
     mockNestedCollectionVariables,
     mockSimpleVariables,
@@ -44,7 +44,7 @@ const submitAction = action('createWorkflowExecution');
 const generateMocks = (variables: Record<string, Variable>) => {
     const mockWorkflow = createMockWorkflow('MyWorkflow');
     mockWorkflow.closure = createMockWorkflowClosure();
-    mockWorkflow.closure!.compiledWorkflow!.primary.template.interface = createMockWorkflowInputsInterface(
+    mockWorkflow.closure!.compiledWorkflow!.primary.template.interface = createMockInputsInterface(
         variables
     );
 
@@ -95,7 +95,7 @@ const generateMocks = (variables: Record<string, Variable>) => {
                 id
             };
             workflow.closure = createMockWorkflowClosure();
-            workflow.closure!.compiledWorkflow!.primary.template.interface = createMockWorkflowInputsInterface(
+            workflow.closure!.compiledWorkflow!.primary.template.interface = createMockInputsInterface(
                 variables
             );
 

--- a/src/components/Launch/LaunchForm/constants.ts
+++ b/src/components/Launch/LaunchForm/constants.ts
@@ -17,6 +17,7 @@ export const formStrings = {
     cancel: 'Cancel',
     inputs: 'Inputs',
     submit: 'Launch',
+    taskVersion: 'Task Version',
     title: 'Launch Workflow',
     workflowVersion: 'Workflow Version',
     launchPlan: 'Launch Plan'

--- a/src/components/Launch/LaunchForm/constants.ts
+++ b/src/components/Launch/LaunchForm/constants.ts
@@ -63,6 +63,8 @@ export const defaultBlobValue: BlobValue = {
 
 export const requiredInputSuffix = '*';
 export const cannotLaunchWorkflowString = 'Workflow cannot be launched';
-export const unsupportedRequiredInputsString = `This Workflow version contains one or more required inputs which are not supported by Flyte Console and do not have default values specified in the Workflow definition or the selected Launch Plan.\n\nYou can launch this Workflow version with the Flyte CLI or by selecting a Launch Plan which provides values for the unsupported inputs.\n\nThe required inputs are :`;
+export const cannotLaunchTaskString = 'Task cannot be launched';
+export const workflowUnsupportedRequiredInputsString = `This Workflow version contains one or more required inputs which are not supported by Flyte Console and do not have default values specified in the Workflow definition or the selected Launch Plan.\n\nYou can launch this Workflow version with the Flyte CLI or by selecting a Launch Plan which provides values for the unsupported inputs.\n\nThe required inputs are :`;
+export const taskUnsupportedRequiredInputsString = `This Task version contains one or more required inputs which are not supported by Flyte Console.\n\nYou can launch this Task version with the Flyte CLI instead.\n\nThe required inputs are :`;
 export const blobUriHelperText = '(required) location of the data';
 export const blobFormatHelperText = '(optional) csv, parquet, etc...';

--- a/src/components/Launch/LaunchForm/constants.ts
+++ b/src/components/Launch/LaunchForm/constants.ts
@@ -18,7 +18,7 @@ export const formStrings = {
     inputs: 'Inputs',
     submit: 'Launch',
     taskVersion: 'Task Version',
-    title: 'Launch Workflow',
+    title: 'Create New Execution',
     workflowVersion: 'Workflow Version',
     launchPlan: 'Launch Plan'
 };

--- a/src/components/Launch/LaunchForm/launchMachine.ts
+++ b/src/components/Launch/LaunchForm/launchMachine.ts
@@ -2,6 +2,7 @@ import {
     Identifier,
     LaunchPlan,
     NamedEntityIdentifier,
+    Task,
     Workflow,
     WorkflowExecutionIdentifier,
     WorkflowId
@@ -30,7 +31,7 @@ export type SelectLaunchPlanEvent = {
 };
 export type WorkflowVersionOptionsLoadedEvent = DoneInvokeEvent<Workflow[]>;
 export type LaunchPlanOptionsLoadedEvent = DoneInvokeEvent<LaunchPlan[]>;
-export type TaskVersionOptionsLoadedEvent = DoneInvokeEvent<Identifier[]>;
+export type TaskVersionOptionsLoadedEvent = DoneInvokeEvent<Task[]>;
 export type ExecutionCreatedEvent = DoneInvokeEvent<
     WorkflowExecutionIdentifier
 >;
@@ -81,8 +82,9 @@ export interface WorkflowLaunchContext extends BaseLaunchContext {
 }
 
 export interface TaskLaunchContext extends BaseLaunchContext {
+    preferredTaskId?: Identifier;
     taskVersion?: Identifier;
-    taskVersionOptions?: Identifier[];
+    taskVersionOptions?: Task[];
 }
 
 export enum LaunchState {
@@ -199,7 +201,7 @@ export type WorkflowLaunchTypestate =
     | {
           value: LaunchState.SELECT_WORKFLOW_VERSION;
           context: WorkflowLaunchContext & {
-              sourceId: WorkflowId;
+              sourceId: NamedEntityIdentifier;
               workflowVersionOptions: Workflow[];
           };
       }
@@ -207,13 +209,20 @@ export type WorkflowLaunchTypestate =
           value: LaunchState.SELECT_LAUNCH_PLAN;
           context: WorkflowLaunchContext & {
               launchPlanOptions: LaunchPlan[];
-              sourceId: WorkflowId;
+              sourceId: NamedEntityIdentifier;
               workflowVersionOptions: Workflow[];
           };
       };
 
-// TODO:
-export type TaskLaunchTypestate = BaseLaunchTypestate;
+export type TaskLaunchTypestate =
+    | BaseLaunchTypestate
+    | {
+          value: LaunchState.SELECT_TASK_VERSION;
+          context: TaskLaunchContext & {
+              sourceId: NamedEntityIdentifier;
+              taskVersionOptions: Task[];
+          };
+      };
 
 const defaultBaseContext: BaseLaunchContext = {
     parsedInputs: [],

--- a/src/components/Launch/LaunchForm/services.ts
+++ b/src/components/Launch/LaunchForm/services.ts
@@ -1,0 +1,18 @@
+import { RefObject } from 'react';
+import { WorkflowLaunchContext } from './launchMachine';
+import { LaunchFormInputsRef } from './types';
+
+export async function validate(
+    formInputsRef: RefObject<LaunchFormInputsRef>,
+    {}: WorkflowLaunchContext
+) {
+    if (formInputsRef.current === null) {
+        throw new Error('Unexpected empty form inputs ref');
+    }
+
+    if (!formInputsRef.current.validate()) {
+        throw new Error(
+            'Some inputs have errors. Please correct them before submitting.'
+        );
+    }
+}

--- a/src/components/Launch/LaunchForm/test/LaunchTaskForm.test.tsx
+++ b/src/components/Launch/LaunchForm/test/LaunchTaskForm.test.tsx
@@ -1,0 +1,603 @@
+import { ThemeProvider } from '@material-ui/styles';
+import {
+    act,
+    fireEvent,
+    getAllByRole,
+    getByRole,
+    queryAllByRole,
+    render,
+    waitFor
+} from '@testing-library/react';
+import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
+import { APIContext } from 'components/data/apiContext';
+import { muiTheme } from 'components/Theme';
+import { Core } from 'flyteidl';
+import { cloneDeep, get } from 'lodash';
+import * as Long from 'long';
+import {
+    createWorkflowExecution,
+    CreateWorkflowExecutionArguments,
+    getTask,
+    Identifier,
+    LaunchPlan,
+    listLaunchPlans,
+    listTasks,
+    Literal,
+    NamedEntityIdentifier,
+    RequestConfig,
+    Task,
+    Variable
+} from 'models';
+import { createMockTaskClosure } from 'models/__mocks__/taskData';
+import * as React from 'react';
+import { delayedPromise, pendingPromise } from 'test/utils';
+import {
+    createMockInputsInterface,
+    mockSimpleVariables,
+    simpleVariableDefaults
+} from '../__mocks__/mockInputs';
+import {
+    cannotLaunchTaskString,
+    formStrings,
+    requiredInputSuffix
+} from '../constants';
+import { LaunchForm } from '../LaunchForm';
+import { LaunchFormProps, TaskInitialLaunchParameters } from '../types';
+import { createInputCacheKey, getInputDefintionForLiteralType } from '../utils';
+import {
+    binaryInputName,
+    booleanInputName,
+    integerInputName,
+    stringInputName,
+    stringNoLabelName
+} from './constants';
+import { createMockObjects } from './utils';
+
+function getTaskVariables(task: Task): Record<string, Variable> {
+    return task.closure!.compiledTask.template.interface!.inputs!.variables;
+}
+
+describe('LaunchForm: Task', () => {
+    let onClose: jest.Mock;
+    let mockTask: Task;
+    let mockTaskVersions: Task[];
+    let taskId: NamedEntityIdentifier;
+    let variables: Record<string, Variable>;
+
+    let mockListTasks: jest.Mock<ReturnType<typeof listTasks>>;
+    let mockGetTask: jest.Mock<ReturnType<typeof getTask>>;
+    let mockCreateWorkflowExecution: jest.Mock<ReturnType<
+        typeof createWorkflowExecution
+    >>;
+
+    beforeEach(() => {
+        onClose = jest.fn();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    const createMockTaskWithInputs = (id: Identifier) => {
+        const task: Task = {
+            id,
+            closure: createMockTaskClosure()
+        };
+        task.closure!.compiledTask!.template.interface = createMockInputsInterface(
+            variables
+        );
+        return task;
+    };
+
+    const createMocks = () => {
+        const mockObjects = createMockObjects(variables);
+        mockTask = mockObjects.mockTask;
+
+        mockTaskVersions = mockObjects.mockTaskVersions;
+
+        taskId = mockTask.id;
+        mockCreateWorkflowExecution = jest.fn();
+        // Return our mock inputs for any version requested
+        mockGetTask = jest
+            .fn()
+            .mockImplementation(id =>
+                Promise.resolve(createMockTaskWithInputs(id))
+            );
+
+        // For workflow/task list endpoints: If the scope has a filter, the calling
+        // code is searching for a specific item. So we'll return a single-item
+        // list containing it.
+        mockListTasks = jest
+            .fn()
+            .mockImplementation(
+                (scope: Partial<Identifier>, { filter }: RequestConfig) => {
+                    if (filter && filter[0].key === 'version') {
+                        const task = { ...mockTaskVersions[0] };
+                        task.id = {
+                            ...scope,
+                            version: filter[0].value
+                        } as Identifier;
+                        return Promise.resolve({
+                            entities: [task]
+                        });
+                    }
+                    return Promise.resolve({ entities: mockTaskVersions });
+                }
+            );
+    };
+
+    const renderForm = (props?: Partial<LaunchFormProps>) => {
+        return render(
+            <ThemeProvider theme={muiTheme}>
+                <APIContext.Provider
+                    value={mockAPIContextValue({
+                        createWorkflowExecution: mockCreateWorkflowExecution,
+                        getTask: mockGetTask,
+                        listTasks: mockListTasks
+                    })}
+                >
+                    <LaunchForm onClose={onClose} taskId={taskId} {...props} />
+                </APIContext.Provider>
+            </ThemeProvider>
+        );
+    };
+
+    const getSubmitButton = (container: HTMLElement) => {
+        const buttons = queryAllByRole(container, 'button').filter(
+            el => el.getAttribute('type') === 'submit'
+        );
+        expect(buttons.length).toBe(1);
+        return buttons[0];
+    };
+
+    describe('With Simple Inputs', () => {
+        beforeEach(() => {
+            const {
+                simpleString,
+                stringNoLabel,
+                simpleInteger,
+                simpleFloat,
+                simpleBoolean,
+                simpleDuration,
+                simpleDatetime
+            } = cloneDeep(mockSimpleVariables);
+            // Only taking supported variable types since they are all required.
+            variables = {
+                simpleString,
+                stringNoLabel,
+                simpleInteger,
+                simpleFloat,
+                simpleBoolean,
+                simpleDuration,
+                simpleDatetime
+            };
+            createMocks();
+        });
+
+        it('should not show task selector until options have loaded', async () => {
+            mockListTasks.mockReturnValue(pendingPromise());
+            const { queryByText } = renderForm();
+            await waitFor(() => {});
+            expect(
+                queryByText(formStrings.taskVersion)
+            ).not.toBeInTheDocument();
+        });
+
+        it('should select the most recent task version by default', async () => {
+            const { getByLabelText } = renderForm();
+            await waitFor(() => {});
+            expect(getByLabelText(formStrings.taskVersion)).toHaveValue(
+                mockTaskVersions[0].id.version
+            );
+        });
+
+        it('should disable submit button until inputs have loaded', async () => {
+            let identifier: Identifier = {} as Identifier;
+            const { promise, resolve } = delayedPromise<Task>();
+            mockGetTask.mockImplementation(id => {
+                identifier = id;
+                return promise;
+            });
+            const { container } = renderForm();
+
+            await waitFor(() => {});
+
+            const submitButton = getSubmitButton(container);
+
+            expect(submitButton).toBeDisabled();
+            resolve(createMockTaskWithInputs(identifier));
+
+            await waitFor(() => {});
+            expect(submitButton).not.toBeDisabled();
+        });
+
+        it('should not show validation errors until first submit', async () => {
+            const { container, getByLabelText } = renderForm();
+            await waitFor(() => {});
+
+            const integerInput = getByLabelText(integerInputName, {
+                exact: false
+            });
+            fireEvent.change(integerInput, { target: { value: 'abc' } });
+
+            act(() => {
+                jest.runAllTimers();
+            });
+            await waitFor(() => {});
+            expect(integerInput).not.toBeInvalid();
+
+            fireEvent.click(getSubmitButton(container));
+            await waitFor(() => {});
+
+            expect(integerInput).toBeInvalid();
+        });
+
+        it('should update validation errors while typing', async () => {
+            const { container, getByLabelText } = renderForm();
+            await waitFor(() => {});
+
+            const integerInput = getByLabelText(integerInputName, {
+                exact: false
+            });
+            fireEvent.change(integerInput, { target: { value: 'abc' } });
+            fireEvent.click(getSubmitButton(container));
+            await waitFor(() => {});
+            expect(integerInput).toBeInvalid();
+
+            fireEvent.change(integerInput, { target: { value: '123' } });
+            act(() => {
+                jest.runAllTimers();
+            });
+            await waitFor(() => {});
+            expect(integerInput).toBeValid();
+        });
+
+        it('should update inputs when selecting a new task version', async () => {
+            const { queryByLabelText, getByTitle } = renderForm();
+            const taskVersionDiv = await waitFor(() =>
+                getByTitle(formStrings.taskVersion)
+            );
+
+            // Delete the string input so that its corresponding input will
+            // disappear after the new launch plan is loaded.
+            const variables = getTaskVariables(mockTaskVersions[1]);
+            delete variables[stringInputName];
+
+            // Click the expander for the task version, select the second item
+            const expander = getByRole(taskVersionDiv, 'button');
+            fireEvent.click(expander);
+            const items = await waitFor(() =>
+                getAllByRole(taskVersionDiv, 'menuitem')
+            );
+            fireEvent.click(items[1]);
+
+            await waitFor(() => getByTitle(formStrings.inputs));
+            expect(
+                queryByLabelText(stringInputName, {
+                    // Don't use exact match because the label will be decorated with type info
+                    exact: false
+                })
+            ).toBeNull();
+        });
+
+        it('should preserve input values when changing task version', async () => {
+            const { getByLabelText, getByTitle } = renderForm();
+            await waitFor(() => {});
+
+            const integerInput = getByLabelText(integerInputName, {
+                exact: false
+            });
+            fireEvent.change(integerInput, { target: { value: '10' } });
+            await waitFor(() => {});
+
+            // Click the expander for the task version, select the second item
+            const taskVersionDiv = getByTitle(formStrings.taskVersion);
+            const expander = getByRole(taskVersionDiv, 'button');
+            fireEvent.click(expander);
+            const items = await waitFor(() =>
+                getAllByRole(taskVersionDiv, 'menuitem')
+            );
+            fireEvent.click(items[1]);
+            await waitFor(() => {});
+
+            expect(
+                getByLabelText(integerInputName, {
+                    exact: false
+                })
+            ).toHaveValue('10');
+        });
+
+        it('should reset form error when inputs change', async () => {
+            const errorString = 'Something went wrong';
+            mockCreateWorkflowExecution.mockRejectedValue(
+                new Error(errorString)
+            );
+
+            const {
+                container,
+                getByText,
+                getByTitle,
+                queryByText
+            } = renderForm();
+            await waitFor(() => {});
+
+            fireEvent.click(getSubmitButton(container));
+            await waitFor(() => {});
+
+            expect(getByText(errorString)).toBeInTheDocument();
+
+            // TODO: Not sure if we need to set the mock up to return a different set of inputs
+            // for the alternate task version
+
+            // Click the expander for the launch plan, select the second item
+            const taskVersionDiv = getByTitle(formStrings.taskVersion);
+            const expander = getByRole(taskVersionDiv, 'button');
+            fireEvent.click(expander);
+            const items = await waitFor(() =>
+                getAllByRole(taskVersionDiv, 'menuitem')
+            );
+            fireEvent.click(items[1]);
+            await waitFor(() => {});
+            expect(queryByText(errorString)).not.toBeInTheDocument();
+        });
+
+        describe('Input Values', () => {
+            it('Should send false for untouched toggles', async () => {
+                let inputs: Core.ILiteralMap = {};
+                mockCreateWorkflowExecution.mockImplementation(
+                    ({
+                        inputs: passedInputs
+                    }: CreateWorkflowExecutionArguments) => {
+                        inputs = passedInputs;
+                        return pendingPromise();
+                    }
+                );
+
+                const { container } = renderForm();
+                await waitFor(() => {});
+
+                fireEvent.click(getSubmitButton(container));
+                await waitFor(() => {});
+
+                expect(mockCreateWorkflowExecution).toHaveBeenCalled();
+                expect(inputs.literals).toBeDefined();
+                const value = get(
+                    inputs.literals,
+                    `${booleanInputName}.scalar.primitive.boolean`
+                );
+                expect(value).toBe(false);
+            });
+
+            it('should decorate all inputs with required labels', async () => {
+                // Add defaults for the string/integer inputs and check that they are
+                // correctly populated
+                const { getByText } = renderForm();
+                await waitFor(() => {});
+                Object.keys(variables).forEach(name => {
+                    expect(
+                        getByText(name, {
+                            exact: false
+                        }).textContent
+                    ).toContain('*');
+                });
+            });
+        });
+
+        describe('When using initial parameters', () => {
+            it('should prefer the provided task version', async () => {
+                const initialParameters: TaskInitialLaunchParameters = {
+                    taskId: mockTaskVersions[2].id
+                };
+                const { getByLabelText } = renderForm({ initialParameters });
+                await waitFor(() => {});
+                expect(getByLabelText(formStrings.taskVersion)).toHaveValue(
+                    mockTaskVersions[2].id.version
+                );
+            });
+
+            it('should only include one instance of the preferred version in the selector', async () => {
+                const initialParameters: TaskInitialLaunchParameters = {
+                    taskId: mockTaskVersions[2].id
+                };
+                const { getByTitle } = renderForm({ initialParameters });
+                await waitFor(() => {});
+                // Click the expander for the workflow, select the second item
+                const versionDiv = getByTitle(formStrings.taskVersion);
+                const expander = getByRole(versionDiv, 'button');
+                fireEvent.click(expander);
+                const items = await waitFor(() =>
+                    getAllByRole(versionDiv, 'menuitem')
+                );
+
+                const expectedVersion = mockTaskVersions[2].id.version;
+                expect(
+                    items.filter(
+                        item =>
+                            item.textContent &&
+                            item.textContent.includes(expectedVersion)
+                    )
+                ).toHaveLength(1);
+            });
+
+            it('should fall back to the first item in the list if preferred version is not found', async () => {
+                mockListTasks.mockImplementation(
+                    (scope: Partial<Identifier>) => {
+                        // If we get a request for a specific item,
+                        // simulate not found
+                        if (scope.version) {
+                            return Promise.resolve({ entities: [] });
+                        }
+                        return Promise.resolve({
+                            entities: mockTaskVersions
+                        });
+                    }
+                );
+                const baseId = mockTaskVersions[2].id;
+                const initialParameters: TaskInitialLaunchParameters = {
+                    taskId: { ...baseId, version: 'nonexistentValue' }
+                };
+                const { getByLabelText } = renderForm({ initialParameters });
+                await waitFor(() => {});
+                expect(getByLabelText(formStrings.taskVersion)).toHaveValue(
+                    mockTaskVersions[0].id.version
+                );
+            });
+
+            it('should prepopulate inputs with provided initial values', async () => {
+                const stringValue = 'initialStringValue';
+                const initialStringValue: Core.ILiteral = {
+                    scalar: { primitive: { stringValue } }
+                };
+                const variables = getTaskVariables(mockTaskVersions[0]);
+                const values = new Map();
+                const stringCacheKey = createInputCacheKey(
+                    stringInputName,
+                    getInputDefintionForLiteralType(
+                        variables[stringInputName].type
+                    )
+                );
+                values.set(stringCacheKey, initialStringValue);
+                const { getByLabelText } = renderForm({
+                    initialParameters: { values }
+                });
+                await waitFor(() => {});
+
+                expect(
+                    getByLabelText(stringInputName, { exact: false })
+                ).toHaveValue(stringValue);
+            });
+
+            it('loads preferred task version when it does not exist in the list of suggestions', async () => {
+                const missingTask = mockTaskVersions[0];
+                missingTask.id.version = 'missingVersionString';
+                const initialParameters: TaskInitialLaunchParameters = {
+                    taskId: missingTask.id
+                };
+                const { getByLabelText } = renderForm({ initialParameters });
+                await waitFor(() => {});
+                expect(getByLabelText(formStrings.taskVersion)).toHaveValue(
+                    missingTask.id.version
+                );
+            });
+
+            it('should select contents of task version input on focus', async () => {
+                const { getByLabelText } = renderForm();
+                await waitFor(() => {});
+
+                // Focus the workflow version input
+                const workflowInput = getByLabelText(formStrings.taskVersion);
+                fireEvent.focus(workflowInput);
+
+                act(() => {
+                    jest.runAllTimers();
+                });
+
+                const expectedValue = mockTaskVersions[0].id.version;
+
+                // The value should remain, but selection should be the entire string
+                expect(workflowInput).toHaveValue(expectedValue);
+                expect((workflowInput as HTMLInputElement).selectionEnd).toBe(
+                    expectedValue.length
+                );
+            });
+
+            it('should correctly render task version search results', async () => {
+                const initialParameters: TaskInitialLaunchParameters = {
+                    taskId: mockTaskVersions[2].id
+                };
+                const inputString = mockTaskVersions[1].id.version.substring(
+                    0,
+                    4
+                );
+                const { getByLabelText } = renderForm({ initialParameters });
+                await waitFor(() => {});
+
+                mockListTasks.mockClear();
+
+                const versionInput = getByLabelText(formStrings.taskVersion);
+                fireEvent.change(versionInput, {
+                    target: { value: inputString }
+                });
+
+                act(() => {
+                    jest.runAllTimers();
+                });
+                await waitFor(() => {});
+                const { project, domain, name } = mockTaskVersions[2].id;
+                expect(mockListTasks).toHaveBeenCalledWith(
+                    { project, domain, name },
+                    expect.anything()
+                );
+            });
+        });
+
+        describe('With Unsupported Required Inputs', () => {
+            beforeEach(() => {
+                // Binary is currently unsupported, and all values are required.
+                // So adding a binary variable will generate our test case.
+                const variables = getTaskVariables(mockTaskVersions[0]);
+                variables[binaryInputName] = cloneDeep(
+                    mockSimpleVariables[binaryInputName]
+                );
+            });
+
+            it('should render error message', async () => {
+                const { getByText } = renderForm();
+                const errorElement = await waitFor(() =>
+                    getByText(cannotLaunchTaskString)
+                );
+                expect(errorElement).toBeInTheDocument();
+            });
+
+            it('should show unsupported inputs', async () => {
+                const { getByText } = renderForm();
+                const inputElement = await waitFor(() =>
+                    getByText(binaryInputName, { exact: false })
+                );
+                expect(inputElement).toBeInTheDocument();
+            });
+
+            it('should print input labels without decoration', async () => {
+                const { getByText } = renderForm();
+                const inputElement = await waitFor(() =>
+                    getByText(binaryInputName, { exact: false })
+                );
+                expect(inputElement.textContent).not.toContain(
+                    requiredInputSuffix
+                );
+            });
+
+            it('should disable submission', async () => {
+                const { getByRole } = renderForm();
+
+                const submitButton = await waitFor(() =>
+                    getByRole('button', { name: formStrings.submit })
+                );
+
+                expect(submitButton).toBeDisabled();
+            });
+
+            it('should not show error if initial value is provided', async () => {
+                const variables = getTaskVariables(mockTaskVersions[0]);
+                const values = new Map();
+                const cacheKey = createInputCacheKey(
+                    binaryInputName,
+                    getInputDefintionForLiteralType(
+                        variables[binaryInputName].type
+                    )
+                );
+                values.set(cacheKey, simpleVariableDefaults.simpleBinary);
+                const { queryByText } = renderForm({
+                    initialParameters: { values }
+                });
+
+                await waitFor(() =>
+                    queryByText(binaryInputName, { exact: false })
+                );
+                expect(queryByText(cannotLaunchTaskString)).toBeNull();
+            });
+        });
+    });
+});

--- a/src/components/Launch/LaunchForm/test/constants.ts
+++ b/src/components/Launch/LaunchForm/test/constants.ts
@@ -1,6 +1,9 @@
 export const booleanInputName = 'simpleBoolean';
 export const stringInputName = 'simpleString';
 export const stringNoLabelName = 'stringNoLabel';
+export const floatInputName = 'simpleFloat';
+export const durationInputName = 'simpleDuration';
+export const datetimeInputName = 'simpleDatetime';
 export const integerInputName = 'simpleInteger';
 export const binaryInputName = 'simpleBinary';
 export const errorInputName = 'simpleError';

--- a/src/components/Launch/LaunchForm/test/getInputs.test.ts
+++ b/src/components/Launch/LaunchForm/test/getInputs.test.ts
@@ -1,5 +1,5 @@
 import { mockSimpleVariables } from '../__mocks__/mockInputs';
-import { getInputs } from '../getInputs';
+import { getInputsForWorkflow } from '../getInputs';
 import { stringInputName } from './constants';
 import { createMockObjects } from './utils';
 
@@ -15,9 +15,13 @@ describe('getInputs', () => {
         const parameters = launchPlan.closure!.expectedInputs.parameters;
         parameters[stringInputName].default = null;
 
-        expect(() => getInputs(mockWorkflow, launchPlan)).not.toThrowError();
+        expect(() =>
+            getInputsForWorkflow(mockWorkflow, launchPlan)
+        ).not.toThrowError();
 
         delete parameters[stringInputName].default;
-        expect(() => getInputs(mockWorkflow, launchPlan)).not.toThrowError();
+        expect(() =>
+            getInputsForWorkflow(mockWorkflow, launchPlan)
+        ).not.toThrowError();
     });
 });

--- a/src/components/Launch/LaunchForm/test/utils.ts
+++ b/src/components/Launch/LaunchForm/test/utils.ts
@@ -2,17 +2,24 @@ import { mapValues } from 'lodash';
 import { Variable } from 'models';
 import { createMockLaunchPlan } from 'models/__mocks__/launchPlanData';
 import {
+    createMockTask,
+    createMockTaskVersions
+} from 'models/__mocks__/taskData';
+import {
     createMockWorkflow,
     createMockWorkflowVersions
 } from 'models/__mocks__/workflowData';
 
 export function createMockObjects(variables: Record<string, Variable>) {
     const mockWorkflow = createMockWorkflow('MyWorkflow');
+    const mockTask = createMockTask('MyTask');
 
     const mockWorkflowVersions = createMockWorkflowVersions(
         mockWorkflow.id.name,
         10
     );
+
+    const mockTaskVersions = createMockTaskVersions(mockTask.id.name, 10);
 
     const mockLaunchPlans = [mockWorkflow.id.name, 'OtherLaunchPlan'].map(
         name => {
@@ -27,5 +34,11 @@ export function createMockObjects(variables: Record<string, Variable>) {
             return launchPlan;
         }
     );
-    return { mockWorkflow, mockLaunchPlans, mockWorkflowVersions };
+    return {
+        mockWorkflow,
+        mockLaunchPlans,
+        mockTask,
+        mockTaskVersions,
+        mockWorkflowVersions
+    };
 }

--- a/src/components/Launch/LaunchForm/types.ts
+++ b/src/components/Launch/LaunchForm/types.ts
@@ -4,6 +4,8 @@ import {
     Identifier,
     LaunchPlan,
     NamedEntityIdentifier,
+    Task,
+    Workflow,
     WorkflowId
 } from 'models';
 import { Interpreter, State } from 'xstate';
@@ -22,6 +24,7 @@ import { SearchableSelectorOption } from './SearchableSelector';
 
 export type InputValueMap = Map<string, InputValue>;
 export type LiteralValueMap = Map<string, Core.ILiteral>;
+export type SearchableVersion = Workflow | Task;
 
 export type BaseInterpretedLaunchState = State<
     BaseLaunchContext,
@@ -52,28 +55,28 @@ export interface WorkflowInitialLaunchParameters
 }
 export interface LaunchWorkflowFormProps extends BaseLaunchFormProps {
     workflowId: NamedEntityIdentifier;
-    initialParameters?: InitialWorkflowLaunchParameters;
+    initialParameters?: WorkflowInitialLaunchParameters;
 }
 
 export interface TaskInitialLaunchParameters
     extends BaseInitialLaunchParameters {
-    taskId?: NamedEntityIdentifier;
+    taskId?: Identifier;
 }
 export interface LaunchTaskFormProps extends BaseLaunchFormProps {
     taskId: NamedEntityIdentifier;
-    initialParameters?: InitialWorkflowLaunchParameters;
+    initialParameters?: TaskInitialLaunchParameters;
 }
 
 export type LaunchFormProps = LaunchWorkflowFormProps | LaunchTaskFormProps;
 
-export interface InitialWorkflowLaunchParameters {
+export interface WorkflowInitialLaunchParameters {
     launchPlan?: Identifier;
     workflow?: WorkflowId;
     values?: LiteralValueMap;
 }
 export interface LaunchWorkflowFormProps {
     workflowId: NamedEntityIdentifier;
-    initialParameters?: InitialWorkflowLaunchParameters;
+    initialParameters?: WorkflowInitialLaunchParameters;
 }
 
 export interface LaunchFormInputsRef {
@@ -93,6 +96,15 @@ export interface WorkflowSourceSelectorState {
         selected: SearchableSelectorOption<WorkflowId>
     ): void;
     onSelectLaunchPlan(selected: SearchableSelectorOption<LaunchPlan>): void;
+}
+
+export interface TaskSourceSelectorState {
+    selectedTask?: SearchableSelectorOption<Identifier>;
+    taskSelectorOptions: SearchableSelectorOption<Identifier>[];
+    fetchSearchResults(
+        query: string
+    ): Promise<SearchableSelectorOption<Identifier>[]>;
+    onSelectTaskVersion(selected: SearchableSelectorOption<Identifier>): void;
 }
 
 export interface LaunchWorkflowFormState {
@@ -121,8 +133,7 @@ export interface LaunchTaskFormState {
         TaskLaunchEvent,
         TaskLaunchTypestate
     >;
-    // TODO:
-    // taskSourceSelectorState: any;
+    taskSourceSelectorState: TaskSourceSelectorState;
 }
 
 export enum InputType {

--- a/src/components/Launch/LaunchForm/useExecutionLaunchConfiguration.ts
+++ b/src/components/Launch/LaunchForm/useExecutionLaunchConfiguration.ts
@@ -3,7 +3,7 @@ import { useAPIContext } from 'components/data/apiContext';
 import { fetchWorkflowExecutionInputs } from 'components/Executions/useWorkflowExecution';
 import { FetchableData, useFetchableData } from 'components/hooks';
 import { Execution, Variable } from 'models';
-import { InitialWorkflowLaunchParameters, LiteralValueMap } from './types';
+import { LiteralValueMap, WorkflowInitialLaunchParameters } from './types';
 import { createInputCacheKey, getInputDefintionForLiteralType } from './utils';
 
 export interface UseExecutionLaunchConfigurationArgs {
@@ -17,16 +17,16 @@ export function useExecutionLaunchConfiguration({
     execution,
     workflowInputs
 }: UseExecutionLaunchConfigurationArgs): FetchableData<
-    InitialWorkflowLaunchParameters
+    WorkflowInitialLaunchParameters
 > {
     const apiContext = useAPIContext();
     return useFetchableData<
-        InitialWorkflowLaunchParameters,
+        WorkflowInitialLaunchParameters,
         UseExecutionLaunchConfigurationArgs
     >(
         {
             debugName: 'ExecutionLaunchConfiguration',
-            defaultValue: {} as InitialWorkflowLaunchParameters,
+            defaultValue: {} as WorkflowInitialLaunchParameters,
             doFetch: async ({ execution, workflowInputs }) => {
                 const {
                     closure: { workflowId },

--- a/src/components/Launch/LaunchForm/useLaunchTaskFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchTaskFormState.ts
@@ -1,0 +1,226 @@
+import { useMachine } from '@xstate/react';
+import { defaultStateMachineConfig } from 'components/common/constants';
+import { APIContextValue, useAPIContext } from 'components/data/apiContext';
+import { isEqual, partial, uniqBy } from 'lodash';
+import {
+    FilterOperationName,
+    Identifier,
+    SortDirection,
+    Task,
+    taskSortFields,
+    WorkflowExecutionIdentifier
+} from 'models';
+import { RefObject, useEffect, useMemo, useRef } from 'react';
+import { getInputsForTask } from './getInputs';
+import {
+    LaunchState,
+    TaskLaunchContext,
+    TaskLaunchEvent,
+    taskLaunchMachine,
+    TaskLaunchTypestate
+} from './launchMachine';
+import { validate } from './services';
+import {
+    LaunchFormInputsRef,
+    LaunchTaskFormProps,
+    LaunchTaskFormState,
+    ParsedInput
+} from './types';
+import { useTaskSourceSelectorState } from './useTaskSourceSelectorState';
+import { getUnsupportedRequiredInputs } from './utils';
+
+async function loadTaskVersions(
+    { listTasks }: APIContextValue,
+    { preferredTaskId, sourceId }: TaskLaunchContext
+) {
+    if (!sourceId) {
+        throw new Error('Cannot load tasks, missing sourceId');
+    }
+    const { project, domain, name } = sourceId;
+    const tasksPromise = listTasks(
+        { project, domain, name },
+        {
+            limit: 10,
+            sort: {
+                key: taskSortFields.createdAt,
+                direction: SortDirection.DESCENDING
+            }
+        }
+    );
+
+    let preferredTaskPromise = Promise.resolve({
+        entities: [] as Task[]
+    });
+    if (preferredTaskId) {
+        const { version, ...scope } = preferredTaskId;
+        preferredTaskPromise = listTasks(scope, {
+            limit: 1,
+            filter: [
+                {
+                    key: 'version',
+                    operation: FilterOperationName.EQ,
+                    value: version
+                }
+            ]
+        });
+    }
+
+    const [tasksResult, preferredTaskResult] = await Promise.all([
+        tasksPromise,
+        preferredTaskPromise
+    ]);
+    const merged = [...tasksResult.entities, ...preferredTaskResult.entities];
+    return uniqBy(merged, ({ id: { version } }) => version);
+}
+
+async function loadInputs(
+    { getTask }: APIContextValue,
+    { defaultInputValues, taskVersion }: TaskLaunchContext
+) {
+    if (!taskVersion) {
+        throw new Error('Failed to load inputs: missing taskVersion');
+    }
+
+    const task = await getTask(taskVersion);
+    const parsedInputs: ParsedInput[] = getInputsForTask(
+        task,
+        defaultInputValues
+    );
+
+    return {
+        parsedInputs,
+        unsupportedRequiredInputs: getUnsupportedRequiredInputs(parsedInputs)
+    };
+}
+
+async function submit(
+    { createWorkflowExecution }: APIContextValue,
+    formInputsRef: RefObject<LaunchFormInputsRef>,
+    { taskVersion }: TaskLaunchContext
+) {
+    if (!taskVersion) {
+        throw new Error('Attempting to launch with no Task version');
+    }
+    if (formInputsRef.current === null) {
+        throw new Error('Unexpected empty form inputs ref');
+    }
+    const literals = formInputsRef.current.getValues();
+    const launchPlanId = taskVersion;
+    const { domain, project } = taskVersion;
+
+    const response = await createWorkflowExecution({
+        domain,
+        launchPlanId,
+        project,
+        inputs: { literals }
+    });
+    const newExecutionId = response.id as WorkflowExecutionIdentifier;
+    if (!newExecutionId) {
+        throw new Error('API Response did not include new execution id');
+    }
+
+    return newExecutionId;
+}
+
+function getServices(
+    apiContext: APIContextValue,
+    formInputsRef: RefObject<LaunchFormInputsRef>
+) {
+    return {
+        loadTaskVersions: partial(loadTaskVersions, apiContext),
+        loadInputs: partial(loadInputs, apiContext),
+        submit: partial(submit, apiContext, formInputsRef),
+        validate: partial(validate, formInputsRef)
+    };
+}
+
+/** Contains all of the form state for a LaunchTaskForm, including input
+ * definitions, current input values, and errors.
+ */
+export function useLaunchTaskFormState({
+    initialParameters = {},
+    taskId: sourceId
+}: LaunchTaskFormProps): LaunchTaskFormState {
+    // These values will be used to auto-select items from the task
+    // version/launch plan drop downs.
+    const {
+        taskId: preferredTaskId,
+        values: defaultInputValues
+    } = initialParameters;
+
+    const apiContext = useAPIContext();
+    const formInputsRef = useRef<LaunchFormInputsRef>(null);
+
+    const services = useMemo(() => getServices(apiContext, formInputsRef), [
+        apiContext,
+        formInputsRef
+    ]);
+
+    const [state, sendEvent, service] = useMachine<
+        TaskLaunchContext,
+        TaskLaunchEvent,
+        TaskLaunchTypestate
+    >(taskLaunchMachine, {
+        ...defaultStateMachineConfig,
+        services,
+        context: {
+            defaultInputValues,
+            preferredTaskId,
+            sourceId
+        }
+    });
+
+    const { taskVersionOptions = [], taskVersion } = state.context;
+
+    const selectTaskVersion = (newTask: Identifier) => {
+        if (newTask === taskVersion) {
+            return;
+        }
+        sendEvent({
+            type: 'SELECT_TASK_VERSION',
+            taskId: newTask
+        });
+    };
+
+    const taskSourceSelectorState = useTaskSourceSelectorState({
+        sourceId,
+        selectTaskVersion,
+        taskVersion,
+        taskVersionOptions
+    });
+
+    useEffect(() => {
+        const subscription = service.subscribe(newState => {
+            if (newState.matches(LaunchState.SELECT_TASK_VERSION)) {
+                const {
+                    taskVersionOptions,
+                    preferredTaskId
+                } = newState.context;
+                if (taskVersionOptions.length > 0) {
+                    let taskToSelect = taskVersionOptions[0];
+                    if (preferredTaskId) {
+                        const preferred = taskVersionOptions.find(({ id }) =>
+                            isEqual(id, preferredTaskId)
+                        );
+                        if (preferred) {
+                            taskToSelect = preferred;
+                        }
+                    }
+                    sendEvent({
+                        type: 'SELECT_TASK_VERSION',
+                        taskId: taskToSelect.id
+                    });
+                }
+            }
+        });
+
+        return subscription.unsubscribe;
+    }, [service, sendEvent]);
+
+    return {
+        formInputsRef,
+        state,
+        service,
+        taskSourceSelectorState
+    };
+}

--- a/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
@@ -12,7 +12,7 @@ import {
     workflowSortFields
 } from 'models';
 import { RefObject, useEffect, useMemo, useRef } from 'react';
-import { getInputs } from './getInputs';
+import { getInputsForWorkflow } from './getInputs';
 import {
     LaunchState,
     WorkflowLaunchContext,
@@ -20,6 +20,7 @@ import {
     workflowLaunchMachine,
     WorkflowLaunchTypestate
 } from './launchMachine';
+import { validate } from './services';
 import {
     LaunchFormInputsRef,
     LaunchWorkflowFormProps,
@@ -143,7 +144,7 @@ async function loadInputs(
         throw new Error('Failed to load inputs: missing launchPlan');
     }
     const workflow = await getWorkflow(workflowVersion);
-    const parsedInputs: ParsedInput[] = getInputs(
+    const parsedInputs: ParsedInput[] = getInputsForWorkflow(
         workflow,
         launchPlan,
         defaultInputValues
@@ -153,22 +154,6 @@ async function loadInputs(
         parsedInputs,
         unsupportedRequiredInputs: getUnsupportedRequiredInputs(parsedInputs)
     };
-}
-
-// TODO: Can be shared between both types of launch form.
-async function validate(
-    formInputsRef: RefObject<LaunchFormInputsRef>,
-    {}: WorkflowLaunchContext
-) {
-    if (formInputsRef.current === null) {
-        throw new Error('Unexpected empty form inputs ref');
-    }
-
-    if (!formInputsRef.current.validate()) {
-        throw new Error(
-            'Some inputs have errors. Please correct them before submitting.'
-        );
-    }
 }
 
 async function submit(

--- a/src/components/Launch/LaunchForm/useTaskSourceSelectorState.ts
+++ b/src/components/Launch/LaunchForm/useTaskSourceSelectorState.ts
@@ -1,0 +1,100 @@
+import { APIContextValue, useAPIContext } from 'components/data/apiContext';
+import {
+    FilterOperationName,
+    Identifier,
+    NamedEntityIdentifier,
+    SortDirection,
+    Task,
+    taskSortFields
+} from 'models';
+import { useMemo, useState } from 'react';
+import { SearchableSelectorOption } from './SearchableSelector';
+import { TaskSourceSelectorState } from './types';
+import { useVersionSelectorOptions } from './useVersionSelectorOptions';
+import { versionsToSearchableSelectorOptions } from './utils';
+
+function generateFetchSearchResults(
+    { listTasks }: APIContextValue,
+    taskId: NamedEntityIdentifier
+) {
+    return async (query: string) => {
+        const { project, domain, name } = taskId;
+        const { entities: tasks } = await listTasks(
+            { project, domain, name },
+            {
+                filter: [
+                    {
+                        key: 'version',
+                        operation: FilterOperationName.CONTAINS,
+                        value: query
+                    }
+                ],
+                sort: {
+                    key: taskSortFields.createdAt,
+                    direction: SortDirection.DESCENDING
+                }
+            }
+        );
+        return versionsToSearchableSelectorOptions(tasks);
+    };
+}
+
+interface UseTaskSourceSelectorStateArgs {
+    /** The parent task for which we are selecting a version. */
+    sourceId: NamedEntityIdentifier;
+    /** The currently selected Task version. */
+    taskVersion?: Identifier;
+    /** The list of options to show for the Task selector. */
+    taskVersionOptions: Task[];
+    /** Callback fired when a task has been selected. */
+    selectTaskVersion(task: Identifier): void;
+}
+
+/** Generates state for the version selector rendered when using a task
+ * as a source in the Launch form.
+ */
+export function useTaskSourceSelectorState({
+    sourceId,
+    taskVersion,
+    taskVersionOptions,
+    selectTaskVersion
+}: UseTaskSourceSelectorStateArgs): TaskSourceSelectorState {
+    const apiContext = useAPIContext();
+    const taskSelectorOptions = useVersionSelectorOptions(taskVersionOptions);
+    const [taskVersionSearchOptions, setTaskVersionSearchOptions] = useState<
+        SearchableSelectorOption<Identifier>[]
+    >([]);
+
+    const selectedTask = useMemo(() => {
+        if (!taskVersion) {
+            return undefined;
+        }
+        // Search both the default and search results to match our selected task
+        // with the correct SearchableSelector item.
+        return [...taskSelectorOptions, ...taskVersionSearchOptions].find(
+            option => option.id === taskVersion.version
+        );
+    }, [taskVersion, taskVersionOptions]);
+
+    const onSelectTaskVersion = useMemo(
+        () => ({ data }: SearchableSelectorOption<Identifier>) =>
+            selectTaskVersion(data),
+        [selectTaskVersion]
+    );
+
+    const fetchSearchResults = useMemo(() => {
+        const doFetch = generateFetchSearchResults(apiContext, sourceId);
+        return async (query: string) => {
+            const results = await doFetch(query);
+            setTaskVersionSearchOptions(results);
+            return results;
+        };
+    }, [apiContext, sourceId, setTaskVersionSearchOptions]);
+
+    return {
+        fetchSearchResults,
+        onSelectTaskVersion,
+        selectedTask,
+        taskSelectorOptions
+    };
+}

--- a/src/components/Launch/LaunchForm/useVersionSelectorOptions.ts
+++ b/src/components/Launch/LaunchForm/useVersionSelectorOptions.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+import { SearchableVersion } from './types';
+import { versionsToSearchableSelectorOptions } from './utils';
+
+export function useVersionSelectorOptions(versions: SearchableVersion[]) {
+    return useMemo(() => {
+        const options = versionsToSearchableSelectorOptions(versions);
+        if (options.length > 0) {
+            options[0].description = 'latest';
+        }
+        return options;
+    }, [versions]);
+}

--- a/src/components/Launch/LaunchForm/useWorkflowSourceSelectorState.ts
+++ b/src/components/Launch/LaunchForm/useWorkflowSourceSelectorState.ts
@@ -11,20 +11,11 @@ import {
 import { useMemo, useState } from 'react';
 import { SearchableSelectorOption } from './SearchableSelector';
 import { WorkflowSourceSelectorState } from './types';
+import { useVersionSelectorOptions } from './useVersionSelectorOptions';
 import {
     launchPlansToSearchableSelectorOptions,
-    workflowsToSearchableSelectorOptions
+    versionsToSearchableSelectorOptions
 } from './utils';
-
-export function useWorkflowSelectorOptions(workflows: Workflow[]) {
-    return useMemo(() => {
-        const options = workflowsToSearchableSelectorOptions(workflows);
-        if (options.length > 0) {
-            options[0].description = 'latest';
-        }
-        return options;
-    }, [workflows]);
-}
 
 function useLaunchPlanSelectorOptions(launchPlans: LaunchPlan[]) {
     return useMemo(() => launchPlansToSearchableSelectorOptions(launchPlans), [
@@ -54,7 +45,7 @@ function generateFetchSearchResults(
                 }
             }
         );
-        return workflowsToSearchableSelectorOptions(workflows);
+        return versionsToSearchableSelectorOptions(workflows);
     };
 }
 
@@ -88,7 +79,7 @@ export function useWorkflowSourceSelectorState({
     selectWorkflowVersion
 }: UseWorkflowSourceSelectorStateArgs): WorkflowSourceSelectorState {
     const apiContext = useAPIContext();
-    const workflowSelectorOptions = useWorkflowSelectorOptions(
+    const workflowSelectorOptions = useVersionSelectorOptions(
         workflowVersionOptions
     );
     const [

--- a/src/models/__mocks__/simpleTaskClosure.json
+++ b/src/models/__mocks__/simpleTaskClosure.json
@@ -1,0 +1,69 @@
+{
+  "compiledTask": {
+    "template": {
+      "id": {
+        "resource_type": "TASK",
+        "project": "myflyteproject",
+        "domain": "development",
+        "name": "work-find-odd-numbers",
+        "version": "ABC123"
+      },
+      "type": "python-task",
+      "metadata": {
+        "runtime": {
+          "type": "FlyteSDK",
+          "version": "0.0.1a0",
+          "flavor": "python"
+        },
+        "timeout": "0s",
+        "retries": {},
+        "discovery_version": "1"
+      },
+      "interface": {
+        "inputs": {
+          "variables": {
+            "list_of_nums": {
+              "type": {
+                "collection_type": {
+                  "simple": "INTEGER"
+                }
+              }
+            }
+          }
+        },
+        "outputs": {
+          "variables": {
+            "are_num_odd": {
+              "type": {
+                "collection_type": {
+                  "simple": "BOOLEAN"
+                }
+              }
+            }
+          }
+        }
+      },
+      "container": {
+        "image": "myflyteproject:DEF123",
+        "command": ["pyflyte-execute"],
+        "args": [
+          "--task-module",
+          "work",
+          "--task-name",
+          "find_odd_numbers",
+          "--inputs",
+          "{{.input}}",
+          "--output-prefix",
+          "{{.outputPrefix}}"
+        ],
+        "resources": {},
+        "env": [
+          {
+            "key": "FLYTE_CONFIGURATION_PATH",
+            "value": "/myflyteproject/flytekit.config"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/models/__mocks__/taskData.ts
+++ b/src/models/__mocks__/taskData.ts
@@ -1,0 +1,43 @@
+import { getCacheKey } from 'components/Cache';
+import { Admin } from 'flyteidl';
+import { cloneDeep } from 'lodash';
+import { Identifier } from '../Common';
+import { Task, TaskClosure } from '../Task';
+import * as simpleClosure from './simpleTaskClosure.json';
+
+const decodedClosure = Admin.TaskClosure.create(
+    (simpleClosure as unknown) as Admin.ITaskClosure
+) as TaskClosure;
+
+const taskId: (name: string, version: string) => Identifier = (
+    name,
+    version
+) => ({
+    name,
+    version,
+    project: 'flyte',
+    domain: 'development'
+});
+
+export const createMockTask: (name: string, version?: string) => Task = (
+    name: string,
+    version: string = 'abcdefg'
+) => ({
+    id: taskId(name, version),
+    closure: createMockTaskClosure()
+});
+
+export const createMockTaskClosure: () => TaskClosure = () =>
+    cloneDeep(decodedClosure);
+
+export const createMockTasks: Fn<Task[]> = () => [
+    createMockTask('task1'),
+    createMockTask('task2'),
+    createMockTask('task3')
+];
+
+export const createMockTaskVersions = (name: string, length: number) => {
+    return Array.from({ length }, (_, idx) => {
+        return createMockTask(name, getCacheKey({ idx }));
+    });
+};


### PR DESCRIPTION
* Added `LaunchTaskForm` and associated state hooks
* Refactored unit tests for LaunchForm and created additional set of tests for the 'task' case
* Updated some shared functionality to be usable with both workflows and tasks
* Updated `LaunchForm` to use new component if a taskId is specified.