### PR TITLE
fix: use correct filter for single task executions

### DIFF
--- a/src/components/Entities/generators.ts
+++ b/src/components/Entities/generators.ts
@@ -15,7 +15,7 @@ export const executionFilterGenerator: {
     [ResourceType.LAUNCH_PLAN]: noFilters,
     [ResourceType.TASK]: ({ name }) => [
         {
-            key: 'launch_plan.name',
+            key: 'task.name',
             operation: FilterOperationName.EQ,
             value: name
         }


### PR DESCRIPTION
lyft/flyte#542

The fix for the above bug in Admin will update the filter for single task executions to be based on `task.name` instead of `launch_plan.name`. So this PR updates the filter used in `EntityDetails` (in the task case) to use the new field.