### PR TITLE
feat: Fetch Node Executions directly if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
     "@date-io/moment": "1.3.9",
-    "@lyft/flyteidl": "^0.18.4",
+    "@lyft/flyteidl": "^0.18.9",
     "@material-ui/core": "^4.0.0",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/pickers": "^3.2.2",

--- a/src/components/Executions/Tables/NodeExecutionChildren.tsx
+++ b/src/components/Executions/Tables/NodeExecutionChildren.tsx
@@ -40,13 +40,14 @@ export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
                 ));
                 const key = `group-${name}`;
                 return showNames ? (
-                    <div key={key}>
+                    <div key={key} role="list">
                         <div
                             className={classnames(
                                 { [tableStyles.borderTop]: groupIndex > 0 },
                                 tableStyles.borderBottom,
                                 tableStyles.childGroupLabel
                             )}
+                            title={name}
                             style={childGroupLabelStyle}
                         >
                             <Typography
@@ -59,7 +60,9 @@ export const NodeExecutionChildren: React.FC<NodeExecutionChildrenProps> = ({
                         <div>{rows}</div>
                     </div>
                 ) : (
-                    <div key={key}>{rows}</div>
+                    <div key={key} role="list">
+                        {rows}
+                    </div>
                 );
             })}
         </>

--- a/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -93,6 +93,7 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
 
     return (
         <div
+            role="listitem"
             className={classnames(tableStyles.row, {
                 [selectedClassName]: selected
             })}

--- a/src/components/Executions/Tables/RowExpander.tsx
+++ b/src/components/Executions/Tables/RowExpander.tsx
@@ -2,6 +2,7 @@ import { IconButton } from '@material-ui/core';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import * as React from 'react';
+import { titleStrings } from './constants';
 
 /** A simple expand/collapse arrow to be rendered next to row items. */
 export const RowExpander: React.FC<{
@@ -12,6 +13,7 @@ export const RowExpander: React.FC<{
         disableRipple={true}
         disableTouchRipple={true}
         size="small"
+        title={titleStrings.expandRow}
         onClick={onClick}
     >
         {expanded ? <ExpandMore /> : <ChevronRight />}

--- a/src/components/Executions/Tables/constants.ts
+++ b/src/components/Executions/Tables/constants.ts
@@ -15,3 +15,8 @@ export const nodeExecutionsTableColumnWidths = {
     phase: 150,
     startedAt: 200
 };
+
+export const titleStrings = {
+    expandRow: 'Expand row',
+    groupName: 'Group name'
+};

--- a/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
+++ b/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
@@ -226,6 +226,14 @@ describe('NodeExecutionsTable', () => {
                 expect(mockListTaskExecutionChildren).not.toHaveBeenCalled();
             });
 
+            it('does not fetch children if flag is false', async () => {
+                mockNodeExecutions[0].metadata = { isParentNode: false };
+                const { getByText } = renderTable();
+                await waitFor(() => getByText(mockNodeExecutions[0].id.nodeId));
+                expect(mockListNodeExecutions).not.toHaveBeenCalled();
+                expect(mockListTaskExecutionChildren).not.toHaveBeenCalled();
+            });
+
             it('correctly renders groups', async () => {
                 const { container } = renderTable();
                 const childGroups = await expandParentNode(container);

--- a/src/components/Executions/TaskExecutionsList/utils.ts
+++ b/src/components/Executions/TaskExecutionsList/utils.ts
@@ -13,7 +13,17 @@ export function getUniqueTaskExecutionName({ id }: TaskExecution) {
     return `${name}${suffix}`;
 }
 
-export function formatRetryAttempt(attempt: number): string {
+export function formatRetryAttempt(
+    attempt: number | string | undefined
+): string {
+    let parsed =
+        typeof attempt === 'number'
+            ? attempt
+            : Number.parseInt(`${attempt}`, 10);
+    if (Number.isNaN(parsed)) {
+        parsed = 0;
+    }
+
     // Retry attempts are zero-based, so incrementing before formatting
-    return `Attempt ${leftPaddedNumber(attempt + 1, 2)}`;
+    return `Attempt ${leftPaddedNumber(parsed + 1, 2)}`;
 }

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -11,6 +11,7 @@ import {
     Execution,
     NodeExecution,
     NodeExecutionIdentifier,
+    NodeExecutionMetadata,
     TaskExecution,
     TaskExecutionIdentifier,
     WorkflowExecutionIdentifier
@@ -47,6 +48,12 @@ export interface NodeInformation {
     node: CompiledNode;
 }
 
+export interface ParentNodeExecution extends NodeExecution {
+    metadata: NodeExecutionMetadata & {
+        isParentNode: true;
+    };
+}
+
 /** An interface combining a NodeExecution with data pulled from the
  * corresponding Workflow Node structure.
  */
@@ -77,6 +84,10 @@ export interface ExecutionDataCache {
     ): GloballyUniqueNode | null | undefined;
     getNodeExecutions(
         workflowExecutionId: WorkflowExecutionIdentifier,
+        config: RequestConfig
+    ): Promise<NodeExecution[]>;
+    getNodeExecutionsForParentNode(
+        id: NodeExecutionIdentifier,
         config: RequestConfig
     ): Promise<NodeExecution[]>;
     getTaskExecutions(

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -80,7 +80,7 @@ export interface DetailedNodeExecutionGroup extends NodeExecutionGroup {
 export interface ExecutionDataCache {
     getNode(id: NodeId): GloballyUniqueNode | undefined;
     getNodeForNodeExecution(
-        nodeExecutionId: NodeExecutionIdentifier
+        nodeExecution: NodeExecution
     ): GloballyUniqueNode | null | undefined;
     getNodeExecutions(
         workflowExecutionId: WorkflowExecutionIdentifier,

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -50,7 +50,7 @@ export interface NodeInformation {
 
 export interface ParentNodeExecution extends NodeExecution {
     metadata: NodeExecutionMetadata & {
-        isParentNode: true;
+        isParentNode: boolean;
     };
 }
 

--- a/src/components/Executions/useChildNodeExecutions.ts
+++ b/src/components/Executions/useChildNodeExecutions.ts
@@ -3,6 +3,7 @@ import { useFetchableData } from 'components/hooks/useFetchableData';
 import { isEqual } from 'lodash';
 import {
     Execution,
+    FilterOperationName,
     NodeExecution,
     RequestConfig,
     TaskExecutionIdentifier,
@@ -12,6 +13,7 @@ import { useContext } from 'react';
 import { ExecutionContext, ExecutionDataCacheContext } from './contexts';
 import { formatRetryAttempt } from './TaskExecutionsList/utils';
 import { ExecutionDataCache, NodeExecutionGroup } from './types';
+import { isParentNodeExecution } from './utils';
 
 interface FetchGroupForTaskExecutionArgs {
     config: RequestConfig;
@@ -109,6 +111,31 @@ async function fetchGroupsForWorkflowExecutionNode({
     return group.nodeExecutions.length > 0 ? [group] : [];
 }
 
+async function fetchGroupsForParentNodeExecution({
+    config,
+    dataCache,
+    nodeExecution
+}: FetchNodeExecutionGroupArgs): Promise<NodeExecutionGroup[]> {
+    const children = await dataCache.getNodeExecutionsForParentNode(
+        nodeExecution.id,
+        config
+    );
+    const groupsByName = children.reduce<Map<string, NodeExecutionGroup>>(
+        (out, child) => {
+            const retryAttempt = formatRetryAttempt(child.metadata?.retryGroup);
+            let group = out.get(retryAttempt);
+            if (!group) {
+                group = { name: retryAttempt, nodeExecutions: [] };
+                out.set(retryAttempt, group);
+            }
+            group.nodeExecutions.push(child);
+            return out;
+        },
+        new Map()
+    );
+    return Array.from(groupsByName.values());
+}
+
 export interface UseChildNodeExecutionsArgs {
     requestConfig: RequestConfig;
     nodeExecution: NodeExecution;
@@ -136,9 +163,14 @@ export function useChildNodeExecutions({
                     nodeExecution: data
                 };
 
-                // Nested NodeExecutions will sometimes have `workflowNodeMetadata` that
-                // points to the parent WorkflowExecution. We're only interested in
-                // showing children if this node is a sub-workflow.
+                // Newer NodeExecution structures can directly indicate their parent
+                // status and have their children fetched in bulk.
+                if (isParentNodeExecution(nodeExecution)) {
+                    return fetchGroupsForParentNodeExecution(fetchArgs);
+                }
+                // Otherwise, we need to determine the type of the node and
+                // recursively fetch NodeExecutions for the corresponding Workflow
+                // or Task executions.
                 if (
                     workflowNodeMetadata &&
                     !isEqual(workflowNodeMetadata.executionId, topExecution.id)

--- a/src/components/Executions/useChildNodeExecutions.ts
+++ b/src/components/Executions/useChildNodeExecutions.ts
@@ -13,7 +13,7 @@ import { useContext } from 'react';
 import { ExecutionContext, ExecutionDataCacheContext } from './contexts';
 import { formatRetryAttempt } from './TaskExecutionsList/utils';
 import { ExecutionDataCache, NodeExecutionGroup } from './types';
-import { isParentNodeExecution } from './utils';
+import { hasParentNodeField } from './utils';
 
 interface FetchGroupForTaskExecutionArgs {
     config: RequestConfig;
@@ -164,9 +164,12 @@ export function useChildNodeExecutions({
                 };
 
                 // Newer NodeExecution structures can directly indicate their parent
-                // status and have their children fetched in bulk.
-                if (isParentNodeExecution(nodeExecution)) {
-                    return fetchGroupsForParentNodeExecution(fetchArgs);
+                // status and have their children fetched in bulk. If the field
+                // is present but false, we can just return an empty list.
+                if (hasParentNodeField(nodeExecution)) {
+                    return nodeExecution.metadata.isParentNode
+                        ? fetchGroupsForParentNodeExecution(fetchArgs)
+                        : [];
                 }
                 // Otherwise, we need to determine the type of the node and
                 // recursively fetch NodeExecutions for the corresponding Workflow

--- a/src/components/Executions/useExecutionDataCache.ts
+++ b/src/components/Executions/useExecutionDataCache.ts
@@ -15,6 +15,7 @@ import {
     GloballyUniqueNode,
     Identifier,
     NodeExecutionIdentifier,
+    nodeExecutionQueryParams,
     NodeId,
     RequestConfig,
     TaskExecutionIdentifier,
@@ -125,6 +126,19 @@ export function createExecutionDataCache(
         return nodeExecutions;
     };
 
+    const getNodeExecutionsForParentNode = async (
+        { executionId, nodeId }: NodeExecutionIdentifier,
+        config: RequestConfig
+    ) => {
+        return getNodeExecutions(executionId, {
+            ...config,
+            params: {
+                ...config.params,
+                [nodeExecutionQueryParams.parentNodeId]: nodeId
+            }
+        });
+    };
+
     const getTaskTemplate = (id: Identifier) => {
         const template = taskTemplatesById.get(getCacheKey(id));
         if (template === undefined) {
@@ -220,6 +234,7 @@ export function createExecutionDataCache(
         getNode,
         getNodeForNodeExecution,
         getNodeExecutions,
+        getNodeExecutionsForParentNode,
         getTaskExecutions,
         getTaskExecutionChildren,
         getTaskTemplate,

--- a/src/components/Executions/utils.ts
+++ b/src/components/Executions/utils.ts
@@ -110,6 +110,10 @@ export const taskExecutionIsTerminal = (taskExecution: TaskExecution) =>
     taskExecution.closure &&
     terminalTaskExecutionStates.includes(taskExecution.closure.phase);
 
+export function getNodeExecutionSpecId(nodeExecution: NodeExecution): string {
+    return nodeExecution.metadata?.specNodeId || nodeExecution.id.nodeId;
+}
+
 /** Populates a NodeExecution with extended information read from an `ExecutionDataCache` */
 export function populateNodeExecutionDetails(
     nodeExecution: NodeExecution,
@@ -118,10 +122,9 @@ export function populateNodeExecutionDetails(
     // Use `spec_node_id` if available to look up the node in the graph (needed to
     // distinguish nodes in sub-workflow scenarios). But this may not exist, so
     // fall back to id.nodeId in those cases.
-    const nodeId =
-        nodeExecution.metadata?.specNodeId || nodeExecution.id.nodeId;
+    const nodeId = getNodeExecutionSpecId(nodeExecution);
     const cacheKey = getCacheKey(nodeExecution.id);
-    const nodeInfo = dataCache.getNodeForNodeExecution(nodeExecution.id);
+    const nodeInfo = dataCache.getNodeForNodeExecution(nodeExecution);
 
     let displayId = nodeId;
     let displayType = NodeExecutionDisplayType.Unknown;

--- a/src/components/Executions/utils.ts
+++ b/src/components/Executions/utils.ts
@@ -228,11 +228,16 @@ function getExecutionTimingMS({
     return { duration: durationMS, queued: queuedMS };
 }
 
-export function isParentNodeExecution(
+/** Indicates the presence of metadata for parent node status. Older executions
+ * may be missing this field and require additional API calls to determine if
+ * their are children.
+ */
+export function hasParentNodeField(
     nodeExecution: NodeExecution
 ): nodeExecution is ParentNodeExecution {
     return (
-        nodeExecution.metadata != null && !!nodeExecution.metadata.isParentNode
+        nodeExecution.metadata != null &&
+        nodeExecution.metadata.isParentNode != null
     );
 }
 

--- a/src/components/Executions/utils.ts
+++ b/src/components/Executions/utils.ts
@@ -32,7 +32,8 @@ import {
     DetailedNodeExecution,
     ExecutionDataCache,
     ExecutionPhaseConstants,
-    NodeExecutionDisplayType
+    NodeExecutionDisplayType,
+    ParentNodeExecution
 } from './types';
 
 /** Given an execution phase, returns a set of constants (i.e. color, display
@@ -114,7 +115,11 @@ export function populateNodeExecutionDetails(
     nodeExecution: NodeExecution,
     dataCache: ExecutionDataCache
 ) {
-    const { nodeId } = nodeExecution.id;
+    // Use `spec_node_id` if available to look up the node in the graph (needed to
+    // distinguish nodes in sub-workflow scenarios). But this may not exist, so
+    // fall back to id.nodeId in those cases.
+    const nodeId =
+        nodeExecution.metadata?.specNodeId || nodeExecution.id.nodeId;
     const cacheKey = getCacheKey(nodeExecution.id);
     const nodeInfo = dataCache.getNodeForNodeExecution(nodeExecution.id);
 
@@ -218,6 +223,14 @@ function getExecutionTimingMS({
         timestampToDate(startedAt).getTime() - createdAtDate.getTime();
 
     return { duration: durationMS, queued: queuedMS };
+}
+
+export function isParentNodeExecution(
+    nodeExecution: NodeExecution
+): nodeExecution is ParentNodeExecution {
+    return (
+        nodeExecution.metadata != null && !!nodeExecution.metadata.isParentNode
+    );
 }
 
 /** Returns timing information (duration, queue time, ...) for a WorkflowExecution */

--- a/src/models/AdminEntity/types.ts
+++ b/src/models/AdminEntity/types.ts
@@ -71,7 +71,7 @@ export interface RequestConfig {
     data?: unknown;
     filter?: FilterOperationList;
     limit?: number;
-    params?: object;
+    params?: Record<string, any>;
     token?: string;
     sort?: Sort;
 }

--- a/src/models/Execution/constants.ts
+++ b/src/models/Execution/constants.ts
@@ -30,4 +30,8 @@ export const executionSortFields = {
     startedAt: 'started_at'
 };
 
+export const nodeExecutionQueryParams = {
+    parentNodeId: 'uniqueParentId'
+};
+
 export const defaultExecutionPrincipal = 'flyteconsole';

--- a/src/models/Execution/types.ts
+++ b/src/models/Execution/types.ts
@@ -81,10 +81,17 @@ export interface NodeExecutionIdentifier extends Core.INodeExecutionIdentifier {
     executionId: WorkflowExecutionIdentifier;
 }
 
+export interface NodeExecutionMetadata extends Admin.INodeExecutionMetaData {
+    retryGroup?: string;
+    isParentNode?: boolean;
+    specNodeId?: string;
+}
+
 export interface NodeExecution extends Admin.INodeExecution {
     id: NodeExecutionIdentifier;
     inputUri: string;
     closure: NodeExecutionClosure;
+    metadata?: NodeExecutionMetadata;
 }
 export interface NodeExecutionClosure extends Admin.INodeExecutionClosure {
     createdAt: Protobuf.ITimestamp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,10 +1855,10 @@
   dependencies:
     core-js "^2.5.7"
 
-"@lyft/flyteidl@^0.18.4":
-  version "0.18.4"
-  resolved "https://registry.yarnpkg.com/@lyft/flyteidl/-/flyteidl-0.18.4.tgz#47177a33e082355a105f8276bfe15cd2388fcb4a"
-  integrity sha512-kQ40KN6ffUogPsQmaoLyVRvrg8tcxVaoVSDiGol4cnspeLxsB6728qBHzQY1oRcOeRBFCRASyImJrbbBVpNXeg==
+"@lyft/flyteidl@^0.18.9":
+  version "0.18.9"
+  resolved "https://registry.yarnpkg.com/@lyft/flyteidl/-/flyteidl-0.18.9.tgz#e8c06a598329de052ca5b539c382749379a93ad7"
+  integrity sha512-BZCAiHpq+JMsd5u2m8UuedlL1E/CQZjDywXnOO27QmNzJv1zdcZ4QDkBU6ClCQQr/KOBszolyfRVY3N//3AG2Q==
 
 "@marionebl/sander@^0.6.0":
   version "0.6.1"
@@ -7057,7 +7057,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -9720,7 +9720,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -11605,11 +11605,6 @@ lodash._basecopy@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
   integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -11618,15 +11613,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -11637,19 +11627,12 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -11770,7 +11753,7 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=


### PR DESCRIPTION
lyft/flyte#438

This builds on the work from lyft/flyteadmin#111 to directly query NodeExecution children for NodeExecutions which use the new `isParent` flag. Most of the work was in the `useChildNodeExecutions` and `useExecutionDataCache` hooks to use the right logic for building a query for the node_executions endpoint.