### PR TITLE
fix: don't skip legacy children check when isParentNode=false

### DIFF
--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -50,7 +50,7 @@ export interface NodeInformation {
 
 export interface ParentNodeExecution extends NodeExecution {
     metadata: NodeExecutionMetadata & {
-        isParentNode: boolean;
+        isParentNode: true;
     };
 }
 

--- a/src/components/Executions/useChildNodeExecutions.ts
+++ b/src/components/Executions/useChildNodeExecutions.ts
@@ -3,7 +3,6 @@ import { useFetchableData } from 'components/hooks/useFetchableData';
 import { isEqual } from 'lodash';
 import {
     Execution,
-    FilterOperationName,
     NodeExecution,
     RequestConfig,
     TaskExecutionIdentifier,
@@ -13,7 +12,7 @@ import { useContext } from 'react';
 import { ExecutionContext, ExecutionDataCacheContext } from './contexts';
 import { formatRetryAttempt } from './TaskExecutionsList/utils';
 import { ExecutionDataCache, NodeExecutionGroup } from './types';
-import { hasParentNodeField } from './utils';
+import { isParentNode } from './utils';
 
 interface FetchGroupForTaskExecutionArgs {
     config: RequestConfig;
@@ -164,12 +163,9 @@ export function useChildNodeExecutions({
                 };
 
                 // Newer NodeExecution structures can directly indicate their parent
-                // status and have their children fetched in bulk. If the field
-                // is present but false, we can just return an empty list.
-                if (hasParentNodeField(nodeExecution)) {
-                    return nodeExecution.metadata.isParentNode
-                        ? fetchGroupsForParentNodeExecution(fetchArgs)
-                        : [];
+                // status and have their children fetched in bulk.
+                if (isParentNode(nodeExecution)) {
+                    return fetchGroupsForParentNodeExecution(fetchArgs);
                 }
                 // Otherwise, we need to determine the type of the node and
                 // recursively fetch NodeExecutions for the corresponding Workflow

--- a/src/components/Executions/utils.ts
+++ b/src/components/Executions/utils.ts
@@ -228,16 +228,12 @@ function getExecutionTimingMS({
     return { duration: durationMS, queued: queuedMS };
 }
 
-/** Indicates the presence of metadata for parent node status. Older executions
- * may be missing this field and require additional API calls to determine if
- * their are children.
- */
-export function hasParentNodeField(
+/** Indicates if a NodeExecution is explicitly marked as a parent node. */
+export function isParentNode(
     nodeExecution: NodeExecution
 ): nodeExecution is ParentNodeExecution {
     return (
-        nodeExecution.metadata != null &&
-        nodeExecution.metadata.isParentNode != null
+        nodeExecution.metadata != null && !!nodeExecution.metadata.isParentNode
     );
 }
 


### PR DESCRIPTION
lyft/flyte#438

In implementing the original changes to use the `isParentNode` flag, I had assumed that the flag would be completely absent. But due to the way protobuf is deserialized, when the metadata object is present, `isParentNode` will default to `false`. This will cause us to incorrectly skip checking for children on legacy node executions by querying the child TaskExecutions first.

So, the logic is now to query directly for child node executions if the flag is true, and fall back to the legacy check otherwise.