### PR TITLE
feat: support Struct as a Launch input type

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -126,3 +126,10 @@ export function toBoolean(value?: string): boolean {
     }
     return ['true', 'True', 'TRUE', '1'].includes(value);
 }
+
+/** Simple shared stringify function to ensure consistency in formatting with
+ * respect to spacing.
+ */
+export function stringifyValue(value: any): string {
+    return JSON.stringify(value, null, 2);
+}

--- a/src/components/Launch/LaunchForm/LaunchFormInputs.tsx
+++ b/src/components/Launch/LaunchForm/LaunchFormInputs.tsx
@@ -4,6 +4,7 @@ import { CollectionInput } from './CollectionInput';
 import { formStrings } from './constants';
 import { LaunchState } from './launchMachine';
 import { SimpleInput } from './SimpleInput';
+import { StructInput } from './StructInput';
 import { useStyles } from './styles';
 import {
     BaseInterpretedLaunchState,
@@ -22,6 +23,8 @@ function getComponentForInput(input: InputProps, showErrors: boolean) {
             return <BlobInput {...props} />;
         case InputType.Collection:
             return <CollectionInput {...props} />;
+        case InputType.Struct:
+            return <StructInput {...props} />;
         case InputType.Map:
         case InputType.Unknown:
         case InputType.None:

--- a/src/components/Launch/LaunchForm/StructInput.tsx
+++ b/src/components/Launch/LaunchForm/StructInput.tsx
@@ -1,0 +1,38 @@
+import { TextField } from '@material-ui/core';
+import * as React from 'react';
+import { InputChangeHandler, InputProps } from './types';
+import { getLaunchInputId } from './utils';
+
+function stringChangeHandler(onChange: InputChangeHandler) {
+    return ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+        onChange(value);
+    };
+}
+
+/** Handles rendering of the input component for a Struct */
+export const StructInput: React.FC<InputProps> = props => {
+    const {
+        error,
+        label,
+        name,
+        onChange,
+        typeDefinition: { subtype },
+        value = ''
+    } = props;
+    const hasError = !!error;
+    const helperText = hasError ? error : props.helperText;
+    return (
+        <TextField
+            id={getLaunchInputId(name)}
+            error={hasError}
+            helperText={helperText}
+            fullWidth={true}
+            label={label}
+            multiline={true}
+            onChange={stringChangeHandler(onChange)}
+            rowsMax={8}
+            value={value}
+            variant="outlined"
+        />
+    );
+};

--- a/src/components/Launch/LaunchForm/inputHelpers/constants.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/constants.ts
@@ -9,6 +9,7 @@ export const allowedDateFormats = [ISO_8601, RFC_2822];
 
 const primitivePath = 'scalar.primitive';
 export const schemaUriPath = 'scalar.schema.uri';
+export const structPath = 'scalar.generic';
 
 /** Strings constants which can be used to perform a deep `get` on a scalar
  * literal type using a primitive value.

--- a/src/components/Launch/LaunchForm/inputHelpers/getHelperForInput.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/getHelperForInput.ts
@@ -9,6 +9,7 @@ import { integerHelper } from './integer';
 import { noneHelper } from './none';
 import { schemaHelper } from './schema';
 import { stringHelper } from './string';
+import { structHelper } from './struct';
 import { InputHelper } from './types';
 
 const unsupportedHelper = noneHelper;
@@ -28,7 +29,7 @@ const inputHelpers: Record<InputType, InputHelper> = {
     [InputType.None]: noneHelper,
     [InputType.Schema]: schemaHelper,
     [InputType.String]: stringHelper,
-    [InputType.Struct]: unsupportedHelper,
+    [InputType.Struct]: structHelper,
     [InputType.Unknown]: unsupportedHelper
 };
 

--- a/src/components/Launch/LaunchForm/inputHelpers/struct.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/struct.ts
@@ -1,0 +1,140 @@
+import { Core, Protobuf } from 'flyteidl';
+import { InputValue } from '../types';
+import { structPath } from './constants';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
+import { extractLiteralWithCheck } from './utils';
+
+type PrimitiveType = string | number | boolean | null | object;
+
+function asValueWithKind(value: Protobuf.IValue): Protobuf.Value {
+    return value instanceof Protobuf.Value
+        ? value
+        : Protobuf.Value.create(value);
+}
+
+function protobufValueToPrimitive(
+    value: Protobuf.IValue
+): PrimitiveType | PrimitiveType[] {
+    const valueWithKind = asValueWithKind(value);
+    const { kind } = valueWithKind;
+    switch (kind) {
+        case 'structValue':
+            if (valueWithKind.structValue == null) {
+                throw new Error('Unexpected empty structValue field');
+            }
+            return protobufStructToObject(valueWithKind.structValue);
+        case 'listValue':
+            if (valueWithKind.listValue == null) {
+                throw new Error('Unexpected empty listValue field');
+            }
+            return protobufListToArray(valueWithKind.listValue);
+        case undefined:
+            throw new Error('Unexpected missing Value.kind');
+        default:
+            return valueWithKind[kind];
+    }
+}
+
+function primitiveToProtobufValue(value: any): Protobuf.IValue {
+    if (value == null) {
+        return { nullValue: Protobuf.NullValue.NULL_VALUE };
+    }
+    if (Array.isArray(value)) {
+        return { listValue: { values: value.map(primitiveToProtobufValue) } };
+    }
+    switch (typeof value) {
+        case 'boolean':
+            return { boolValue: !!value };
+        case 'number':
+            return { numberValue: value };
+        case 'string':
+            return { stringValue: value };
+        case 'object':
+            return { structValue: objectToProtobufStruct(value) };
+        default:
+            throw new Error(`Unsupported value type: ${typeof value} `);
+    }
+}
+
+function protobufListToArray(list: Protobuf.IListValue): PrimitiveType[] {
+    if (!list.values) {
+        return [];
+    }
+
+    return list.values.map(protobufValueToPrimitive);
+}
+
+function protobufStructToObject(struct: Protobuf.IStruct): Dictionary<any> {
+    if (struct.fields == null) {
+        return {};
+    }
+
+    return Object.entries(struct.fields).reduce<Dictionary<any>>(
+        (out, [key, value]) => {
+            out[key] = protobufValueToPrimitive(value);
+            return out;
+        },
+        {}
+    );
+}
+
+function objectToProtobufStruct(obj: Dictionary<any>): Protobuf.IStruct {
+    const fields = Object.entries(obj).reduce<Record<string, Protobuf.IValue>>(
+        (out, [key, value]) => {
+            try {
+                out[key] = primitiveToProtobufValue(value);
+                return out;
+            } catch (e) {
+                throw new Error(
+                    `Failed to convert value ${key} to Protobuf.Value: ${e}`
+                );
+            }
+        },
+        {}
+    );
+
+    return { fields };
+}
+
+function fromLiteral(literal: Core.ILiteral): InputValue {
+    const structValue = extractLiteralWithCheck<Protobuf.IStruct>(
+        literal,
+        structPath
+    );
+
+    return JSON.stringify(protobufStructToObject(structValue), null, 2);
+}
+
+function toLiteral({ value }: ConverterInput): Core.ILiteral {
+    const stringValue = typeof value === 'string' ? value : value.toString();
+
+    let parsedObject: Dictionary<any>;
+    try {
+        parsedObject = JSON.parse(stringValue);
+        if (typeof parsedObject !== 'object') {
+            throw new Error(`Result was of type: ${typeof parsedObject}`);
+        }
+    } catch (e) {
+        throw new Error(`Value did not parse to an object`);
+    }
+
+    return { scalar: { generic: objectToProtobufStruct(parsedObject) } };
+}
+
+function validate({ value }: InputValidatorParams) {
+    if (typeof value !== 'string') {
+        throw new Error('Value is not a string');
+    }
+
+    try {
+        JSON.parse(value);
+    } catch (e) {
+        throw new Error(`Value did not parse to an object: ${e}`);
+    }
+}
+
+export const structHelper: InputHelper = {
+    fromLiteral,
+    toLiteral,
+    validate
+};

--- a/src/components/Launch/LaunchForm/inputHelpers/test/structTestCases.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/test/structTestCases.ts
@@ -1,0 +1,109 @@
+import { Core, Protobuf } from 'flyteidl';
+import { literalNone } from '../constants';
+
+export function structLiteral(generic: Protobuf.IStruct): Core.ILiteral {
+    return { scalar: { generic } };
+}
+
+const values = {
+    stringField: 'aString',
+    integerField: 123,
+    floatField: 123.456,
+    nullField: null,
+    undefinedField: undefined,
+    booleanTrueField: true,
+    booleanFalseField: false
+};
+
+const structValues: { [k in keyof typeof values]: Protobuf.IValue } = {
+    stringField: { stringValue: 'aString' },
+    integerField: { numberValue: 123 },
+    floatField: { numberValue: 123.456 },
+    nullField: { nullValue: Protobuf.NullValue.NULL_VALUE },
+    undefinedField: { nullValue: Protobuf.NullValue.NULL_VALUE },
+    booleanTrueField: { boolValue: true },
+    booleanFalseField: { boolValue: false }
+};
+
+type StructTestCase = [string, Core.ILiteral];
+export const structTestCases: StructTestCase[] = [
+    ['{}', structLiteral({})],
+    // simple case with no lists or nested structs
+    [
+        JSON.stringify({ ...values }),
+        structLiteral({ fields: { ...structValues } })
+    ],
+    // Nested struct value
+    [
+        JSON.stringify({ nestedStruct: { ...values } }),
+        structLiteral({
+            fields: {
+                nestedStruct: { structValue: { fields: { ...structValues } } }
+            }
+        })
+    ],
+    // List
+    [
+        JSON.stringify({ listField: Object.values(values) }),
+        structLiteral({
+            fields: {
+                listField: {
+                    listValue: { values: Object.values(structValues) }
+                }
+            }
+        })
+    ],
+    // Nested struct with list
+    [
+        JSON.stringify({ nestedStruct: { listField: Object.values(values) } }),
+        structLiteral({
+            fields: {
+                nestedStruct: {
+                    structValue: {
+                        fields: {
+                            listField: {
+                                listValue: {
+                                    values: Object.values(structValues)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    ],
+    // List with nested struct
+    [
+        JSON.stringify({ listField: [{ ...values }] }),
+        structLiteral({
+            fields: {
+                listField: {
+                    listValue: {
+                        values: [
+                            { structValue: { fields: { ...structValues } } }
+                        ]
+                    }
+                }
+            }
+        })
+    ],
+    // List with nested list
+    [
+        JSON.stringify({ listField: [[Object.values(values)]] }),
+        structLiteral({
+            fields: {
+                listField: {
+                    listValue: {
+                        values: [
+                            {
+                                listValue: {
+                                    values: Object.values(structValues)
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        })
+    ]
+];

--- a/src/components/Launch/LaunchForm/inputHelpers/test/structTestCases.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/test/structTestCases.ts
@@ -1,5 +1,5 @@
+import { stringifyValue } from 'common/utils';
 import { Core, Protobuf } from 'flyteidl';
-import { literalNone } from '../constants';
 
 export function structLiteral(generic: Protobuf.IStruct): Core.ILiteral {
     return { scalar: { generic } };
@@ -10,7 +10,6 @@ const values = {
     integerField: 123,
     floatField: 123.456,
     nullField: null,
-    undefinedField: undefined,
     booleanTrueField: true,
     booleanFalseField: false
 };
@@ -20,22 +19,21 @@ const structValues: { [k in keyof typeof values]: Protobuf.IValue } = {
     integerField: { numberValue: 123 },
     floatField: { numberValue: 123.456 },
     nullField: { nullValue: Protobuf.NullValue.NULL_VALUE },
-    undefinedField: { nullValue: Protobuf.NullValue.NULL_VALUE },
     booleanTrueField: { boolValue: true },
     booleanFalseField: { boolValue: false }
 };
 
 type StructTestCase = [string, Core.ILiteral];
 export const structTestCases: StructTestCase[] = [
-    ['{}', structLiteral({})],
+    ['{}', structLiteral({ fields: {} })],
     // simple case with no lists or nested structs
     [
-        JSON.stringify({ ...values }),
+        stringifyValue({ ...values }),
         structLiteral({ fields: { ...structValues } })
     ],
     // Nested struct value
     [
-        JSON.stringify({ nestedStruct: { ...values } }),
+        stringifyValue({ nestedStruct: { ...values } }),
         structLiteral({
             fields: {
                 nestedStruct: { structValue: { fields: { ...structValues } } }
@@ -44,7 +42,7 @@ export const structTestCases: StructTestCase[] = [
     ],
     // List
     [
-        JSON.stringify({ listField: Object.values(values) }),
+        stringifyValue({ listField: Object.values(values) }),
         structLiteral({
             fields: {
                 listField: {
@@ -55,7 +53,7 @@ export const structTestCases: StructTestCase[] = [
     ],
     // Nested struct with list
     [
-        JSON.stringify({ nestedStruct: { listField: Object.values(values) } }),
+        stringifyValue({ nestedStruct: { listField: Object.values(values) } }),
         structLiteral({
             fields: {
                 nestedStruct: {
@@ -74,7 +72,7 @@ export const structTestCases: StructTestCase[] = [
     ],
     // List with nested struct
     [
-        JSON.stringify({ listField: [{ ...values }] }),
+        stringifyValue({ listField: [{ ...values }] }),
         structLiteral({
             fields: {
                 listField: {
@@ -89,7 +87,7 @@ export const structTestCases: StructTestCase[] = [
     ],
     // List with nested list
     [
-        JSON.stringify({ listField: [[Object.values(values)]] }),
+        stringifyValue({ listField: [Object.values(values)] }),
         structLiteral({
             fields: {
                 listField: {

--- a/src/components/Launch/LaunchForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/test/testCases.ts
@@ -201,7 +201,6 @@ export const validityTestCases = {
     // schema is just a specialized string input, so it has the same validity cases as string
     schema: { invalid: [123, true, new Date(), {}], valid: ['', 'abcdefg'] },
     string: { invalid: [123, true, new Date(), {}], valid: ['', 'abcdefg'] },
-    // TODO-NOW
     struct: {
         invalid: [
             123,

--- a/src/components/Launch/LaunchForm/inputHelpers/test/testCases.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/test/testCases.ts
@@ -1,4 +1,8 @@
-import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
+import {
+    dateToTimestamp,
+    millisecondsToDuration,
+    stringifyValue
+} from 'common/utils';
 import { Core } from 'flyteidl';
 import * as Long from 'long';
 import { BlobDimensionality, SchemaColumnType } from 'models';
@@ -8,7 +12,7 @@ import { literalNone } from '../constants';
 import { structTestCases } from './structTestCases';
 
 // Defines type of value, input, and expected value of a `Core.ILiteral`
-type LiteralTestParams = [InputTypeDefinition, any, Core.ILiteral];
+type InputToLiteralTestParams = [InputTypeDefinition, any, Core.ILiteral];
 
 type InputTypeKey =
     | 'binary'
@@ -210,7 +214,7 @@ export const validityTestCases = {
         ],
         valid: [
             // Valid use case is any stringified POJO
-            JSON.stringify({
+            stringifyValue({
                 someString: 'someValue',
                 someNumber: 123,
                 someBoolean: true,
@@ -224,7 +228,7 @@ export const validityTestCases = {
 
 /** Test cases for converting a *valid* input value to its corresponding ILiteral
  * representation. */
-export const literalTestCases: LiteralTestParams[] = [
+export const literalTestCases: InputToLiteralTestParams[] = [
     [inputTypes.boolean, true, primitiveLiteral({ boolean: true })],
     [inputTypes.boolean, 'true', primitiveLiteral({ boolean: true })],
     [inputTypes.boolean, 't', primitiveLiteral({ boolean: true })],
@@ -461,21 +465,23 @@ export const literalTestCases: LiteralTestParams[] = [
     ],
     // Blob which is not an object (results in None)
     [inputTypes.blobMulti, undefined, literalNone()],
-    ...structTestCases.map<LiteralTestParams>(([stringValue, literalValue]) => [
-        inputTypes.struct,
-        stringValue,
-        literalValue
-    ])
+    ...structTestCases.map<InputToLiteralTestParams>(
+        ([stringValue, literalValue]) => [
+            inputTypes.struct,
+            stringValue,
+            literalValue
+        ]
+    )
 ];
 
-type InputToLiteralTestParams = [
+type LiteralToInputTestParams = [
     InputTypeDefinition,
     Core.ILiteral,
     InputValue | undefined
 ];
 
 /** Test cases for converting a Core.ILiteral to a usable InputValue */
-export const literalToInputTestCases: InputToLiteralTestParams[] = [
+export const literalToInputTestCases: LiteralToInputTestParams[] = [
     [inputTypes.boolean, primitiveLiteral({ boolean: true }), true],
     [inputTypes.boolean, primitiveLiteral({ boolean: false }), false],
     [
@@ -609,7 +615,7 @@ export const literalToInputTestCases: InputToLiteralTestParams[] = [
             uri: 's3://somePath'
         }
     ],
-    ...structTestCases.map<InputToLiteralTestParams>(
+    ...structTestCases.map<LiteralToInputTestParams>(
         ([stringValue, literalValue]) => [
             inputTypes.struct,
             literalValue,

--- a/src/components/Launch/LaunchForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/utils.ts
@@ -38,7 +38,6 @@ export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
         case InputType.Error:
         case InputType.Map:
         case InputType.None:
-        case InputType.Struct:
         case InputType.Unknown:
             return false;
         case InputType.Boolean:
@@ -49,6 +48,7 @@ export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
         case InputType.Integer:
         case InputType.Schema:
         case InputType.String:
+        case InputType.Struct:
             return true;
         case InputType.Collection: {
             if (!subtype) {

--- a/src/components/Launch/LaunchForm/inputHelpers/utils.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/utils.ts
@@ -1,4 +1,4 @@
-import { assertNever } from 'common/utils';
+import { assertNever, stringifyValue } from 'common/utils';
 import { Core } from 'flyteidl';
 import { get } from 'lodash';
 import { BlobDimensionality } from 'models';
@@ -25,7 +25,9 @@ export function collectionChildToString(type: InputType, value: any) {
     if (value === undefined) {
         return '';
     }
-    return type === InputType.Integer ? `${value}` : JSON.stringify(value);
+    return type === (InputType.Integer || InputType.Struct)
+        ? `${value}`
+        : stringifyValue(value);
 }
 
 /** Determines if a given input type, including all levels of nested types, is

--- a/src/components/common/DumpJSON.tsx
+++ b/src/components/common/DumpJSON.tsx
@@ -1,11 +1,10 @@
+import { stringifyValue } from 'common/utils';
 import { useCommonStyles } from 'components/common/styles';
 import * as React from 'react';
 
 export const DumpJSON: React.FC<{ value: any }> = ({ value }) => {
     const commonStyles = useCommonStyles();
     return (
-        <div className={commonStyles.codeBlock}>
-            {JSON.stringify(value, null, 2)}
-        </div>
+        <div className={commonStyles.codeBlock}>{stringifyValue(value)}</div>
     );
 };


### PR DESCRIPTION
# TL;DR
This adds support for our `Struct` input type, which is essentially just a `Protobuf.Struct` object. Users will enter this value as a JSON object string, which will then be parsed and converted to a Protobuf.Struct object using the appropriate types for resulting values.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?
 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Added inputHelper code for converting between a JSON object string and a `Struct` Literal.
* Updated code for type support to allow `Structs`.
* Added a component for entering a `Struct` value, which is similar to a `Collection` in that it is a multi-line string input.
* Added test cases, which involved some refactoring of the unit tests to correctly format the input values and expected outputs.
* Added a simple wrapper for `JSON.stringify` to ensure consistent formatting (2 spaces) and updated relevant code to use that instead of `JSON.stringify` directly

## Tracking Issue
https://github.com/lyft/flyte/issues/22

## Follow-up issue
_NA_

![image](https://user-images.githubusercontent.com/1815175/97045552-c605a300-152a-11eb-81cd-ab4cf6516b6f.png)
