### PR TITLE
fix: unable to submit after fixing validation errors

### DIFF
--- a/src/components/Launch/LaunchForm/launchMachine.ts
+++ b/src/components/Launch/LaunchForm/launchMachine.ts
@@ -285,7 +285,8 @@ const baseStateConfig: StatesConfig<
     },
     [LaunchState.INVALID_INPUTS]: {
         on: {
-            VALIDATE: LaunchState.VALIDATING_INPUTS
+            VALIDATE: LaunchState.VALIDATING_INPUTS,
+            SUBMIT: LaunchState.SUBMIT_VALIDATING
         }
     },
     [LaunchState.SUBMIT_VALIDATING]: {

--- a/src/components/Launch/LaunchForm/test/LaunchTaskForm.test.tsx
+++ b/src/components/Launch/LaunchForm/test/LaunchTaskForm.test.tsx
@@ -246,6 +246,30 @@ describe('LaunchForm: Task', () => {
             await waitFor(() => expect(integerInput).toBeValid());
         });
 
+        it('should allow submission after fixing validation errors', async () => {
+            const { container, getByLabelText } = renderForm();
+            await waitFor(() => {});
+
+            const integerInput = await waitFor(() =>
+                getByLabelText(integerInputName, {
+                    exact: false
+                })
+            );
+            fillInputs(container);
+            const submitButton = getSubmitButton(container);
+            fireEvent.change(integerInput, { target: { value: 'abc' } });
+            fireEvent.click(submitButton);
+            await waitFor(() => expect(integerInput).toBeInvalid());
+            expect(mockCreateWorkflowExecution).not.toHaveBeenCalled();
+
+            fireEvent.change(integerInput, { target: { value: '123' } });
+            await waitFor(() => expect(integerInput).toBeValid());
+            fireEvent.click(submitButton);
+            await waitFor(() =>
+                expect(mockCreateWorkflowExecution).toHaveBeenCalled()
+            );
+        });
+
         it('should update inputs when selecting a new task version', async () => {
             const { queryByLabelText, getByTitle } = renderForm();
             const taskVersionDiv = await waitFor(() =>

--- a/src/components/Launch/LaunchForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchForm/test/LaunchWorkflowForm.test.tsx
@@ -302,6 +302,29 @@ describe('LaunchForm: Workflow', () => {
             expect(integerInput).toBeValid();
         });
 
+        it('should allow submission after fixing validation errors', async () => {
+            const { container, getByLabelText } = renderForm();
+            await waitFor(() => {});
+
+            const integerInput = await waitFor(() =>
+                getByLabelText(integerInputName, {
+                    exact: false
+                })
+            );
+            const submitButton = getSubmitButton(container);
+            fireEvent.change(integerInput, { target: { value: 'abc' } });
+            fireEvent.click(submitButton);
+            await waitFor(() => expect(integerInput).toBeInvalid());
+            expect(mockCreateWorkflowExecution).not.toHaveBeenCalled();
+
+            fireEvent.change(integerInput, { target: { value: '123' } });
+            await waitFor(() => expect(integerInput).toBeValid());
+            fireEvent.click(submitButton);
+            await waitFor(() =>
+                expect(mockCreateWorkflowExecution).toHaveBeenCalled()
+            );
+        });
+
         it('should update launch plan when selecting a new workflow version', async () => {
             const { getByTitle } = renderForm();
             await waitFor(() => getByTitle(formStrings.launchPlan));


### PR DESCRIPTION
# TL;DR
There was a missing state transition between the invalid inputs state and the submission/validation state, causing the state machine to do nothing when attempting to submit after fixing validation errors. The fix just required adding an allowed state transition and corresponding unit tests.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?
 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
_N/A_

## Tracking Issue
https://github.com/lyft/flyte/issues/565