### PR TITLE
fix: stale selected item reference in NE details panel

### DIFF
--- a/src/components/Executions/Tables/useNodeExecutionsTableState.ts
+++ b/src/components/Executions/Tables/useNodeExecutionsTableState.ts
@@ -28,9 +28,7 @@ export function useNodeExecutionsTableState({
 
     const setSelectedExecution = useMemo(
         () => (newValue: DetailedNodeExecution | null) =>
-            setSelectedExecutionKey(
-                newValue == null ? null : newValue.cacheKey ?? null
-            ),
+            setSelectedExecutionKey(newValue?.cacheKey ?? null),
         [setSelectedExecutionKey]
     );
 

--- a/src/components/Executions/Tables/useNodeExecutionsTableState.ts
+++ b/src/components/Executions/Tables/useNodeExecutionsTableState.ts
@@ -14,10 +14,25 @@ export function useNodeExecutionsTableState({
         [value]
     );
 
-    const [
-        selectedExecution,
-        setSelectedExecution
-    ] = useState<DetailedNodeExecution | null>(null);
+    const [selectedExecutionKey, setSelectedExecutionKey] = useState<
+        string | null
+    >(null);
+
+    const selectedExecution = useMemo(
+        () =>
+            executions.find(
+                ({ cacheKey }) => cacheKey === selectedExecutionKey
+            ) || null,
+        [executions, selectedExecutionKey]
+    );
+
+    const setSelectedExecution = useMemo(
+        () => (newValue: DetailedNodeExecution | null) =>
+            setSelectedExecutionKey(
+                newValue == null ? null : newValue.cacheKey ?? null
+            ),
+        [setSelectedExecutionKey]
+    );
 
     return {
         executions,

--- a/src/components/common/DetailsPanel.tsx
+++ b/src/components/common/DetailsPanel.tsx
@@ -41,6 +41,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
     return (
         <Drawer
             anchor="right"
+            data-testid="details-panel"
             ModalProps={{
                 className: styles.modal,
                 hideBackdrop: true,


### PR DESCRIPTION
# TL;DR
Fixes an issue where status of a NodeExecution doesn't update in the DetailsPanel if you have the panel open when the status changes.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?
 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We were assigning the selected item for the Details Panel using an object reference, instead of an id reference. When the node executions update, new copies of the items are returned. But the DetailsPanel was still rendering the previously referenced object. To fix it, I updated the state tracking the selected item to be by id / cache key and am now computing the object to return using a memoized `find` call on the array of executions whenever the array or the selected id change.
Also added a test to cover the regression.

## Tracking Issue
https://github.com/lyft/flyte/issues/505

## Follow-up issue
_NA_