### PR TITLE
fix: recompute row heights when new items are appended to DataList

### DIFF
--- a/src/components/Executions/Tables/WorkflowExecutionsTable.tsx
+++ b/src/components/Executions/Tables/WorkflowExecutionsTable.tsx
@@ -239,7 +239,7 @@ export const WorkflowExecutionsTable: React.FC<WorkflowExecutionsTableProps> = p
     const listRef = React.useRef<DataListRef>(null);
 
     // Reset error expansion states whenever list changes
-    React.useEffect(() => {
+    React.useLayoutEffect(() => {
         setExpandedErrors({});
     }, [executions]);
 


### PR DESCRIPTION
# TL;DR
When the last item in the list is larger than the default row size, appending more items to the list will cause the next item to bleed into the previously last item. This is because react-virtualized has the wrong value for the height of the row and hasn't been told to recompute it.

*Note*: There is no accompanying test for this change because testing the DataList component is prohibitively difficult due to the use of `CellMeasurer` and `Autosizer` from the `react-virtualized` package. I manually verified the fix.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?
 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
When starting with a list of length `n`, the item at row index `n+1` is our "load more" row. We use a `CellMeasurerCache` to keep track of the heights of each row, and allow `react-virtualized` to computer the heights using a `CellMeasurer`. The starting height of the last row will be the height of our "load more" row. When we append more items, the first item in the newly-appended list will not be measured because we already have a height for it (previously computed using the "load more" row). To account for this, we are now using a layout effect that fires when the list length changes, and will force a recompute for the first item in the newly appended list if our list length is _increasing_.

## Tracking Issue
https://github.com/lyft/flyte/issues/507

## Follow-up issue
_NA_
