### PR TITLE
fix: handle null LiteralMap in RemoteLiteralMapViewer

### DIFF
--- a/src/components/Executions/ExecutionDetails/test/RelaunchExecutionForm.test.tsx
+++ b/src/components/Executions/ExecutionDetails/test/RelaunchExecutionForm.test.tsx
@@ -84,7 +84,9 @@ describe('RelaunchExecutionForm', () => {
         task = createMockTask('MyTask');
         executionData = {
             inputs: { url: 'http://somePath', bytes: long(1000) },
-            outputs: {}
+            outputs: {},
+            fullInputs: null,
+            fullOutputs: null
         };
 
         mockGetWorkflow = jest.fn().mockResolvedValue(workflow);

--- a/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
+++ b/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
@@ -47,7 +47,13 @@ const nodeRetryAttempts = {
 
 const apiContext = mockAPIContextValue({
     getExecution: () => Promise.resolve(workflowExecution),
-    getNodeExecutionData: () => Promise.resolve({ inputs: {}, outputs: {} }),
+    getNodeExecutionData: () =>
+        Promise.resolve({
+            inputs: {},
+            outputs: {},
+            fullInputs: null,
+            fullOutputs: null
+        }),
     listTaskExecutions: nodeExecutionId => {
         const length = nodeRetryAttempts[nodeExecutionId.nodeId] || 1;
         const entities = Array.from({ length }, (_, retryAttempt) =>

--- a/src/components/Launch/LaunchForm/__stories__/LaunchForm.stories.tsx
+++ b/src/components/Launch/LaunchForm/__stories__/LaunchForm.stories.tsx
@@ -67,7 +67,9 @@ const generateMocks = (variables: Record<string, Variable>) => {
 
     const mockExecutionData: ExecutionData = {
         inputs: { url: 'inputsUrl', bytes: Long.fromNumber(1000) },
-        outputs: { url: 'outputsUrl', bytes: Long.fromNumber(1000) }
+        outputs: { url: 'outputsUrl', bytes: Long.fromNumber(1000) },
+        fullInputs: null,
+        fullOutputs: null
     };
 
     const mockExecutionInputs: LiteralMap = Object.keys(

--- a/src/components/Literals/RemoteLiteralMapViewer.tsx
+++ b/src/components/Literals/RemoteLiteralMapViewer.tsx
@@ -28,7 +28,7 @@ const BlobTooLarge: React.FC<{ url: string }> = ({ url }) => (
  */
 export const RemoteLiteralMapViewer: React.FC<{
     blob: UrlBlob;
-    map?: LiteralMap;
+    map: LiteralMap | null;
 }> = ({ blob, map }) => {
     if (!blob.url || !blob.bytes) {
         return (
@@ -38,7 +38,7 @@ export const RemoteLiteralMapViewer: React.FC<{
         );
     }
 
-    if (map !== undefined) {
+    if (map != null) {
         return <LiteralMapViewer map={map} />;
     }
 

--- a/src/components/Literals/test/RemoteLiteralMapViewer.test.tsx
+++ b/src/components/Literals/test/RemoteLiteralMapViewer.test.tsx
@@ -18,7 +18,7 @@ describe('RemoteLiteralMapViewer', () => {
         };
 
         const { getAllByText } = render(
-            <RemoteLiteralMapViewer map={undefined} blob={blob} />
+            <RemoteLiteralMapViewer map={null} blob={blob} />
         );
 
         const items = getAllByText('No data is available.');
@@ -45,7 +45,7 @@ describe('RemoteLiteralMapViewer', () => {
         expect(items.length).toBe(1);
     });
 
-    it('fetches blob if map is undefined', () => {
+    it('fetches blob if map is null', () => {
         const map: LiteralMap = {
             literals: {
                 input1: {}
@@ -65,7 +65,7 @@ describe('RemoteLiteralMapViewer', () => {
         };
 
         const { getAllByText } = render(
-            <RemoteLiteralMapViewer map={undefined} blob={blob} />
+            <RemoteLiteralMapViewer map={null} blob={blob} />
         );
 
         const items = getAllByText('input1:');

--- a/src/models/Execution/api.ts
+++ b/src/models/Execution/api.ts
@@ -65,7 +65,9 @@ export const getExecution = (
 
 const emptyExecutionData: ExecutionData = {
     inputs: {},
-    outputs: {}
+    outputs: {},
+    fullInputs: null,
+    fullOutputs: null
 };
 /** Fetches data URLs for an `Execution` record */
 export const getExecutionData = (

--- a/src/models/Execution/types.ts
+++ b/src/models/Execution/types.ts
@@ -132,6 +132,6 @@ export interface TaskExecutionClosure extends Admin.ITaskExecutionClosure {
 export interface ExecutionData {
     inputs: UrlBlob;
     outputs: UrlBlob;
-    fullInputs?: LiteralMap;
-    fullOutputs?: LiteralMap;
+    fullInputs: LiteralMap | null;
+    fullOutputs: LiteralMap | null;
 }


### PR DESCRIPTION
# TL;DR
Handle null LiteralMap in RemoteLiteralMapViewer

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Not sure I completely understand how proto objects translate to JS objects. There are cases when `fullInputs` and `fullOutputs` are equal to null. Pull request adds a null check that complements the existing undefined check.

