### PR TITLE
fix: use one-based day of week for aws cron expressions

### DIFF
--- a/src/common/formatters.ts
+++ b/src/common/formatters.ts
@@ -1,11 +1,7 @@
 import cronstrue from 'cronstrue';
 import { Admin, Protobuf } from 'flyteidl';
 import * as moment from 'moment-timezone';
-import {
-    subSecondString,
-    unknownValueString,
-    zeroSecondsString
-} from './constants';
+import { unknownValueString, zeroSecondsString } from './constants';
 import { timezone } from './timezone';
 import { durationToMilliseconds, isValidDate } from './utils';
 
@@ -202,7 +198,9 @@ export function getScheduleFrequencyString(schedule?: Admin.ISchedule) {
     if (schedule.cronExpression) {
         // Need to add a leading 0 to get a valid CRON expression, because
         // ISchedule is using AWS-style expressions, which don't allow a `seconds` position
-        return cronstrue.toString(`0 ${schedule.cronExpression}`);
+        return cronstrue.toString(`0 ${schedule.cronExpression}`, {
+            dayOfWeekStartIndexZero: false
+        });
     }
     if (schedule.rate) {
         return fixedRateToString(schedule.rate);

--- a/src/common/test/formatters.spec.ts
+++ b/src/common/test/formatters.spec.ts
@@ -1,11 +1,7 @@
 import { millisecondsToDuration } from 'common/utils';
 import { Admin } from 'flyteidl';
 import * as moment from 'moment-timezone';
-import {
-    subSecondString,
-    unknownValueString,
-    zeroSecondsString
-} from '../constants';
+import { unknownValueString, zeroSecondsString } from '../constants';
 import {
     dateDiffString,
     dateFromNow,
@@ -199,6 +195,7 @@ describe('getScheduleFrequencyString', () => {
     // input and expected result
     const cases: [Admin.ISchedule, string][] = [
         [{ cronExpression: '* * * * *' }, 'Every minute'],
+        [{ cronExpression: '0 20 ? * 3 *' }, 'At 08:00 PM, only on Tuesday'],
         [
             { rate: { value: 1, unit: Admin.FixedRateUnit.MINUTE } },
             'Every 1 minutes'


### PR DESCRIPTION
# TL;DR
Fixed a display issue for [AWS-style cron expressions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions) using an integer day-of-week field. We need to parse those expressions using a one-based index.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?
 - [x] Code completed
 - [x] Unit tests added

## Tracking Issue
https://github.com/lyft/flyte/issues/616

## Follow-up issue
_NA_