### PR TITLE
fix: convert empty array literals to empty collection literals

### DIFF
--- a/src/components/Launch/LaunchForm/inputHelpers/collection.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/collection.ts
@@ -64,9 +64,6 @@ function toLiteral({
             return literalNone();
         }
         parsed = parseCollection(stringValue);
-        if (!parsed.length) {
-            return literalNone();
-        }
     }
 
     const helper = getHelperForInput(subtype.type);

--- a/src/components/Launch/LaunchForm/inputHelpers/test/inputHelpers.test.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/test/inputHelpers.test.ts
@@ -1,7 +1,7 @@
 import { stringifyValue } from 'common/utils';
 import { Core } from 'flyteidl';
 import * as Long from 'long';
-import { BlobDimensionality } from 'models';
+import { BlobDimensionality, SimpleType } from 'models';
 import {
     collectionInputTypeDefinition,
     nestedCollectionInputTypeDefinition,
@@ -206,6 +206,34 @@ describe('inputToLiteral', () => {
                     result.collection!.literals![0].collection!.literals![0]
                 ).toEqual(output);
             });
+        });
+
+        it('should convert empty array string literal to empty collection', () => {
+            const input = makeCollectionInput(
+                {
+                    type: InputType.String,
+                    literalType: { simple: SimpleType.STRING }
+                },
+                '[]'
+            );
+            const expected: Core.ILiteral = {
+                collection: { literals: [] }
+            };
+            expect(inputToLiteral(input)).toEqual(expected);
+        });
+
+        it('should convert nested empty array string literal to nested empty collection', () => {
+            const input = makeNestedCollectionInput(
+                {
+                    type: InputType.String,
+                    literalType: { simple: SimpleType.STRING }
+                },
+                '[[]]'
+            );
+            const expected: Core.ILiteral = {
+                collection: { literals: [{ collection: { literals: [] } }] }
+            };
+            expect(inputToLiteral(input)).toEqual(expected);
         });
     });
 


### PR DESCRIPTION
# TL;DR
This change ensures that the empty array literal string (`"[]"`) is correctly converted to a `Core.ILiteral` collection with an empty `literals` property.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?
 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
The original implementation incorrectly determined that an empty array literal string should be converted to a `None` type `Literal`. This is equivalent to passing `void`/`null` for the value, which is not correct. I updated the code to continue trying to parse the inner value (which will be an empty JS array), resulting in the proper `Literal` value being returned.

## Tracking Issue
https://github.com/lyft/flyte/issues/533

## Follow-up issue
_NA_
