### PR TITLE
fix: display issues with Project selector

### DIFF
--- a/src/components/Navigation/ProjectSelector.tsx
+++ b/src/components/Navigation/ProjectSelector.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { KeyCodes } from 'common/constants';
 import { useCommonStyles } from 'components/common/styles';
-import { listhoverColor, mutedPrimaryTextColor } from 'components/Theme';
+import { listhoverColor } from 'components/Theme';
 import { SearchableProjectList } from './SearchableProjectList';
 
 const expanderGridHeight = 12;
@@ -31,7 +31,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         flex: '0 0 auto'
     },
     header: {
-        flex: '1 0 auto',
+        flex: '1 0 0',
         textAlign: 'left'
     },
     listContainer: {
@@ -83,7 +83,7 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             >
                 <header className={styles.header}>
                     <div className={commonStyles.microHeader}>PROJECT</div>
-                    <div className={commonStyles.mutedHeader}>
+                    <div className={classnames(commonStyles.mutedHeader, commonStyles.textWrapped)}>
                         {selectedProject.name}
                     </div>
                 </header>

--- a/src/components/Navigation/SearchableProjectList.tsx
+++ b/src/components/Navigation/SearchableProjectList.tsx
@@ -1,3 +1,4 @@
+import * as classnames from 'classnames';
 import { Fade, Tooltip, Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { SearchableList, SearchResult } from 'components/common/SearchableList';
@@ -12,7 +13,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         width: '100%'
     },
     itemName: {
-        flex: '1 0 auto',
+        flex: '1 0 0',
         fontWeight: 'bold'
     },
     noResults: {
@@ -72,6 +73,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
                     TransitionComponent={Fade}
                     key={value.id}
                     placement="bottom-end"
+                    enterDelay={500}
                     title={
                         <Typography variant="body1">
                             <div className={commonStyles.textMonospace}>
@@ -90,7 +92,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
                         className={styles.searchResult}
                         onClick={onProjectSelected.bind(null, value)}
                     >
-                        <div className={styles.itemName}>{content}</div>
+                        <div className={classnames(styles.itemName, commonStyles.textWrapped)}>{content}</div>
                     </div>
                 </Tooltip>
             ))}

--- a/src/components/Navigation/SearchableProjectList.tsx
+++ b/src/components/Navigation/SearchableProjectList.tsx
@@ -1,7 +1,8 @@
-import { ButtonBase, Typography } from '@material-ui/core';
+import { Fade, Tooltip, Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { SearchableList, SearchResult } from 'components/common/SearchableList';
 import { useCommonStyles } from 'components/common/styles';
+import { defaultProjectDescription } from 'components/SelectProject/constants';
 import { Project } from 'models';
 import * as React from 'react';
 
@@ -66,14 +67,32 @@ const SearchResults: React.FC<SearchResultsProps> = ({
         <NoResults />
     ) : (
         <ul className={commonStyles.listUnstyled}>
-            {results.map(({ key, content, value }) => (
-                <div
-                    className={styles.searchResult}
-                    key={key}
-                    onClick={onProjectSelected.bind(null, value)}
+            {results.map(({ content, value }) => (
+                <Tooltip
+                    TransitionComponent={Fade}
+                    key={value.id}
+                    placement="bottom-end"
+                    title={
+                        <Typography variant="body1">
+                            <div className={commonStyles.textMonospace}>
+                                {value.id}
+                            </div>
+                            <div>
+                                <em>
+                                    {value.description ||
+                                        defaultProjectDescription}
+                                </em>
+                            </div>
+                        </Typography>
+                    }
                 >
-                    <div className={styles.itemName}>{content}</div>
-                </div>
+                    <div
+                        className={styles.searchResult}
+                        onClick={onProjectSelected.bind(null, value)}
+                    >
+                        <div className={styles.itemName}>{content}</div>
+                    </div>
+                </Tooltip>
             ))}
         </ul>
     );


### PR DESCRIPTION
Fixes a few small issues with the Project selector on the Project Details page:
1. React errors about duplicate keys when more than one project entry uses the same `name`. This can easily happen when copying a project to a new repository. The `id` field should be used to key the elements.
2. Projects with duplicate names are difficult to tell apart because the `id` and `description` are not shown. Now all entries will show a tooltip on hover with the inner `id` and `description`(or a default 'no description').
3. Fixed overflow issues in the selector for long project names.