### PR TITLE
fix: failed data loading/refreshing in TaskExecutionDetails

### DIFF
--- a/src/components/Executions/TaskExecutionDetails/TaskExecutionNodes.tsx
+++ b/src/components/Executions/TaskExecutionDetails/TaskExecutionNodes.tsx
@@ -13,7 +13,7 @@ import {
 } from 'models';
 import * as React from 'react';
 import { useQueryClient } from 'react-query';
-import { nodeExecutionIsTerminal } from '..';
+import { executionRefreshIntervalMs, nodeExecutionIsTerminal } from '..';
 import { NodeExecutionsRequestConfigContext } from '../contexts';
 import { ExecutionFilters } from '../ExecutionFilters';
 import { useNodeExecutionFiltersState } from '../filters/useExecutionFiltersState';
@@ -65,11 +65,18 @@ export const TaskExecutionNodes: React.FC<TaskExecutionNodesProps> = ({
     );
 
     const shouldEnableQuery = (executions: NodeExecution[]) =>
-        every(executions, nodeExecutionIsTerminal) &&
-        taskExecutionIsTerminal(taskExecution);
+        !every(executions, nodeExecutionIsTerminal) ||
+        !taskExecutionIsTerminal(taskExecution);
 
     const nodeExecutionsQuery = useConditionalQuery(
-        makeTaskExecutionChildListQuery(useQueryClient(), taskExecution.id, requestConfig),
+        {
+            ...makeTaskExecutionChildListQuery(
+                useQueryClient(),
+                taskExecution.id,
+                requestConfig
+            ),
+            refetchInterval: executionRefreshIntervalMs
+        },
         shouldEnableQuery
     );
 

--- a/src/components/hooks/useConditionalQuery.ts
+++ b/src/components/hooks/useConditionalQuery.ts
@@ -27,6 +27,8 @@ export function useConditionalQuery<
 ) {
     const queryClient = useQueryClient();
     const queryData = queryClient.getQueryData<TData>(options.queryKey);
-    const enabled = queryData === undefined ? true : shouldEnableFn(queryData);
-    return useQuery<TData, TError, TQueryFnData>({ ...options, enabled });
+    const enabled = queryData === undefined || shouldEnableFn(queryData);
+    const staleTime = enabled ? options.staleTime : Infinity;
+    const refetchInterval = enabled ? options.refetchInterval : false;
+    return useQuery<TData, TError, TQueryFnData>({ ...options, refetchInterval, staleTime });
 }


### PR DESCRIPTION
# TL;DR
Fixes a failure to load data in the TaskExecutionDetails view when coming from a page where the TaskExecution has already been loaded an is in a final state.
Also fixes a refresh issue with child NodeExecutions on that page.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Complete description
The `enabled` flag on `useQuery` is meant to delay running a dependent query until data from the parent is available. We were abusing it a little bit by attempting to use it to return cached data from a query without running the query. A better implementation of this is to conditionally set the `staleTime` to `Infinity` and disable refetch in the case where we want to just use whatever cached data is available. This updates `useCondtionalQuery` to follow that logic.
Also fixed an issue where the NodeExecutions list on the TaskExecutionDetails page was not refreshing when the parent generator task succeeded but the spawned NodeExecutions were still in progress. This required adding a refetchInterval to the query and fixing the logic in the `shouldEnableQuery` function.

## Tracking Issue
https://github.com/lyft/flyte/issues/672
