### PR TITLE
chore: re-enable prettier

### DIFF
--- a/.storybook/StorybookContainer.tsx
+++ b/.storybook/StorybookContainer.tsx
@@ -21,7 +21,7 @@ export const StorybookContainer: React.FC = ({ children }) => {
             <CssBaseline />
             <ErrorBoundary>
                 <QueryClientProvider client={queryClient}>
-                <div className={useStyles().container}>{children}</div>
+                    <div className={useStyles().container}>{children}</div>
                 </QueryClientProvider>
             </ErrorBoundary>
         </ThemeProvider>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,7 +7,11 @@ import { StorybookContainer } from './StorybookContainer';
 
 addDecorator(withKnobs);
 addDecorator(StoryRouter());
-addDecorator(Story => <StorybookContainer><Story /></StorybookContainer>);
+addDecorator(Story => (
+    <StorybookContainer>
+        <Story />
+    </StorybookContainer>
+));
 
 // Storybook executes this module in both bootstap phase (Node)
 // and a story's runtime (browser). However, cannot call `setupWorker`

--- a/.storybook/public/mockServiceWorker.js
+++ b/.storybook/public/mockServiceWorker.js
@@ -7,170 +7,170 @@
 /* eslint-disable */
 /* tslint:disable */
 
-const INTEGRITY_CHECKSUM = '65d33ca82955e1c5928aed19d1bdf3f9'
-const bypassHeaderName = 'x-msw-bypass'
+const INTEGRITY_CHECKSUM = '65d33ca82955e1c5928aed19d1bdf3f9';
+const bypassHeaderName = 'x-msw-bypass';
 
-let clients = {}
+let clients = {};
 
-self.addEventListener('install', function () {
-  return self.skipWaiting()
-})
+self.addEventListener('install', function() {
+    return self.skipWaiting();
+});
 
-self.addEventListener('activate', async function (event) {
-  return self.clients.claim()
-})
+self.addEventListener('activate', async function(event) {
+    return self.clients.claim();
+});
 
-self.addEventListener('message', async function (event) {
-  const clientId = event.source.id
-  const client = await event.currentTarget.clients.get(clientId)
-  const allClients = await self.clients.matchAll()
-  const allClientIds = allClients.map((client) => client.id)
+self.addEventListener('message', async function(event) {
+    const clientId = event.source.id;
+    const client = await event.currentTarget.clients.get(clientId);
+    const allClients = await self.clients.matchAll();
+    const allClientIds = allClients.map(client => client.id);
 
-  switch (event.data) {
-    case 'KEEPALIVE_REQUEST': {
-      sendToClient(client, {
-        type: 'KEEPALIVE_RESPONSE',
-      })
-      break
-    }
-
-    case 'INTEGRITY_CHECK_REQUEST': {
-      sendToClient(client, {
-        type: 'INTEGRITY_CHECK_RESPONSE',
-        payload: INTEGRITY_CHECKSUM,
-      })
-      break
-    }
-
-    case 'MOCK_ACTIVATE': {
-      clients = ensureKeys(allClientIds, clients)
-      clients[clientId] = true
-
-      sendToClient(client, {
-        type: 'MOCKING_ENABLED',
-        payload: true,
-      })
-      break
-    }
-
-    case 'MOCK_DEACTIVATE': {
-      clients = ensureKeys(allClientIds, clients)
-      clients[clientId] = false
-      break
-    }
-
-    case 'CLIENT_CLOSED': {
-      const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId
-      })
-
-      // Unregister itself when there are no more clients
-      if (remainingClients.length === 0) {
-        self.registration.unregister()
-      }
-
-      break
-    }
-  }
-})
-
-self.addEventListener('fetch', function (event) {
-  const { clientId, request } = event
-  const requestClone = request.clone()
-  const getOriginalResponse = () => fetch(requestClone)
-
-  // Bypass navigation requests.
-  if (request.mode === 'navigate') {
-    return
-  }
-
-  // Bypass mocking if the current client isn't present in the internal clients map
-  // (i.e. has the mocking disabled).
-  if (!clients[clientId]) {
-    return
-  }
-
-  // Opening the DevTools triggers the "only-if-cached" request
-  // that cannot be handled by the worker. Bypass such requests.
-  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
-    return
-  }
-
-  event.respondWith(
-    new Promise(async (resolve, reject) => {
-      const client = await event.target.clients.get(clientId)
-
-      // Bypass mocking when the request client is not active.
-      if (!client) {
-        return resolve(getOriginalResponse())
-      }
-
-      // Bypass requests with the explicit bypass header
-      if (requestClone.headers.get(bypassHeaderName) === 'true') {
-        const modifiedHeaders = serializeHeaders(requestClone.headers)
-
-        // Remove the bypass header to comply with the CORS preflight check
-        delete modifiedHeaders[bypassHeaderName]
-
-        const originalRequest = new Request(requestClone, {
-          headers: new Headers(modifiedHeaders),
-        })
-
-        return resolve(fetch(originalRequest))
-      }
-
-      const reqHeaders = serializeHeaders(request.headers)
-      const body = await request.text()
-
-      const rawClientMessage = await sendToClient(client, {
-        type: 'REQUEST',
-        payload: {
-          url: request.url,
-          method: request.method,
-          headers: reqHeaders,
-          cache: request.cache,
-          mode: request.mode,
-          credentials: request.credentials,
-          destination: request.destination,
-          integrity: request.integrity,
-          redirect: request.redirect,
-          referrer: request.referrer,
-          referrerPolicy: request.referrerPolicy,
-          body,
-          bodyUsed: request.bodyUsed,
-          keepalive: request.keepalive,
-        },
-      })
-
-      const clientMessage = rawClientMessage
-
-      switch (clientMessage.type) {
-        case 'MOCK_SUCCESS': {
-          setTimeout(
-            resolve.bind(this, createResponse(clientMessage)),
-            clientMessage.payload.delay,
-          )
-          break
+    switch (event.data) {
+        case 'KEEPALIVE_REQUEST': {
+            sendToClient(client, {
+                type: 'KEEPALIVE_RESPONSE'
+            });
+            break;
         }
 
-        case 'MOCK_NOT_FOUND': {
-          return resolve(getOriginalResponse())
+        case 'INTEGRITY_CHECK_REQUEST': {
+            sendToClient(client, {
+                type: 'INTEGRITY_CHECK_RESPONSE',
+                payload: INTEGRITY_CHECKSUM
+            });
+            break;
         }
 
-        case 'NETWORK_ERROR': {
-          const { name, message } = clientMessage.payload
-          const networkError = new Error(message)
-          networkError.name = name
+        case 'MOCK_ACTIVATE': {
+            clients = ensureKeys(allClientIds, clients);
+            clients[clientId] = true;
 
-          // Rejecting a request Promise emulates a network error.
-          return reject(networkError)
+            sendToClient(client, {
+                type: 'MOCKING_ENABLED',
+                payload: true
+            });
+            break;
         }
 
-        case 'INTERNAL_ERROR': {
-          const parsedBody = JSON.parse(clientMessage.payload.body)
+        case 'MOCK_DEACTIVATE': {
+            clients = ensureKeys(allClientIds, clients);
+            clients[clientId] = false;
+            break;
+        }
 
-          console.error(
-            `\
+        case 'CLIENT_CLOSED': {
+            const remainingClients = allClients.filter(client => {
+                return client.id !== clientId;
+            });
+
+            // Unregister itself when there are no more clients
+            if (remainingClients.length === 0) {
+                self.registration.unregister();
+            }
+
+            break;
+        }
+    }
+});
+
+self.addEventListener('fetch', function(event) {
+    const { clientId, request } = event;
+    const requestClone = request.clone();
+    const getOriginalResponse = () => fetch(requestClone);
+
+    // Bypass navigation requests.
+    if (request.mode === 'navigate') {
+        return;
+    }
+
+    // Bypass mocking if the current client isn't present in the internal clients map
+    // (i.e. has the mocking disabled).
+    if (!clients[clientId]) {
+        return;
+    }
+
+    // Opening the DevTools triggers the "only-if-cached" request
+    // that cannot be handled by the worker. Bypass such requests.
+    if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+        return;
+    }
+
+    event.respondWith(
+        new Promise(async (resolve, reject) => {
+            const client = await event.target.clients.get(clientId);
+
+            // Bypass mocking when the request client is not active.
+            if (!client) {
+                return resolve(getOriginalResponse());
+            }
+
+            // Bypass requests with the explicit bypass header
+            if (requestClone.headers.get(bypassHeaderName) === 'true') {
+                const modifiedHeaders = serializeHeaders(requestClone.headers);
+
+                // Remove the bypass header to comply with the CORS preflight check
+                delete modifiedHeaders[bypassHeaderName];
+
+                const originalRequest = new Request(requestClone, {
+                    headers: new Headers(modifiedHeaders)
+                });
+
+                return resolve(fetch(originalRequest));
+            }
+
+            const reqHeaders = serializeHeaders(request.headers);
+            const body = await request.text();
+
+            const rawClientMessage = await sendToClient(client, {
+                type: 'REQUEST',
+                payload: {
+                    url: request.url,
+                    method: request.method,
+                    headers: reqHeaders,
+                    cache: request.cache,
+                    mode: request.mode,
+                    credentials: request.credentials,
+                    destination: request.destination,
+                    integrity: request.integrity,
+                    redirect: request.redirect,
+                    referrer: request.referrer,
+                    referrerPolicy: request.referrerPolicy,
+                    body,
+                    bodyUsed: request.bodyUsed,
+                    keepalive: request.keepalive
+                }
+            });
+
+            const clientMessage = rawClientMessage;
+
+            switch (clientMessage.type) {
+                case 'MOCK_SUCCESS': {
+                    setTimeout(
+                        resolve.bind(this, createResponse(clientMessage)),
+                        clientMessage.payload.delay
+                    );
+                    break;
+                }
+
+                case 'MOCK_NOT_FOUND': {
+                    return resolve(getOriginalResponse());
+                }
+
+                case 'NETWORK_ERROR': {
+                    const { name, message } = clientMessage.payload;
+                    const networkError = new Error(message);
+                    networkError.name = name;
+
+                    // Rejecting a request Promise emulates a network error.
+                    return reject(networkError);
+                }
+
+                case 'INTERNAL_ERROR': {
+                    const parsedBody = JSON.parse(clientMessage.payload.body);
+
+                    console.error(
+                        `\
 [MSW] Request handler function for "%s %s" has thrown the following exception:
 
 ${parsedBody.errorType}: ${parsedBody.message}
@@ -179,63 +179,63 @@ ${parsedBody.errorType}: ${parsedBody.message}
 This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error.
 If you wish to mock an error response, please refer to this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
   `,
-            request.method,
-            request.url,
-          )
+                        request.method,
+                        request.url
+                    );
 
-          return resolve(createResponse(clientMessage))
-        }
-      }
-    }).catch((error) => {
-      console.error(
-        '[MSW] Failed to mock a "%s" request to "%s": %s',
-        request.method,
-        request.url,
-        error,
-      )
-    }),
-  )
-})
+                    return resolve(createResponse(clientMessage));
+                }
+            }
+        }).catch(error => {
+            console.error(
+                '[MSW] Failed to mock a "%s" request to "%s": %s',
+                request.method,
+                request.url,
+                error
+            );
+        })
+    );
+});
 
 function serializeHeaders(headers) {
-  const reqHeaders = {}
-  headers.forEach((value, name) => {
-    reqHeaders[name] = reqHeaders[name]
-      ? [].concat(reqHeaders[name]).concat(value)
-      : value
-  })
-  return reqHeaders
+    const reqHeaders = {};
+    headers.forEach((value, name) => {
+        reqHeaders[name] = reqHeaders[name]
+            ? [].concat(reqHeaders[name]).concat(value)
+            : value;
+    });
+    return reqHeaders;
 }
 
 function sendToClient(client, message) {
-  return new Promise((resolve, reject) => {
-    const channel = new MessageChannel()
+    return new Promise((resolve, reject) => {
+        const channel = new MessageChannel();
 
-    channel.port1.onmessage = (event) => {
-      if (event.data && event.data.error) {
-        reject(event.data.error)
-      } else {
-        resolve(event.data)
-      }
-    }
+        channel.port1.onmessage = event => {
+            if (event.data && event.data.error) {
+                reject(event.data.error);
+            } else {
+                resolve(event.data);
+            }
+        };
 
-    client.postMessage(JSON.stringify(message), [channel.port2])
-  })
+        client.postMessage(JSON.stringify(message), [channel.port2]);
+    });
 }
 
 function createResponse(clientMessage) {
-  return new Response(clientMessage.payload.body, {
-    ...clientMessage.payload,
-    headers: clientMessage.payload.headers,
-  })
+    return new Response(clientMessage.payload.body, {
+        ...clientMessage.payload,
+        headers: clientMessage.payload.headers
+    });
 }
 
 function ensureKeys(keys, obj) {
-  return Object.keys(obj).reduce((acc, key) => {
-    if (keys.includes(key)) {
-      acc[key] = obj[key]
-    }
+    return Object.keys(obj).reduce((acc, key) => {
+        if (keys.includes(key)) {
+            acc[key] = obj[key];
+        }
 
-    return acc
-  }, {})
+        return acc;
+    }, {});
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "lint-staged": {
     "*.{js,ts,tsx}": [
       "eslint --fix",
+      "prettier --write",
       "git add"
     ]
   },

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,4 +12,3 @@ export const zeroSecondsString = '0s';
 export enum KeyCodes {
     ESCAPE = 27
 }
-

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -7,7 +7,10 @@ import { APIContext, useAPIState } from 'components/data/apiContext';
 import { QueryAuthorizationObserver } from 'components/data/QueryAuthorizationObserver';
 import { createQueryClient } from 'components/data/queryCache';
 import { SystemStatusBanner } from 'components/Notifications/SystemStatusBanner';
-import { skeletonColor, skeletonHighlightColor } from 'components/Theme/constants';
+import {
+    skeletonColor,
+    skeletonHighlightColor
+} from 'components/Theme/constants';
 import { muiTheme } from 'components/Theme/muiTheme';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';

--- a/src/components/Cache/createCache.ts
+++ b/src/components/Cache/createCache.ts
@@ -6,7 +6,7 @@ interface HasIdObject {
 }
 
 function hasId(value: Object): value is HasIdObject {
-    return {}.hasOwnProperty.call(value, ('id'));
+    return {}.hasOwnProperty.call(value, 'id');
 }
 
 /** A generic cache for any type of object or Array. Keys can be objects,

--- a/src/components/Entities/EntityExecutions.tsx
+++ b/src/components/Entities/EntityExecutions.tsx
@@ -59,7 +59,10 @@ export const EntityExecutions: React.FC<EntityExecutionsProps> = ({ id }) => {
                 <ExecutionFilters {...filtersState} />
             </div>
             <WaitForData {...executions}>
-                <WorkflowExecutionsTable {...executions} isFetching={isLoadingState(executions.state)} />
+                <WorkflowExecutionsTable
+                    {...executions}
+                    isFetching={isLoadingState(executions.state)}
+                />
             </WaitForData>
         </>
     );

--- a/src/components/Executions/ExecutionDetails/ExecutionDetails.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionDetails.tsx
@@ -96,7 +96,10 @@ export const ExecutionDetailsContainer: React.FC<ExecutionDetailsProps> = ({
     );
 
     return (
-        <WaitForQuery loadingComponent={LargeLoadingSpinner} query={useWorkflowExecutionQuery(id)}>
+        <WaitForQuery
+            loadingComponent={LargeLoadingSpinner}
+            query={useWorkflowExecutionQuery(id)}
+        >
             {renderExecutionDetails}
         </WaitForQuery>
     );

--- a/src/components/Executions/ExecutionDetails/ExecutionWorkflowGraph.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionWorkflowGraph.tsx
@@ -1,4 +1,3 @@
-
 import { DetailsPanel } from 'components/common/DetailsPanel';
 import { WaitForQuery } from 'components/common/WaitForQuery';
 import { makeWorkflowQuery } from 'components/Workflow/workflowQueries';

--- a/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
+++ b/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
@@ -210,7 +210,11 @@ export const NodeExecutionDetailsPanelContent: React.FC<NodeExecutionDetailsProp
     const commonStyles = useCommonStyles();
     const styles = useStyles();
     const detailsQuery = useNodeExecutionDetails(nodeExecution);
-    const displayId = detailsQuery.data ? detailsQuery.data.displayId : <Skeleton />;
+    const displayId = detailsQuery.data ? (
+        detailsQuery.data.displayId
+    ) : (
+        <Skeleton />
+    );
     const taskTemplate = detailsQuery.data
         ? detailsQuery.data.taskTemplate
         : null;

--- a/src/components/Executions/ExecutionDetails/utils.ts
+++ b/src/components/Executions/ExecutionDetails/utils.ts
@@ -1,6 +1,6 @@
-import { Identifier, ResourceType } from "models/Common/types";
-import { Execution } from "models/Execution/types";
-import { Routes } from "routes/routes";
+import { Identifier, ResourceType } from 'models/Common/types';
+import { Execution } from 'models/Execution/types';
+import { Routes } from 'routes/routes';
 
 export function isSingleTaskExecution(execution: Execution) {
     return execution.spec.launchPlan.resourceType === ResourceType.TASK;

--- a/src/components/Executions/ExecutionFilters.tsx
+++ b/src/components/Executions/ExecutionFilters.tsx
@@ -36,7 +36,12 @@ const RenderFilter: React.FC<{ filter: FilterState }> = ({ filter }) => {
                 <MultiSelectForm {...(filter as MultiFilterState<any, any>)} />
             );
         case 'search':
-            return <SearchInputForm {...searchFilterState} defaultValue={searchFilterState.value} />;
+            return (
+                <SearchInputForm
+                    {...searchFilterState}
+                    defaultValue={searchFilterState.value}
+                />
+            );
         default:
             return null;
     }

--- a/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -5,9 +5,7 @@ import { useTheme } from 'components/Theme/useTheme';
 import { isEqual } from 'lodash';
 import { NodeExecution } from 'models/Execution/types';
 import * as React from 'react';
-import {
-    NodeExecutionsRequestConfigContext
-} from '../contexts';
+import { NodeExecutionsRequestConfigContext } from '../contexts';
 import { useChildNodeExecutionGroupsQuery } from '../nodeExecutionQueries';
 import { titleStrings } from './constants';
 import { NodeExecutionsTableContext } from './contexts';
@@ -27,7 +25,9 @@ interface NodeExecutionRowProps {
 const ChildFetchErrorIcon: React.FC<{
     query: ReturnType<typeof useChildNodeExecutionGroupsQuery>;
 }> = ({ query }) => {
-    return query.isFetching ? <CircularProgress size={24} /> : (
+    return query.isFetching ? (
+        <CircularProgress size={24} />
+    ) : (
         <IconButton
             disableRipple={true}
             disableTouchRipple={true}

--- a/src/components/Executions/Tables/WorkflowExecutionRow.tsx
+++ b/src/components/Executions/Tables/WorkflowExecutionRow.tsx
@@ -1,11 +1,14 @@
-import { makeStyles, Theme } from "@material-ui/core";
-import classnames from "classnames";
-import { Execution } from "models/Execution/types";
-import * as React from "react";
-import { ListRowProps } from "react-virtualized";
-import { ExpandableExecutionError } from "./ExpandableExecutionError";
-import { useExecutionTableStyles } from "./styles";
-import { WorkflowExecutionColumnDefinition, WorkflowExecutionsTableState } from "./types";
+import { makeStyles, Theme } from '@material-ui/core';
+import classnames from 'classnames';
+import { Execution } from 'models/Execution/types';
+import * as React from 'react';
+import { ListRowProps } from 'react-virtualized';
+import { ExpandableExecutionError } from './ExpandableExecutionError';
+import { useExecutionTableStyles } from './styles';
+import {
+    WorkflowExecutionColumnDefinition,
+    WorkflowExecutionsTableState
+} from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
     row: {

--- a/src/components/Executions/Tables/__mocks__/WorkflowExecutionsTable.tsx
+++ b/src/components/Executions/Tables/__mocks__/WorkflowExecutionsTable.tsx
@@ -26,7 +26,14 @@ export const WorkflowExecutionsTable: React.FC<WorkflowExecutionsTableProps> = p
             )}
         >
             <ExecutionsTableHeader columns={columns} />
-            {executions.map(execution => <WorkflowExecutionRow key={execution.id.name} execution={execution} columns={columns} state={state} /> )}
+            {executions.map(execution => (
+                <WorkflowExecutionRow
+                    key={execution.id.name}
+                    execution={execution}
+                    columns={columns}
+                    state={state}
+                />
+            ))}
         </div>
     );
 };

--- a/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
+++ b/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
@@ -24,9 +24,13 @@ stories.addDecorator(story => {
     return <div className={useStyles().container}>{story()}</div>;
 });
 stories.add('Basic', () => {
-    const query = useQuery(makeNodeExecutionListQuery(useQueryClient(), workflowExecution.id));
-    return query.data ? <NodeExecutionsTable nodeExecutions={query.data} /> : <div />;
+    const query = useQuery(
+        makeNodeExecutionListQuery(useQueryClient(), workflowExecution.id)
+    );
+    return query.data ? (
+        <NodeExecutionsTable nodeExecutions={query.data} />
+    ) : (
+        <div />
+    );
 });
-stories.add('With no items', () => (
-    <NodeExecutionsTable  nodeExecutions={[]} />
-));
+stories.add('With no items', () => <NodeExecutionsTable nodeExecutions={[]} />);

--- a/src/components/Executions/Tables/styles.ts
+++ b/src/components/Executions/Tables/styles.ts
@@ -1,7 +1,17 @@
 import { makeStyles, Theme } from '@material-ui/core';
 import { headerGridHeight } from 'components/Tables/constants';
-import { headerFontFamily, listhoverColor, nestedListColor, smallFontSize, tableHeaderColor, tablePlaceholderColor } from 'components/Theme/constants';
-import { nodeExecutionsTableColumnWidths, workflowExecutionsTableColumnWidths } from './constants';
+import {
+    headerFontFamily,
+    listhoverColor,
+    nestedListColor,
+    smallFontSize,
+    tableHeaderColor,
+    tablePlaceholderColor
+} from 'components/Theme/constants';
+import {
+    nodeExecutionsTableColumnWidths,
+    workflowExecutionsTableColumnWidths
+} from './constants';
 
 export const selectedClassName = 'selected';
 

--- a/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
+++ b/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
@@ -32,7 +32,11 @@ import { mockServer } from 'mocks/server';
 import { FilterOperationName, RequestConfig } from 'models/AdminEntity/types';
 import { nodeExecutionQueryParams } from 'models/Execution/constants';
 import { NodeExecutionPhase } from 'models/Execution/enums';
-import { Execution, NodeExecution, TaskNodeMetadata } from 'models/Execution/types';
+import {
+    Execution,
+    NodeExecution,
+    TaskNodeMetadata
+} from 'models/Execution/types';
 import * as React from 'react';
 import { QueryClient, QueryClientProvider, useQueryClient } from 'react-query';
 import { makeIdentifier } from 'test/modelUtils';

--- a/src/components/Executions/Tables/types.ts
+++ b/src/components/Executions/Tables/types.ts
@@ -1,4 +1,8 @@
-import { Execution, NodeExecution, NodeExecutionIdentifier } from "models/Execution/types";
+import {
+    Execution,
+    NodeExecution,
+    NodeExecutionIdentifier
+} from 'models/Execution/types';
 
 export interface WorkflowExecutionsTableState {
     selectedIOExecution: Execution | null;

--- a/src/components/Executions/TaskExecutionDetails/TaskExecutionDetailsAppBarContent.tsx
+++ b/src/components/Executions/TaskExecutionDetails/TaskExecutionDetailsAppBarContent.tsx
@@ -6,7 +6,10 @@ import { formatDateUTC, protobufDurationToHMS } from 'common/formatters';
 import { timestampToDate } from 'common/utils';
 import { useCommonStyles } from 'components/common/styles';
 import { NavBarContent } from 'components/Navigation/NavBarContent';
-import { interactiveTextDisabledColor, smallFontSize } from 'components/Theme/constants';
+import {
+    interactiveTextDisabledColor,
+    smallFontSize
+} from 'components/Theme/constants';
 import { TaskExecution } from 'models/Execution/types';
 import * as React from 'react';
 import { Link as RouterLink } from 'react-router-dom';

--- a/src/components/Executions/TaskExecutionDetails/TaskExecutionNodes.tsx
+++ b/src/components/Executions/TaskExecutionDetails/TaskExecutionNodes.tsx
@@ -65,7 +65,11 @@ export const TaskExecutionNodes: React.FC<TaskExecutionNodesProps> = ({
         taskExecutionIsTerminal(taskExecution);
 
     const nodeExecutionsQuery = useConditionalQuery(
-        makeTaskExecutionChildListQuery(useQueryClient(), taskExecution.id, requestConfig),
+        makeTaskExecutionChildListQuery(
+            useQueryClient(),
+            taskExecution.id,
+            requestConfig
+        ),
         shouldEnableQuery
     );
 

--- a/src/components/Executions/constants.ts
+++ b/src/components/Executions/constants.ts
@@ -1,4 +1,9 @@
-import { negativeTextColor, positiveTextColor, secondaryTextColor, statusColors } from 'components/Theme/constants';
+import {
+    negativeTextColor,
+    positiveTextColor,
+    secondaryTextColor,
+    statusColors
+} from 'components/Theme/constants';
 import { Core } from 'flyteidl';
 import {
     NodeExecutionPhase,

--- a/src/components/Executions/filters/useMultiFilterState.ts
+++ b/src/components/Executions/filters/useMultiFilterState.ts
@@ -1,6 +1,9 @@
 import { useQueryState } from 'components/hooks/useQueryState';
 import { isEqual, mapValues, pickBy } from 'lodash';
-import { FilterOperationName, FilterOperationValue } from 'models/AdminEntity/types';
+import {
+    FilterOperationName,
+    FilterOperationValue
+} from 'models/AdminEntity/types';
 import { useEffect, useState } from 'react';
 import { FilterValue, MultiFilterState } from './types';
 import { useFilterButtonState } from './useFilterButtonState';

--- a/src/components/Executions/filters/useSingleFilterState.ts
+++ b/src/components/Executions/filters/useSingleFilterState.ts
@@ -20,7 +20,7 @@ function valueOrDefault<FilterKey extends string>(
         return defaultValue;
     }
 
-    if (!{}.hasOwnProperty.call(options,newValue)) {
+    if (!{}.hasOwnProperty.call(options, newValue)) {
         log.warn(`Filter has no option ${newValue}, using default`);
         return defaultValue;
     }

--- a/src/components/Executions/nodeExecutionQueries.ts
+++ b/src/components/Executions/nodeExecutionQueries.ts
@@ -2,9 +2,18 @@ import { QueryInput, QueryType } from 'components/data/types';
 import { useConditionalQuery } from 'components/hooks/useConditionalQuery';
 import { isEqual } from 'lodash';
 import { RequestConfig } from 'models/AdminEntity/types';
-import { getNodeExecution, listNodeExecutions, listTaskExecutionChildren } from 'models/Execution/api';
+import {
+    getNodeExecution,
+    listNodeExecutions,
+    listTaskExecutionChildren
+} from 'models/Execution/api';
 import { nodeExecutionQueryParams } from 'models/Execution/constants';
-import { NodeExecution, NodeExecutionIdentifier, TaskExecutionIdentifier, WorkflowExecutionIdentifier } from 'models/Execution/types';
+import {
+    NodeExecution,
+    NodeExecutionIdentifier,
+    TaskExecutionIdentifier,
+    WorkflowExecutionIdentifier
+} from 'models/Execution/types';
 import { endNodeId, startNodeId } from 'models/Node/constants';
 import { QueryClient, QueryObserverResult, useQueryClient } from 'react-query';
 import { fetchTaskExecutionList } from './taskExecutionQueries';
@@ -237,7 +246,6 @@ async function fetchGroupsForParentNodeExecution(
     return Array.from(groupsByName.values());
 }
 
-
 function fetchChildNodeExecutionGroups(
     queryClient: QueryClient,
     nodeExecution: NodeExecution,
@@ -284,7 +292,7 @@ export function useChildNodeExecutionGroupsQuery(
         if (!nodeExecutionIsTerminal(nodeExecution)) {
             return true;
         }
-        return groups.some( group =>
+        return groups.some(group =>
             group.nodeExecutions.some(ne => !nodeExecutionIsTerminal(ne))
         );
     };

--- a/src/components/Executions/test/utils.test.ts
+++ b/src/components/Executions/test/utils.test.ts
@@ -4,7 +4,11 @@ import {
     TaskExecutionPhase,
     WorkflowExecutionPhase
 } from 'models/Execution/enums';
-import { Execution, NodeExecution, TaskExecution } from 'models/Execution/types';
+import {
+    Execution,
+    NodeExecution,
+    TaskExecution
+} from 'models/Execution/types';
 import { createMockNodeExecutions } from 'models/Execution/__mocks__/mockNodeExecutionsData';
 import { createMockTaskExecutionsListResponse } from 'models/Execution/__mocks__/mockTaskExecutionsData';
 import { createMockWorkflowExecutionsListResponse } from 'models/Execution/__mocks__/mockWorkflowExecutionsData';

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -4,7 +4,12 @@ import {
     NodeExecutionMetadata,
     WorkflowNodeMetadata
 } from 'models/Execution/types';
-import { BranchNode, CompiledNode, TaskNode, WorkflowNode } from 'models/Node/types';
+import {
+    BranchNode,
+    CompiledNode,
+    TaskNode,
+    WorkflowNode
+} from 'models/Node/types';
 import { TaskTemplate } from 'models/Task/types';
 
 export interface ExecutionPhaseConstants {

--- a/src/components/Executions/utils.ts
+++ b/src/components/Executions/utils.ts
@@ -1,11 +1,21 @@
 import { durationToMilliseconds, timestampToDate } from 'common/utils';
-import { runningExecutionStates, terminalExecutionStates, terminalNodeExecutionStates, terminalTaskExecutionStates } from 'models/Execution/constants';
+import {
+    runningExecutionStates,
+    terminalExecutionStates,
+    terminalNodeExecutionStates,
+    terminalTaskExecutionStates
+} from 'models/Execution/constants';
 import {
     NodeExecutionPhase,
     TaskExecutionPhase,
     WorkflowExecutionPhase
 } from 'models/Execution/enums';
-import { BaseExecutionClosure, Execution, NodeExecution, TaskExecution } from 'models/Execution/types';
+import {
+    BaseExecutionClosure,
+    Execution,
+    NodeExecution,
+    TaskExecution
+} from 'models/Execution/types';
 import { CompiledNode } from 'models/Node/types';
 import {
     nodeExecutionPhaseConstants,

--- a/src/components/Executions/workflowExecutionQueries.ts
+++ b/src/components/Executions/workflowExecutionQueries.ts
@@ -25,6 +25,6 @@ export function makeWorkflowExecutionListQuery(
                 finalConfig
             );
             return { data, token };
-        },
+        }
     });
 }

--- a/src/components/Launch/LaunchForm/__mocks__/mockInputs.ts
+++ b/src/components/Launch/LaunchForm/__mocks__/mockInputs.ts
@@ -2,7 +2,12 @@ import { dateToTimestamp, millisecondsToDuration } from 'common/utils';
 import { Core } from 'flyteidl';
 import { cloneDeep, mapValues } from 'lodash';
 import * as Long from 'long';
-import { BlobDimensionality, SimpleType, TypedInterface, Variable } from 'models/Common/types';
+import {
+    BlobDimensionality,
+    SimpleType,
+    TypedInterface,
+    Variable
+} from 'models/Common/types';
 import { literalNone } from '../inputHelpers/constants';
 import { primitiveLiteral } from './utils';
 

--- a/src/components/Launch/LaunchForm/test/LaunchTaskForm.test.tsx
+++ b/src/components/Launch/LaunchForm/test/LaunchTaskForm.test.tsx
@@ -14,8 +14,15 @@ import { muiTheme } from 'components/Theme/muiTheme';
 import { Core } from 'flyteidl';
 import { cloneDeep, get } from 'lodash';
 import { RequestConfig } from 'models/AdminEntity/types';
-import { Identifier, NamedEntityIdentifier, Variable } from 'models/Common/types';
-import { createWorkflowExecution, CreateWorkflowExecutionArguments } from 'models/Execution/api';
+import {
+    Identifier,
+    NamedEntityIdentifier,
+    Variable
+} from 'models/Common/types';
+import {
+    createWorkflowExecution,
+    CreateWorkflowExecutionArguments
+} from 'models/Execution/api';
 import { getTask, listTasks } from 'models/Task/api';
 import { Task } from 'models/Task/types';
 import { createMockTaskClosure } from 'models/__mocks__/taskData';

--- a/src/components/Launch/LaunchForm/test/LaunchWorkflowForm.test.tsx
+++ b/src/components/Launch/LaunchForm/test/LaunchWorkflowForm.test.tsx
@@ -15,8 +15,16 @@ import { Core } from 'flyteidl';
 import { cloneDeep, get } from 'lodash';
 import * as Long from 'long';
 import { RequestConfig } from 'models/AdminEntity/types';
-import { Identifier, Literal, NamedEntityIdentifier, Variable } from 'models/Common/types';
-import { createWorkflowExecution, CreateWorkflowExecutionArguments } from 'models/Execution/api';
+import {
+    Identifier,
+    Literal,
+    NamedEntityIdentifier,
+    Variable
+} from 'models/Common/types';
+import {
+    createWorkflowExecution,
+    CreateWorkflowExecutionArguments
+} from 'models/Execution/api';
 import { listLaunchPlans } from 'models/Launch/api';
 import { LaunchPlan } from 'models/Launch/types';
 import { getWorkflow, listWorkflows } from 'models/Workflow/api';

--- a/src/components/Launch/LaunchForm/types.ts
+++ b/src/components/Launch/LaunchForm/types.ts
@@ -1,5 +1,10 @@
 import { Admin, Core } from 'flyteidl';
-import { BlobDimensionality, Identifier, LiteralType, NamedEntityIdentifier } from 'models/Common/types';
+import {
+    BlobDimensionality,
+    Identifier,
+    LiteralType,
+    NamedEntityIdentifier
+} from 'models/Common/types';
 import { WorkflowExecutionIdentifier } from 'models/Execution/types';
 import { LaunchPlan } from 'models/Launch/types';
 import { Task } from 'models/Task/types';

--- a/src/components/Literals/LiteralValue.tsx
+++ b/src/components/Literals/LiteralValue.tsx
@@ -1,4 +1,9 @@
-import { Literal, LiteralCollection, LiteralMap, Scalar } from 'models/Common/types';
+import {
+    Literal,
+    LiteralCollection,
+    LiteralMap,
+    Scalar
+} from 'models/Common/types';
 import * as React from 'react';
 import { LiteralCollectionViewer } from './LiteralCollectionViewer';
 import { LiteralMapViewer } from './LiteralMapViewer';

--- a/src/components/Literals/Scalar/ProtobufStructValue.tsx
+++ b/src/components/Literals/Scalar/ProtobufStructValue.tsx
@@ -1,7 +1,11 @@
 import * as classnames from 'classnames';
 import { sortedObjectEntries } from 'common/utils';
 import { useCommonStyles } from 'components/common/styles';
-import { ProtobufListValue, ProtobufStruct, ProtobufValue } from 'models/Common/types';
+import {
+    ProtobufListValue,
+    ProtobufStruct,
+    ProtobufValue
+} from 'models/Common/types';
 import * as React from 'react';
 import { htmlEntities } from '../constants';
 import { PrintList } from '../PrintList';

--- a/src/components/Literals/Scalar/ScalarValue.tsx
+++ b/src/components/Literals/Scalar/ScalarValue.tsx
@@ -1,4 +1,12 @@
-import { Binary, Blob, Error, Primitive, ProtobufStruct, Scalar, Schema } from 'models/Common/types';
+import {
+    Binary,
+    Blob,
+    Error,
+    Primitive,
+    ProtobufStruct,
+    Scalar,
+    Schema
+} from 'models/Common/types';
 import * as React from 'react';
 import { PrintValue } from '../PrintValue';
 import { UnsupportedType } from '../UnsupportedType';

--- a/src/components/Literals/__stories__/binaryValues.ts
+++ b/src/components/Literals/__stories__/binaryValues.ts
@@ -1,4 +1,4 @@
-import { Binary } from "models/Common/types";
+import { Binary } from 'models/Common/types';
 
 export const binaryValues: Dictionary<Binary> = {
     basic: { tag: 'some_tag_value', value: new Uint8Array() }

--- a/src/components/Literals/__stories__/blobValues.ts
+++ b/src/components/Literals/__stories__/blobValues.ts
@@ -1,4 +1,4 @@
-import { Blob, BlobDimensionality } from "models/Common/types";
+import { Blob, BlobDimensionality } from 'models/Common/types';
 
 export const blobValues: Dictionary<Blob> = {
     singleBlobValue: {

--- a/src/components/Literals/__stories__/protobufValues.ts
+++ b/src/components/Literals/__stories__/protobufValues.ts
@@ -1,4 +1,4 @@
-import { ProtobufValue } from "models/Common/types";
+import { ProtobufValue } from 'models/Common/types';
 
 export const protobufValues: Dictionary<ProtobufValue> = {
     booleanFalse: {

--- a/src/components/Literals/__stories__/schemaValues.ts
+++ b/src/components/Literals/__stories__/schemaValues.ts
@@ -1,4 +1,4 @@
-import { Schema, SchemaColumnType } from "models/Common/types";
+import { Schema, SchemaColumnType } from 'models/Common/types';
 
 const schemaWithNoColumns: Schema = {
     uri: 's3://path/to/my/schema_with_no_columns',

--- a/src/components/Navigation/ProjectSelector.tsx
+++ b/src/components/Navigation/ProjectSelector.tsx
@@ -82,7 +82,12 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             >
                 <header className={styles.header}>
                     <div className={commonStyles.microHeader}>PROJECT</div>
-                    <div className={classnames(commonStyles.mutedHeader, commonStyles.textWrapped)}>
+                    <div
+                        className={classnames(
+                            commonStyles.mutedHeader,
+                            commonStyles.textWrapped
+                        )}
+                    >
                         {selectedProject.name}
                     </div>
                 </header>

--- a/src/components/Navigation/SearchableProjectList.tsx
+++ b/src/components/Navigation/SearchableProjectList.tsx
@@ -92,7 +92,14 @@ const SearchResults: React.FC<SearchResultsProps> = ({
                         className={styles.searchResult}
                         onClick={onProjectSelected.bind(null, value)}
                     >
-                        <div className={classnames(styles.itemName, commonStyles.textWrapped)}>{content}</div>
+                        <div
+                            className={classnames(
+                                styles.itemName,
+                                commonStyles.textWrapped
+                            )}
+                        >
+                            {content}
+                        </div>
                     </div>
                 </Tooltip>
             ))}

--- a/src/components/Navigation/withSideNavigation.tsx
+++ b/src/components/Navigation/withSideNavigation.tsx
@@ -1,4 +1,7 @@
-import { ContentContainer, ContentContainerProps } from 'components/common/ContentContainer';
+import {
+    ContentContainer,
+    ContentContainerProps
+} from 'components/common/ContentContainer';
 import * as React from 'react';
 import { SideNavigation } from './SideNavigation';
 

--- a/src/components/Notifications/SystemStatusBanner.tsx
+++ b/src/components/Notifications/SystemStatusBanner.tsx
@@ -7,7 +7,12 @@ import Warning from '@material-ui/icons/Warning';
 import { Empty } from 'components/common/Empty';
 import { LinkifiedText } from 'components/common/LinkifiedText';
 import { WaitForData } from 'components/common/WaitForData';
-import { infoIconColor, mutedButtonColor, mutedButtonHoverColor, warningIconColor } from 'components/Theme/constants';
+import {
+    infoIconColor,
+    mutedButtonColor,
+    mutedButtonHoverColor,
+    warningIconColor
+} from 'components/Theme/constants';
 import { StatusString, SystemStatus } from 'models/Common/types';
 import * as React from 'react';
 import { useSystemStatus } from './useSystemStatus';

--- a/src/components/Project/ProjectDetails.tsx
+++ b/src/components/Project/ProjectDetails.tsx
@@ -42,7 +42,10 @@ const ProjectEntitiesByDomain: React.FC<{
         throw new Error('No domains exist for this project');
     }
     const domainId = params.domain || project.domains[0].id;
-    const handleTabChange = (_event: React.ChangeEvent<unknown>, tabId: string) =>
+    const handleTabChange = (
+        _event: React.ChangeEvent<unknown>,
+        tabId: string
+    ) =>
         setQueryState({
             domain: tabId
         });
@@ -68,7 +71,7 @@ const ProjectEntitiesByDomain: React.FC<{
     );
 };
 
-const ProjectExecutionsByDomain: React.FC<{ project: Project}> = ({
+const ProjectExecutionsByDomain: React.FC<{ project: Project }> = ({
     project
 }) => <ProjectEntitiesByDomain project={project} entityType="executions" />;
 
@@ -98,8 +101,14 @@ export const ProjectDetailsContainer: React.FC<ProjectDetailsRouteParams> = ({
                         <Route path={Routes.ProjectDetails.sections.tasks.path}>
                             <ProjectTasksByDomain project={project.value} />
                         </Route>
-                        <Route path={Routes.ProjectDetails.sections.executions.path}>
-                            <ProjectExecutionsByDomain project={project.value} />
+                        <Route
+                            path={
+                                Routes.ProjectDetails.sections.executions.path
+                            }
+                        >
+                            <ProjectExecutionsByDomain
+                                project={project.value}
+                            />
                         </Route>
                         <Redirect
                             to={Routes.ProjectDetails.sections.workflows.makeUrl(

--- a/src/components/Project/test/ProjectExecutions.test.tsx
+++ b/src/components/Project/test/ProjectExecutions.test.tsx
@@ -12,7 +12,11 @@ import { Execution } from 'models/Execution/types';
 import * as React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router';
-import { createTestQueryClient, disableQueryLogger, enableQueryLogger } from 'test/utils';
+import {
+    createTestQueryClient,
+    disableQueryLogger,
+    enableQueryLogger
+} from 'test/utils';
 import { failedToLoadExecutionsString } from '../constants';
 import { ProjectExecutions } from '../ProjectExecutions';
 
@@ -90,7 +94,9 @@ describe('ProjectExecutions', () => {
 
         it('shows error message', async () => {
             const { getByText } = renderView();
-            await waitFor(() => expect(getByText(failedToLoadExecutionsString)));
+            await waitFor(() =>
+                expect(getByText(failedToLoadExecutionsString))
+            );
         });
     });
 });

--- a/src/components/Tables/DataTable.tsx
+++ b/src/components/Tables/DataTable.tsx
@@ -3,7 +3,13 @@ import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import * as classnames from 'classnames';
 import { noExecutionsFoundString } from 'common/constants';
 import { useCommonStyles } from 'components/common/styles';
-import { bodyFontSize, headerFontFamily, separatorColor, tableHeaderColor, tablePlaceholderColor } from 'components/Theme/constants';
+import {
+    bodyFontSize,
+    headerFontFamily,
+    separatorColor,
+    tableHeaderColor,
+    tablePlaceholderColor
+} from 'components/Theme/constants';
 import * as React from 'react';
 import {
     AutoSizer,

--- a/src/components/Tables/LoadMoreRowContent.tsx
+++ b/src/components/Tables/LoadMoreRowContent.tsx
@@ -37,7 +37,12 @@ export const LoadMoreRowContent: React.FC<LoadMoreRowContentProps> = props => {
     const { loadMoreRows, lastError, isFetching, style } = props;
 
     const button = (
-        <Button onClick={loadMoreRows} size="small" variant="outlined" disabled={isFetching}>
+        <Button
+            onClick={loadMoreRows}
+            size="small"
+            variant="outlined"
+            disabled={isFetching}
+        >
             Load More
             {isFetching ? <ButtonCircularProgress /> : null}
         </Button>

--- a/src/components/Tables/filters/FilterPopoverButton.tsx
+++ b/src/components/Tables/filters/FilterPopoverButton.tsx
@@ -3,7 +3,11 @@ import { fade, makeStyles, Theme } from '@material-ui/core/styles';
 import Close from '@material-ui/icons/Close';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import * as classnames from 'classnames';
-import { buttonHoverColor, interactiveTextBackgroundColor, interactiveTextColor } from 'components/Theme/constants';
+import {
+    buttonHoverColor,
+    interactiveTextBackgroundColor,
+    interactiveTextColor
+} from 'components/Theme/constants';
 import * as React from 'react';
 
 const useStyles = makeStyles((theme: Theme) => {

--- a/src/components/Task/useLatestTask.ts
+++ b/src/components/Task/useLatestTask.ts
@@ -1,11 +1,10 @@
-import { useFetchableData } from "components/hooks/useFetchableData";
-import { NotFoundError } from "errors/fetchErrors";
-import { SortDirection } from "models/AdminEntity/types";
-import { NamedEntityIdentifier } from "models/Common/types";
-import { listTasks } from "models/Task/api";
-import { taskSortFields } from "models/Task/constants";
-import { Task } from "models/Task/types";
-
+import { useFetchableData } from 'components/hooks/useFetchableData';
+import { NotFoundError } from 'errors/fetchErrors';
+import { SortDirection } from 'models/AdminEntity/types';
+import { NamedEntityIdentifier } from 'models/Common/types';
+import { listTasks } from 'models/Task/api';
+import { taskSortFields } from 'models/Task/constants';
+import { Task } from 'models/Task/types';
 
 async function fetchLatestTaskVersion(id: NamedEntityIdentifier) {
     const { entities } = await listTasks(id, {

--- a/src/components/Workflow/workflowQueries.ts
+++ b/src/components/Workflow/workflowQueries.ts
@@ -4,7 +4,10 @@ import { getWorkflow } from 'models/Workflow/api';
 import { Workflow, WorkflowId } from 'models/Workflow/types';
 import { QueryClient } from 'react-query';
 
-export function makeWorkflowQuery(queryClient: QueryClient, id: WorkflowId): QueryInput<Workflow> {
+export function makeWorkflowQuery(
+    queryClient: QueryClient,
+    id: WorkflowId
+): QueryInput<Workflow> {
     return {
         queryKey: [QueryType.Workflow, id],
         queryFn: async () => {
@@ -13,7 +16,10 @@ export function makeWorkflowQuery(queryClient: QueryClient, id: WorkflowId): Que
             // stored on the workflow so that we don't need to fetch them separately
             // if future queries reference them.
             extractTaskTemplates(workflow).forEach(task =>
-                queryClient.setQueryData([QueryType.TaskTemplate, task.id], task)
+                queryClient.setQueryData(
+                    [QueryType.TaskTemplate, task.id],
+                    task
+                )
             );
             return workflow;
         },

--- a/src/components/WorkflowGraph/utils.ts
+++ b/src/components/WorkflowGraph/utils.ts
@@ -1,5 +1,5 @@
-import { DAGNode } from "models/Graph/types";
-import { endNodeId, startNodeId } from "models/Node/constants";
+import { DAGNode } from 'models/Graph/types';
+import { endNodeId, startNodeId } from 'models/Node/constants';
 
 export function isStartNode(node: DAGNode) {
     return node.id === startNodeId;

--- a/src/components/common/ExpandableMonospaceText.tsx
+++ b/src/components/common/ExpandableMonospaceText.tsx
@@ -2,7 +2,14 @@ import { Button, ButtonBase } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import FileCopy from '@material-ui/icons/FileCopy';
 import * as classnames from 'classnames';
-import { bodyFontFamily, errorBackgroundColor, listhoverColor, nestedListColor, separatorColor, smallFontSize } from 'components/Theme/constants';
+import {
+    bodyFontFamily,
+    errorBackgroundColor,
+    listhoverColor,
+    nestedListColor,
+    separatorColor,
+    smallFontSize
+} from 'components/Theme/constants';
 import * as copyToClipboard from 'copy-to-clipboard';
 import * as React from 'react';
 

--- a/src/components/common/styles.ts
+++ b/src/components/common/styles.ts
@@ -1,5 +1,12 @@
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { buttonHoverColor, dangerousButtonBorderColor, dangerousButtonColor, dangerousButtonHoverColor, mutedPrimaryTextColor, smallFontSize } from 'components/Theme/constants';
+import {
+    buttonHoverColor,
+    dangerousButtonBorderColor,
+    dangerousButtonColor,
+    dangerousButtonHoverColor,
+    mutedPrimaryTextColor,
+    smallFontSize
+} from 'components/Theme/constants';
 
 const unstyledLinkProps = {
     textDecoration: 'none',

--- a/src/components/data/test/queryUtils.test.ts
+++ b/src/components/data/test/queryUtils.test.ts
@@ -4,7 +4,7 @@ import { InfiniteQueryPage, QueryType } from '../types';
 describe('queryUtils', () => {
     describe('createPaginationQuery', () => {
         it('should treat empty string token as undefined', () => {
-            const response: InfiniteQueryPage<string> = { data: [], token: ''};
+            const response: InfiniteQueryPage<string> = { data: [], token: '' };
             const query = createPaginationQuery<string>({
                 queryKey: [QueryType.WorkflowExecutionList, 'test'],
                 queryFn: () => response

--- a/src/components/data/types.ts
+++ b/src/components/data/types.ts
@@ -1,4 +1,7 @@
-import { InfiniteQueryObserverOptions, QueryObserverOptions } from 'react-query';
+import {
+    InfiniteQueryObserverOptions,
+    QueryObserverOptions
+} from 'react-query';
 
 export enum QueryType {
     NodeExecutionDetails = 'NodeExecutionDetails',
@@ -20,9 +23,13 @@ export interface QueryInput<T> extends QueryObserverOptions<T, Error> {
     queryFn: QueryObserverOptions<T, Error>['queryFn'];
 }
 
-export interface InfiniteQueryInput<T> extends InfiniteQueryObserverOptions<InfiniteQueryPage<T>, Error> {
+export interface InfiniteQueryInput<T>
+    extends InfiniteQueryObserverOptions<InfiniteQueryPage<T>, Error> {
     queryKey: QueryKeyArray;
-    queryFn: InfiniteQueryObserverOptions<InfiniteQueryPage<T>, Error>['queryFn'];
+    queryFn: InfiniteQueryObserverOptions<
+        InfiniteQueryPage<T>,
+        Error
+    >['queryFn'];
 }
 
 export interface InfiniteQueryPage<T> {

--- a/src/components/flytegraph/types.ts
+++ b/src/components/flytegraph/types.ts
@@ -71,7 +71,7 @@ export interface NodeRendererProps<T> extends BaseNodeProps<T> {
     textRenderer?: NodeTextRenderer<T>;
 }
 
-export type NodeTextRendererProps<T> = BaseNodeProps<T>
+export type NodeTextRendererProps<T> = BaseNodeProps<T>;
 
 export interface NodeLinkRendererProps<T> {
     link: RenderableNodeLink<T>;

--- a/src/components/hooks/types.ts
+++ b/src/components/hooks/types.ts
@@ -1,4 +1,7 @@
-import { PaginatedEntityResponse, RequestConfig } from 'models/AdminEntity/types';
+import {
+    PaginatedEntityResponse,
+    RequestConfig
+} from 'models/AdminEntity/types';
 import { Execution, NodeExecution } from 'models/Execution/types';
 import { EventObject, State, StateMachine } from 'xstate';
 

--- a/src/components/hooks/useNamedEntity.ts
+++ b/src/components/hooks/useNamedEntity.ts
@@ -2,7 +2,11 @@ import { useAPIContext } from 'components/data/apiContext';
 import { Core } from 'flyteidl';
 import { RequestConfig } from 'models/AdminEntity/types';
 import { getNamedEntity } from 'models/Common/api';
-import { DomainIdentifierScope, NamedEntity, ResourceType } from 'models/Common/types';
+import {
+    DomainIdentifierScope,
+    NamedEntity,
+    ResourceType
+} from 'models/Common/types';
 import { useFetchableData } from './useFetchableData';
 import { usePagination } from './usePagination';
 

--- a/src/components/hooks/useNodeExecution.ts
+++ b/src/components/hooks/useNodeExecution.ts
@@ -1,5 +1,9 @@
 import { useAPIContext } from 'components/data/apiContext';
-import { ExecutionData, NodeExecution, NodeExecutionIdentifier } from 'models/Execution/types';
+import {
+    ExecutionData,
+    NodeExecution,
+    NodeExecutionIdentifier
+} from 'models/Execution/types';
 import { FetchableData } from './types';
 import { useFetchableData } from './useFetchableData';
 

--- a/src/components/hooks/useWorkflows.ts
+++ b/src/components/hooks/useWorkflows.ts
@@ -1,6 +1,10 @@
 import { useAPIContext } from 'components/data/apiContext';
 import { RequestConfig } from 'models/AdminEntity/types';
-import { IdentifierScope, NamedEntityIdentifier, ResourceType } from 'models/Common/types';
+import {
+    IdentifierScope,
+    NamedEntityIdentifier,
+    ResourceType
+} from 'models/Common/types';
 import { Workflow } from 'models/Workflow/types';
 import { usePagination } from './usePagination';
 

--- a/src/components/hooks/utils.ts
+++ b/src/components/hooks/utils.ts
@@ -1,6 +1,6 @@
-import { GloballyUniqueNode } from "models/Node/types";
-import { TaskTemplate } from "models/Task/types";
-import { Workflow } from "models/Workflow/types";
+import { GloballyUniqueNode } from 'models/Node/types';
+import { TaskTemplate } from 'models/Task/types';
+import { Workflow } from 'models/Workflow/types';
 
 export function extractTaskTemplates(workflow: Workflow): TaskTemplate[] {
     if (!workflow.closure || !workflow.closure.compiledWorkflow) {

--- a/src/mocks/createAdminServer.ts
+++ b/src/mocks/createAdminServer.ts
@@ -2,8 +2,19 @@ import { Admin } from 'flyteidl';
 import { limits } from 'models/AdminEntity/constants';
 import { EncodableType } from 'models/AdminEntity/types';
 import { adminApiUrl, encodeProtoPayload } from 'models/AdminEntity/utils';
-import { DomainIdentifierScope, Identifier, ResourceType } from 'models/Common/types';
-import { Execution, NodeExecution, NodeExecutionIdentifier, TaskExecution, TaskExecutionIdentifier, WorkflowExecutionIdentifier } from 'models/Execution/types';
+import {
+    DomainIdentifierScope,
+    Identifier,
+    ResourceType
+} from 'models/Common/types';
+import {
+    Execution,
+    NodeExecution,
+    NodeExecutionIdentifier,
+    TaskExecution,
+    TaskExecutionIdentifier,
+    WorkflowExecutionIdentifier
+} from 'models/Execution/types';
 import { LaunchPlan } from 'models/Launch/types';
 import { Project } from 'models/Project/types';
 import { Task } from 'models/Task/types';

--- a/src/mocks/data/fixtures/basicPythonWorkflow.ts
+++ b/src/mocks/data/fixtures/basicPythonWorkflow.ts
@@ -4,11 +4,10 @@ import { endNodeId, startNodeId } from 'models/Node/constants';
 import { variableNames } from '../constants';
 import {
     generateExecutionForWorkflow,
-    generateNodeExecution, generateTask,
-
-
-
-    generateTaskExecution, generateWorkflow
+    generateNodeExecution,
+    generateTask,
+    generateTaskExecution,
+    generateWorkflow
 } from '../generators';
 import { bindingFromNode, makeDefaultLaunchPlan, taskNodeIds } from '../utils';
 

--- a/src/mocks/data/fixtures/dynamicExternalSubworkflow.ts
+++ b/src/mocks/data/fixtures/dynamicExternalSubworkflow.ts
@@ -1,6 +1,12 @@
 import { cloneDeep } from 'lodash';
 import { endNodeId, startNodeId } from 'models/Node/constants';
-import { generateExecutionForWorkflow, generateNodeExecution, generateTask, generateTaskExecution, generateWorkflow } from '../generators';
+import {
+    generateExecutionForWorkflow,
+    generateNodeExecution,
+    generateTask,
+    generateTaskExecution,
+    generateWorkflow
+} from '../generators';
 import { makeDefaultLaunchPlan, taskNodeIds } from '../utils';
 
 const topWorkflowName = 'LaunchExternalSubWorkflow';

--- a/src/mocks/data/fixtures/dynamicPythonWorkflow.ts
+++ b/src/mocks/data/fixtures/dynamicPythonWorkflow.ts
@@ -3,11 +3,10 @@ import { endNodeId, startNodeId } from 'models/Node/constants';
 import { nodeIds } from '../constants';
 import {
     generateExecutionForWorkflow,
-    generateNodeExecution, generateTask,
-
-
-
-    generateTaskExecution, generateWorkflow
+    generateNodeExecution,
+    generateTask,
+    generateTaskExecution,
+    generateWorkflow
 } from '../generators';
 import { makeDefaultLaunchPlan, taskNodeIds } from '../utils';
 
@@ -81,7 +80,13 @@ function getSharedEntities() {
 }
 
 function generateWithDynamicTaskChild() {
-    const {dynamicTask, pythonTask, workflow, launchPlan, execution } = getSharedEntities();
+    const {
+        dynamicTask,
+        pythonTask,
+        workflow,
+        launchPlan,
+        execution
+    } = getSharedEntities();
     const pythonNodeExecution = generateNodeExecution(execution, pythonNodeId);
     const pythonTaskExecutions = [
         generateTaskExecution(pythonNodeExecution, pythonTask, {
@@ -139,7 +144,13 @@ function generateWithDynamicTaskChild() {
 }
 
 function generateWithNodeExecutionChild() {
-    const {dynamicTask, pythonTask, workflow, launchPlan, execution } = getSharedEntities();
+    const {
+        dynamicTask,
+        pythonTask,
+        workflow,
+        launchPlan,
+        execution
+    } = getSharedEntities();
     const dynamicNodeExecution = generateNodeExecution(
         execution,
         dynamicNodeId,
@@ -172,7 +183,7 @@ function generateWithNodeExecutionChild() {
             dynamic: dynamicTask,
             python: pythonTask
         },
-        workflows: { top: workflow},
+        workflows: { top: workflow },
         workflowExecutions: {
             top: {
                 data: execution,
@@ -183,13 +194,17 @@ function generateWithNodeExecutionChild() {
                             firstChild: {
                                 data: pythonNodeExecutions[0],
                                 taskExecutions: {
-                                    firstAttempt: { data: pythonTaskExecutions[0]}
+                                    firstAttempt: {
+                                        data: pythonTaskExecutions[0]
+                                    }
                                 }
                             },
                             secondChild: {
                                 data: pythonNodeExecutions[1],
                                 taskExecutions: {
-                                    firstAttempt: { data: pythonTaskExecutions[1]}
+                                    firstAttempt: {
+                                        data: pythonTaskExecutions[1]
+                                    }
                                 }
                             }
                         },

--- a/src/mocks/data/fixtures/types.ts
+++ b/src/mocks/data/fixtures/types.ts
@@ -1,7 +1,11 @@
-import { Execution, NodeExecution, TaskExecution } from "models/Execution/types";
-import { LaunchPlan } from "models/Launch/types";
-import { Task } from "models/Task/types";
-import { Workflow } from "models/Workflow/types";
+import {
+    Execution,
+    NodeExecution,
+    TaskExecution
+} from 'models/Execution/types';
+import { LaunchPlan } from 'models/Launch/types';
+import { Task } from 'models/Task/types';
+import { Workflow } from 'models/Workflow/types';
 
 /** Represents a TaskExecution and its associated children. */
 export interface MockTaskExecutionData {

--- a/src/mocks/data/generators.ts
+++ b/src/mocks/data/generators.ts
@@ -9,7 +9,11 @@ import {
     TaskExecutionPhase,
     WorkflowExecutionPhase
 } from 'models/Execution/enums';
-import { Execution, NodeExecution, TaskExecution } from 'models/Execution/types';
+import {
+    Execution,
+    NodeExecution,
+    TaskExecution
+} from 'models/Execution/types';
 import { LaunchPlan } from 'models/Launch/types';
 import { endNodeId, startNodeId } from 'models/Node/constants';
 import { CompiledTask, Task } from 'models/Task/types';

--- a/src/mocks/errors.ts
+++ b/src/mocks/errors.ts
@@ -1,4 +1,4 @@
-import { obj } from "test/utils";
+import { obj } from 'test/utils';
 
 export enum RequestErrorType {
     NotFound = 404,

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -3,4 +3,7 @@ import { AdminServer, createAdminServer } from './createAdminServer';
 
 const { handlers, server } = createAdminServer();
 export type MockServer = SetupServerApi & AdminServer;
-export const mockServer: MockServer = { ...setupServer(...handlers), ...server };
+export const mockServer: MockServer = {
+    ...setupServer(...handlers),
+    ...server
+};

--- a/src/models/Common/api.ts
+++ b/src/models/Common/api.ts
@@ -9,7 +9,10 @@ import {
 } from 'models/AdminEntity/AdminEntity';
 import { defaultPaginationConfig } from 'models/AdminEntity/constants';
 import { transformRequestError } from 'models/AdminEntity/transformRequestError';
-import { PaginatedEntityResponse, RequestConfig } from 'models/AdminEntity/types';
+import {
+    PaginatedEntityResponse,
+    RequestConfig
+} from 'models/AdminEntity/types';
 import { getProfileUrl } from 'models/AdminEntity/utils';
 import {
     defaultAxiosConfig,

--- a/src/models/Common/types.ts
+++ b/src/models/Common/types.ts
@@ -5,9 +5,9 @@ import { Collection } from 'react-virtualized';
 /** These are types shared across multiple sections of the data model. Most of
  * map to types found in `flyteidl.core`.
  */
-export type Alias = Core.IAlias
-export type Binding = Core.IBinding
-export type Container = Core.IContainer
+export type Alias = Core.IAlias;
+export type Binding = Core.IBinding;
+export type Container = Core.IContainer;
 export type FixedRateUnit = Admin.FixedRateUnit;
 export const FixedRateUnit = Admin.FixedRateUnit;
 export interface Identifier extends Core.IIdentifier {
@@ -18,24 +18,28 @@ export interface Identifier extends Core.IIdentifier {
     version: string;
 }
 
-export type NamedEntityIdentifier = RequiredNonNullable<Admin.INamedEntityIdentifier>
+export type NamedEntityIdentifier = RequiredNonNullable<
+    Admin.INamedEntityIdentifier
+>;
 export interface ResourceIdentifier extends NamedEntityIdentifier {
     resourceType: Core.ResourceType;
 }
 
-export type NamedEntityMetadata = RequiredNonNullable<Admin.INamedEntityMetadata>
+export type NamedEntityMetadata = RequiredNonNullable<
+    Admin.INamedEntityMetadata
+>;
 
 export interface NamedEntity extends Admin.INamedEntity {
     resourceType: Core.ResourceType;
     id: NamedEntityIdentifier;
     metadata: NamedEntityMetadata;
 }
-export type Notification = Admin.INotification
+export type Notification = Admin.INotification;
 export type ResourceType = Core.ResourceType;
 export const ResourceType = Core.ResourceType;
-export type RetryStrategy = Core.IRetryStrategy
-export type RuntimeMetadata = Core.IRuntimeMetadata
-export type Schedule = Admin.ISchedule
+export type RetryStrategy = Core.IRetryStrategy;
+export type RuntimeMetadata = Core.IRuntimeMetadata;
+export type Schedule = Admin.ISchedule;
 export type MessageFormat = Core.TaskLog.MessageFormat;
 export interface TaskLog extends Core.ITaskLog {
     name: string;
@@ -43,7 +47,7 @@ export interface TaskLog extends Core.ITaskLog {
 }
 
 /*** Literals ****/
-export type Binary = RequiredNonNullable<Core.IBinary>
+export type Binary = RequiredNonNullable<Core.IBinary>;
 
 export interface Blob extends Core.IBlob {
     metadata: BlobMetadata;
@@ -59,9 +63,9 @@ export interface BlobMetadata extends Core.IBlobMetadata {
 export interface BlobType extends Core.IBlobType {
     dimensionality: BlobDimensionality;
 }
-export type UrlBlob = Admin.IUrlBlob
+export type UrlBlob = Admin.IUrlBlob;
 
-export type Error = RequiredNonNullable<Core.IError>
+export type Error = RequiredNonNullable<Core.IError>;
 
 export interface Literal extends Core.Literal {
     value: keyof Core.ILiteral;
@@ -77,9 +81,9 @@ export interface BlobLiteral extends Core.ILiteral {
     scalar: BlobScalar;
 }
 
-export type LiteralCollection = RequiredNonNullable<Core.ILiteralCollection>
+export type LiteralCollection = RequiredNonNullable<Core.ILiteralCollection>;
 
-export type LiteralMap = RequiredNonNullable<Core.ILiteralMap>
+export type LiteralMap = RequiredNonNullable<Core.ILiteralMap>;
 export const LiteralMap = Core.LiteralMap;
 export interface LiteralMapBlob extends Admin.ILiteralMapBlob {
     values: LiteralMap;

--- a/src/models/Execution/__mocks__/mockTaskExecutionsData.ts
+++ b/src/models/Execution/__mocks__/mockTaskExecutionsData.ts
@@ -3,10 +3,7 @@ import { Admin } from 'flyteidl';
 import { cloneDeep } from 'lodash';
 import { TaskLog } from 'models/Common/types';
 import { TaskExecutionPhase } from '../enums';
-import {
-    TaskExecution,
-    TaskExecutionClosure
-} from '../types';
+import { TaskExecution, TaskExecutionClosure } from '../types';
 import { sampleError } from './sampleExecutionError';
 
 const sampleLogs: TaskLog[] = [

--- a/src/models/Execution/api.ts
+++ b/src/models/Execution/api.ts
@@ -3,10 +3,17 @@ import {
     getAdminEntity,
     postAdminEntity
 } from 'models/AdminEntity/AdminEntity';
-import { defaultListExecutionChildrenConfig, defaultPaginationConfig } from 'models/AdminEntity/constants';
+import {
+    defaultListExecutionChildrenConfig,
+    defaultPaginationConfig
+} from 'models/AdminEntity/constants';
 import { RequestConfig } from 'models/AdminEntity/types';
 import { endpointPrefixes } from 'models/Common/constants';
-import { Identifier, IdentifierScope, NameIdentifierScope } from 'models/Common/types';
+import {
+    Identifier,
+    IdentifierScope,
+    NameIdentifierScope
+} from 'models/Common/types';
 import { makeIdentifierPath } from 'models/Common/utils';
 import { defaultExecutionPrincipal } from './constants';
 import {

--- a/src/models/Execution/types.ts
+++ b/src/models/Execution/types.ts
@@ -1,12 +1,17 @@
 import { Admin, Core, Protobuf } from 'flyteidl';
-import { Identifier, LiteralMap, LiteralMapBlob, TaskLog, UrlBlob } from 'models/Common/types';
+import {
+    Identifier,
+    LiteralMap,
+    LiteralMapBlob,
+    TaskLog,
+    UrlBlob
+} from 'models/Common/types';
 import {
     ExecutionMode,
     NodeExecutionPhase,
     TaskExecutionPhase,
     WorkflowExecutionPhase
 } from './enums';
-
 
 export type WorkflowExecutionIdentifier = RequiredNonNullable<
     Core.IWorkflowExecutionIdentifier

--- a/src/models/Graph/types.ts
+++ b/src/models/Graph/types.ts
@@ -1,5 +1,5 @@
-import { NodeExecution } from "models/Execution/types";
-import { TaskTemplate } from "models/Task/types";
+import { NodeExecution } from 'models/Execution/types';
+import { TaskTemplate } from 'models/Task/types';
 
 /** A flyte-graph compatible node representation which also includes all of the
  * additional task data needed for our custom rendering

--- a/src/models/Node/types.ts
+++ b/src/models/Node/types.ts
@@ -2,9 +2,9 @@ import { Core } from 'flyteidl';
 import { Alias, Binding, Identifier } from 'models/Common/types';
 
 /** A graph node indicating a subworkflow execution */
-export type WorkflowNode = Core.IWorkflowNode
+export type WorkflowNode = Core.IWorkflowNode;
 /** A graph node indicating a branching decision. */
-export type BranchNode = Core.IBranchNode
+export type BranchNode = Core.IBranchNode;
 
 /** A graph node indicating a task to be executed. This is the most common
  * node type in a Flyte graph.

--- a/src/models/Task/types.ts
+++ b/src/models/Task/types.ts
@@ -1,5 +1,11 @@
 import { Admin, Core, Protobuf } from 'flyteidl';
-import { Container, Identifier, RetryStrategy, RuntimeMetadata, TypedInterface } from 'models/Common/types';
+import {
+    Container,
+    Identifier,
+    RetryStrategy,
+    RuntimeMetadata,
+    TypedInterface
+} from 'models/Common/types';
 
 /** Additional, optional metadata pertaining to a task template */
 

--- a/src/models/Task/utils.ts
+++ b/src/models/Task/utils.ts
@@ -5,7 +5,6 @@ import { IdentifierScope } from 'models/Common/types';
 import { makeIdentifierPath } from 'models/Common/utils';
 import { Task } from './types';
 
-
 /** Generate the correct path for retrieving a task or list of tasks based on the
  * given scope.
  */

--- a/src/models/__mocks__/executionsData.ts
+++ b/src/models/__mocks__/executionsData.ts
@@ -1,7 +1,12 @@
 import { Core, Protobuf } from 'flyteidl';
 import * as Long from 'long';
 import { LiteralMap, LiteralMapBlob } from 'models/Common/types';
-import { Execution, ExecutionClosure, ExecutionMetadata, ExecutionSpec } from 'models/Execution/types';
+import {
+    Execution,
+    ExecutionClosure,
+    ExecutionMetadata,
+    ExecutionSpec
+} from 'models/Execution/types';
 import { ExecutionMode, WorkflowExecutionPhase } from '../Execution/enums';
 
 export const MOCK_LAUNCH_PLAN_ID = {

--- a/src/models/__mocks__/projectData.ts
+++ b/src/models/__mocks__/projectData.ts
@@ -1,4 +1,4 @@
-import { Domain, Project } from "models/Project/types";
+import { Domain, Project } from 'models/Project/types';
 
 export const emptyProject = {
     id: 'emptyproject',

--- a/src/routes/ApplicationRouter.tsx
+++ b/src/routes/ApplicationRouter.tsx
@@ -1,4 +1,7 @@
-import { ContentContainer, ContentContainerProps } from 'components/common/ContentContainer';
+import {
+    ContentContainer,
+    ContentContainerProps
+} from 'components/common/ContentContainer';
 import { withSideNavigation } from 'components/Navigation/withSideNavigation';
 import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,5 +1,8 @@
 import { ensureSlashPrefixed } from 'common/utils';
-import { TaskExecutionIdentifier, WorkflowExecutionIdentifier } from 'models/Execution/types';
+import {
+    TaskExecutionIdentifier,
+    WorkflowExecutionIdentifier
+} from 'models/Execution/types';
 import {
     projectBasePath,
     projectDomainBasePath,

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -34,10 +34,7 @@ export default function serverRenderer({
             .toString();
     }
 
-    return (
-        _req: express.Request,
-        res: express.Response
-    ) => {
+    return (_req: express.Request, res: express.Response) => {
         if (isDev) {
             const indexPath = path.join(currentDirectory, 'dist', 'index.html');
             html = fileSystem.readFileSync(indexPath).toString();

--- a/src/test/modelUtils.ts
+++ b/src/test/modelUtils.ts
@@ -1,5 +1,11 @@
 import { Admin, Core } from 'flyteidl';
-import { Identifier, NamedEntity, NamedEntityIdentifier, NamedEntityMetadata, ResourceType } from 'models/Common/types';
+import {
+    Identifier,
+    NamedEntity,
+    NamedEntityIdentifier,
+    NamedEntityMetadata,
+    ResourceType
+} from 'models/Common/types';
 const defaultMetadata = {
     description: '',
     state: Admin.NamedEntityState.NAMED_ENTITY_ACTIVE

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -6,7 +6,7 @@ import { obj } from './utils';
 beforeAll(() => {
     insertDefaultData(mockServer);
     mockServer.listen({
-        onUnhandledRequest: (req) => {
+        onUnhandledRequest: req => {
             const message = `Unexpected request: ${obj(req)}`;
             throw new Error(message);
         }


### PR DESCRIPTION
When making the switch from tslint->eslint, I had mistakenly thought that running `eslint --fix` as part of precommits was enough to run prettier and fix any formatting issues on staged files. This turns out to not be the case, so lots of files were out of sync with our formatting standard.
This PR re-enables prettier as part of pre-commits and also includes a pass of running prettier on the repo.
All changes other than `package.json` should just be formatting.