### PR TITLE
fix: back button on execution detail page

### DIFF
--- a/src/components/Executions/ExecutionDetails/ExecutionDetailsAppBarContent.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionDetailsAppBarContent.tsx
@@ -11,6 +11,8 @@ import { interactiveTextDisabledColor } from 'components/Theme/constants';
 import { Execution } from 'models/Execution/types';
 import * as React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
+import { history } from 'routes/history';
+import { Routes } from 'routes/routes';
 import { ExecutionInputsOutputsModal } from '../ExecutionInputsOutputsModal';
 import { ExecutionStatusBadge } from '../ExecutionStatusBadge';
 import { TerminateExecutionButton } from '../TerminateExecution/TerminateExecutionButton';
@@ -79,12 +81,20 @@ export const ExecutionDetailsAppBarContent: React.FC<{
     const { domain, name, project } = execution.id;
     const { phase } = execution.closure;
     const sourceId = getExecutionSourceId(execution);
-    const { backLink = getExecutionBackLink(execution) } = useLocationState();
+    const {
+        backLink: originalBackLink = getExecutionBackLink(execution)
+    } = useLocationState();
     const isRunning = executionIsRunning(execution);
     const isTerminal = executionIsTerminal(execution);
     const onClickShowInputsOutputs = () => setShowInputsOutputs(true);
     const onClickRelaunch = () => setShowRelaunchForm(true);
     const onCloseRelaunch = () => setShowRelaunchForm(false);
+    const fromExecutionNav = new URLSearchParams(history.location.search).get(
+        'fromExecutionNav'
+    );
+    const backLink = fromExecutionNav
+        ? Routes.ProjectDetails.sections.executions.makeUrl(project, domain)
+        : originalBackLink;
 
     let modalContent: JSX.Element | null = null;
     if (showInputsOutputs) {

--- a/src/components/Executions/Tables/WorkflowExecutionLink.tsx
+++ b/src/components/Executions/Tables/WorkflowExecutionLink.tsx
@@ -4,6 +4,7 @@ import { WorkflowExecutionIdentifier } from 'models/Execution/types';
 import * as React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { Routes } from 'routes/routes';
+import { history } from 'routes/history';
 
 /** A simple component to render a link to a specific WorkflowExecution */
 export const WorkflowExecutionLink: React.FC<{
@@ -11,10 +12,17 @@ export const WorkflowExecutionLink: React.FC<{
     id: WorkflowExecutionIdentifier;
 }> = ({ className, id }) => {
     const commonStyles = useCommonStyles();
+    const {
+        location: { pathname }
+    } = history;
+    const fromExecutionNav = pathname.split('/').pop() === 'executions';
+
     return (
         <RouterLink
             className={classnames(commonStyles.primaryLink, className)}
-            to={Routes.ExecutionDetails.makeUrl(id)}
+            to={`${Routes.ExecutionDetails.makeUrl(id)}${
+                fromExecutionNav ? '?fromExecutionNav=true' : ''
+            }`}
         >
             {id.name}
         </RouterLink>


### PR DESCRIPTION
Signed-off-by: Pianist038801 <steven@union.ai>

Initially, when navigating to the Execution Details page via the project-level Executions list, the back button was leading to the wrong view (Workflow list or Task list).
Now it's fixed to return back to the Executions list.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/662

