### PR TITLE
fix: improve start time filter for executions

### DIFF
--- a/src/components/Executions/filters/startTimeFilters.ts
+++ b/src/components/Executions/filters/startTimeFilters.ts
@@ -37,7 +37,7 @@ export function startTimeFilters(key: string): FilterMap<StartTimeFilterKey> {
             ]
         },
         today: {
-            label: 'Today',
+            label: 'Last 24 hours',
             value: 'today',
             data: [
                 {
@@ -45,13 +45,13 @@ export function startTimeFilters(key: string): FilterMap<StartTimeFilterKey> {
                     operation: FilterOperationName.GTE,
                     value: () =>
                         moment()
-                            .startOf('day')
+                            .subtract(24, 'hour')
                             .toISOString()
                 }
             ]
         },
         yesterday: {
-            label: 'Yesterday',
+            label: 'Last 48 hours',
             value: 'yesterday',
             data: [
                 {
@@ -59,8 +59,7 @@ export function startTimeFilters(key: string): FilterMap<StartTimeFilterKey> {
                     operation: FilterOperationName.GTE,
                     value: () =>
                         moment()
-                            .startOf('day')
-                            .subtract(1, 'day')
+                            .subtract(48, 'hour')
                             .toISOString()
                 },
                 {


### PR DESCRIPTION
Signed-off-by: Pianist038801 <steven@union.ai>

This PR updates the "today" filter to be "last 24 hours", and do a similar thing with the "yesterday" filter (last 48 hours or 24-48 hours ago) when filtering workflow executions.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/539

## Follow-up issue
_NA_