### PR TITLE
Use maintained nodejs18-debian12 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN : \
   && mkdir /app \
   && cp -R ./website/console/dist/* /app
 
-FROM gcr.io/distroless/nodejs
+FROM gcr.io/distroless/nodejs18-debian12
 LABEL org.opencontainers.image.source https://github.com/flyteorg/flyteconsole
 
 COPY --from=builder /app app


### PR DESCRIPTION
# TL;DR

 - The nodejs distroless image was last updated 10 months ago and as such there are a number of high severity CVEs present in the last flyteconsole image that shipped v1.10.2

 - The existing base image is based on node v18, so for compatibility use the gcr.io/distroless/nodejs18-debian12 image, which is being actively maintained:

   https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Docker scout isn't the most thorough scanner -- but a quick compare:

#### Current image

```
❯ docker scout quickview cr.flyte.org/flyteorg/flyteconsole:v1.10.2
    i New version 1.3.0 available (installed version is 1.2.0) at https://github.com/docker/scout-cli
    ✓ SBOM of image already cached, 12 packages indexed

  Target   │  cr.flyte.org/flyteorg/flyteconsole:v1.10.2  │    1C     3H     0M     1L     1?
    digest │  1014457db028                                │
```

#### Updated image

```
❯ docker scout quickview quay.io/domino/train-flyteconsole-docker:dev
    i New version 1.3.0 available (installed version is 1.2.0) at https://github.com/docker/scout-cli
    ✓ Image stored for indexing
    ✓ Indexed 12 packages

  Target     │  quay.io/domino/train-flyteconsole-docker:dev  │    0C     0H     0M     0L
    digest   │  8da8ca41dd80                                  │
  Base image │  distroless/static-debian12:nonroot            │    0C     0H     0M     0L
```

## Follow-up issue
_NA_
