### PR TITLE
feat: display execution tags and filter

### DIFF
--- a/packages/console/src/components/Executions/ExecutionFilters.tsx
+++ b/packages/console/src/components/Executions/ExecutionFilters.tsx
@@ -5,12 +5,14 @@ import { MultiSelectForm } from 'components/common/MultiSelectForm';
 import { SearchInputForm } from 'components/common/SearchInputForm';
 import { SingleSelectForm } from 'components/common/SingleSelectForm';
 import { FilterPopoverButton } from 'components/Tables/filters/FilterPopoverButton';
+import { TagsInputForm } from 'components/common/TagsInputForm';
 import {
   FilterState,
   MultiFilterState,
   SearchFilterState,
   SingleFilterState,
   BooleanFilterState,
+  TagsFilterState,
 } from './filters/types';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -49,6 +51,7 @@ export interface ExecutionFiltersProps {
 
 const RenderFilter: React.FC<{ filter: FilterState }> = ({ filter }) => {
   const searchFilterState = filter as SearchFilterState;
+  const tagsFilterState = filter as TagsFilterState;
   switch (filter.type) {
     case 'single':
       return <SingleSelectForm {...(filter as SingleFilterState<any>)} />;
@@ -59,6 +62,13 @@ const RenderFilter: React.FC<{ filter: FilterState }> = ({ filter }) => {
         <SearchInputForm
           {...searchFilterState}
           defaultValue={searchFilterState.value}
+        />
+      );
+    case 'tags':
+      return (
+        <TagsInputForm
+          {...tagsFilterState}
+          defaultValue={tagsFilterState.tags}
         />
       );
     default:

--- a/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/cells.tsx
+++ b/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/cells.tsx
@@ -22,6 +22,7 @@ import { Execution } from 'models/Execution/types';
 import { ExecutionState, WorkflowExecutionPhase } from 'models/Execution/enums';
 import classnames from 'classnames';
 import { LaunchPlanLink } from 'components/LaunchPlan/LaunchPlanLink';
+import { getColorFromString } from 'components/utils';
 import { WorkflowExecutionsTableState } from '../types';
 import { WorkflowExecutionLink } from '../WorkflowExecutionLink';
 import { getWorkflowExecutionTimingMS, isExecutionArchived } from '../../utils';
@@ -115,7 +116,10 @@ export function getExecutionTagsCell(
             key={tag}
             label={tag}
             size="small"
-            color={isArchived ? 'default' : 'primary'}
+            color="default"
+            style={{
+              backgroundColor: isArchived ? undefined : getColorFromString(tag),
+            }}
           />
         );
       })}

--- a/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/cells.tsx
+++ b/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/cells.tsx
@@ -4,6 +4,7 @@ import {
   IconButton,
   Button,
   CircularProgress,
+  Chip,
 } from '@material-ui/core';
 import ArchiveOutlined from '@material-ui/icons/ArchiveOutlined';
 import UnarchiveOutline from '@material-ui/icons/UnarchiveOutlined';
@@ -97,6 +98,28 @@ export function getDurationCell(execution: Execution): React.ReactNode {
     >
       {timing !== null ? millisecondsToHMS(timing.duration) : ''}
     </Typography>
+  );
+}
+
+export function getExecutionTagsCell(
+  execution: Execution,
+  className: string,
+): React.ReactNode {
+  const isArchived = isExecutionArchived(execution);
+  const tags = execution.spec.tags ?? [];
+  return (
+    <div className={className}>
+      {tags.map(tag => {
+        return (
+          <Chip
+            key={tag}
+            label={tag}
+            size="small"
+            color={isArchived ? 'default' : 'primary'}
+          />
+        );
+      })}
+    </div>
   );
 }
 

--- a/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/strings.ts
+++ b/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/strings.ts
@@ -5,6 +5,7 @@ import { Protobuf } from '@flyteorg/flyteidl-types';
 
 const str = {
   tableLabel_name: 'execution id',
+  tableLabel_tags: 'tags',
   tableLabel_launchPlan: 'launch plan',
   tableLabel_phase: 'status',
   tableLabel_startedAt: 'start time',

--- a/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/styles.ts
+++ b/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/styles.ts
@@ -10,6 +10,11 @@ export const useStyles = makeStyles((theme: Theme) => ({
     flexBasis: workflowExecutionsTableColumnWidths.name,
     whiteSpace: 'normal',
   },
+  columnExecutionTags: {
+    flexGrow: 1,
+    flexBasis: workflowExecutionsTableColumnWidths.tags,
+    whiteSpace: 'normal',
+  },
   columnLaunchPlan: {
     flexGrow: 1,
     flexBasis: workflowExecutionsTableColumnWidths.launchPlan,
@@ -55,5 +60,9 @@ export const useStyles = makeStyles((theme: Theme) => ({
   actionProgress: {
     width: '100px', // same as confirmationButton size
     textAlign: 'center',
+  },
+  executionTagsStack: {
+    display: 'flex',
+    gap: theme.spacing(0.5),
   },
 }));

--- a/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/styles.ts
+++ b/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/styles.ts
@@ -64,5 +64,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
   executionTagsStack: {
     display: 'flex',
     gap: theme.spacing(0.5),
+    flexWrap: 'wrap',
   },
 }));

--- a/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/useWorkflowExecutionsTableColumns.tsx
+++ b/packages/console/src/components/Executions/Tables/WorkflowExecutionTable/useWorkflowExecutionsTableColumns.tsx
@@ -12,6 +12,7 @@ import {
   getStartTimeCell,
   getStatusCell,
   getLaunchPlanCell,
+  getExecutionTagsCell,
 } from './cells';
 import { useStyles } from './styles';
 import t, { patternKey } from './strings';
@@ -44,6 +45,13 @@ export function useWorkflowExecutionsTableColumns(
         className: styles.columnName,
         key: 'name',
         label: t(patternKey('tableLabel', 'name')),
+      },
+      {
+        cellRenderer: ({ execution }) =>
+          getExecutionTagsCell(execution, styles.executionTagsStack),
+        className: styles.columnExecutionTags,
+        key: 'tags',
+        label: t(patternKey('tableLabel', 'tags')),
       },
       {
         cellRenderer: ({ execution }) =>

--- a/packages/console/src/components/Executions/Tables/constants.ts
+++ b/packages/console/src/components/Executions/Tables/constants.ts
@@ -6,7 +6,7 @@ export const workflowExecutionsTableColumnWidths = {
   launchPlan: 120,
   phase: 120,
   startedAt: 200,
-  tags: 120,
+  tags: 200,
 };
 
 export const nodeExecutionsTableColumnWidths = {

--- a/packages/console/src/components/Executions/Tables/constants.ts
+++ b/packages/console/src/components/Executions/Tables/constants.ts
@@ -2,10 +2,11 @@ export const workflowExecutionsTableColumnWidths = {
   duration: 100,
   actions: 130,
   lastRun: 130,
-  name: 240,
+  name: 200,
   launchPlan: 120,
   phase: 120,
   startedAt: 200,
+  tags: 120,
 };
 
 export const nodeExecutionsTableColumnWidths = {

--- a/packages/console/src/components/Executions/filters/constants.ts
+++ b/packages/console/src/components/Executions/filters/constants.ts
@@ -3,4 +3,5 @@ export const filterLabels = {
   startTime: 'Start Time',
   status: 'Status',
   version: 'Version',
+  tags: 'Tags',
 };

--- a/packages/console/src/components/Executions/filters/types.ts
+++ b/packages/console/src/components/Executions/filters/types.ts
@@ -20,7 +20,12 @@ export interface FilterButtonState {
   onClick: () => void;
 }
 
-export type FilterStateType = 'single' | 'multi' | 'search' | 'boolean';
+export type FilterStateType =
+  | 'single'
+  | 'multi'
+  | 'search'
+  | 'boolean'
+  | 'tags';
 
 export interface FilterState {
   active: boolean;
@@ -59,4 +64,11 @@ export interface MultiFilterState<FilterKey extends string, DataType>
 export interface BooleanFilterState extends FilterState {
   setActive: (active: boolean) => void;
   type: 'boolean';
+}
+
+export interface TagsFilterState extends FilterState {
+  onChange: (newTags: string[]) => void;
+  placeholder: string;
+  type: 'tags';
+  tags: string[];
 }

--- a/packages/console/src/components/Executions/filters/useExecutionFiltersState.ts
+++ b/packages/console/src/components/Executions/filters/useExecutionFiltersState.ts
@@ -14,6 +14,7 @@ import { FilterState } from './types';
 import { useMultiFilterState } from './useMultiFilterState';
 import { useSearchFilterState } from './useSearchFilterState';
 import { useSingleFilterState } from './useSingleFilterState';
+import { useTagsFilterState } from './useTagsFilterState';
 
 export interface ExecutionFiltersState {
   appliedFilters: FilterOperation[];
@@ -44,6 +45,12 @@ export function useWorkflowExecutionFiltersState() {
       label: filterLabels.status,
       listHeader: 'Filter By',
       queryStateKey: 'status',
+    }),
+    useTagsFilterState({
+      filterKey: 'admin_tag.name',
+      label: filterLabels.tags,
+      placeholder: 'Enter Tags String',
+      queryStateKey: 'tags',
     }),
     useSearchFilterState({
       filterKey: 'workflow.version',

--- a/packages/console/src/components/Executions/filters/useTagsFilterState.ts
+++ b/packages/console/src/components/Executions/filters/useTagsFilterState.ts
@@ -1,0 +1,87 @@
+import { useQueryState } from 'components/hooks/useQueryState';
+import { FilterOperationName } from 'models/AdminEntity/types';
+import { useEffect, useState } from 'react';
+import { TagsFilterState } from './types';
+import { useFilterButtonState } from './useFilterButtonState';
+
+function serializeForQueryState(values: any[]) {
+  return values.join(';');
+}
+function deserializeFromQueryState(stateValue = '') {
+  return stateValue.split(';');
+}
+
+interface TagsFilterStateStateArgs {
+  defaultValue?: string[];
+  filterKey: string;
+  filterOperation?: FilterOperationName;
+  label: string;
+  placeholder: string;
+  queryStateKey: string;
+}
+
+/** Maintains the state for a `TagsInputForm` filter.
+ * The generated `FilterOperation` will use the provided `key` and `operation`
+ * (defaults to `VALUE_IN`)
+ * The current search value will be synced to the query string using the
+ * provided `queryStateKey` value.
+ */
+export function useTagsFilterState({
+  defaultValue = [],
+  filterKey,
+  filterOperation = FilterOperationName.VALUE_IN,
+  label,
+  placeholder,
+  queryStateKey,
+}: TagsFilterStateStateArgs): TagsFilterState {
+  const { params, setQueryStateValue } =
+    useQueryState<Record<string, string>>();
+  const queryStateValue = params[queryStateKey];
+
+  const [tags, setTags] = useState(defaultValue);
+  const active = tags.length !== 0;
+
+  const button = useFilterButtonState();
+  const onChange = (newValue: string[]) => {
+    setTags(newValue);
+  };
+
+  const onReset = () => {
+    setTags(defaultValue);
+    button.setOpen(false);
+  };
+
+  useEffect(() => {
+    const queryValue = tags.length ? serializeForQueryState(tags) : undefined;
+    setQueryStateValue(queryStateKey, queryValue);
+  }, [tags.join(), queryStateKey]);
+
+  useEffect(() => {
+    if (queryStateValue) {
+      setTags(deserializeFromQueryState(queryStateValue));
+    }
+  }, [queryStateValue]);
+
+  const getFilter = () =>
+    tags.length
+      ? [
+          {
+            value: tags,
+            key: filterKey,
+            operation: filterOperation,
+          },
+        ]
+      : [];
+
+  return {
+    active,
+    button,
+    getFilter,
+    onChange,
+    onReset,
+    label,
+    placeholder,
+    tags,
+    type: 'tags',
+  };
+}

--- a/packages/console/src/components/common/TagsInputForm.tsx
+++ b/packages/console/src/components/common/TagsInputForm.tsx
@@ -1,0 +1,154 @@
+import {
+  Chip,
+  FormControl,
+  FormLabel,
+  IconButton,
+  InputAdornment,
+  makeStyles,
+  OutlinedInput,
+  Theme,
+  Link,
+} from '@material-ui/core';
+import { Add } from '@material-ui/icons';
+import { getColorFromString } from 'components/utils';
+import * as React from 'react';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  input: {
+    margin: `${theme.spacing(1)}px 0`,
+  },
+  listHeader: {
+    color: theme.palette.text.secondary,
+    lineHeight: 1.5,
+    textTransform: 'uppercase',
+  },
+  resetLink: {
+    marginLeft: theme.spacing(4),
+    width: theme.spacing(5),
+  },
+  title: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    margin: 0,
+    textTransform: 'uppercase',
+    color: theme.palette.text.secondary,
+  },
+  tagStack: {
+    display: 'flex',
+    gap: theme.spacing(0.5),
+    flexWrap: 'wrap',
+    width: '240px',
+    margin: `${theme.spacing(1)}px 0`,
+  },
+}));
+
+export interface TagsInputFormProps {
+  label: string;
+  placeholder?: string;
+  onChange: (tags: string[]) => void;
+  defaultValue: string[];
+}
+
+/** Form content for rendering a header and search input. The value is applied
+ * on submission of the form.
+ */
+export const TagsInputForm: React.FC<TagsInputFormProps> = ({
+  label,
+  placeholder,
+  onChange,
+  defaultValue,
+}) => {
+  const [tags, setTags] = React.useState<string[]>(defaultValue);
+  const [value, setValue] = React.useState('');
+  const composition = React.useRef(false);
+
+  const styles = useStyles();
+  const onInputChange: React.ChangeEventHandler<HTMLInputElement> = ({
+    target: { value },
+  }) => setValue(value);
+
+  const addTag = () => {
+    const newTag = value.trim();
+    setValue('');
+    if (!tags.includes(newTag) && newTag !== '') {
+      const newTags = [...tags, newTag];
+      setTags(newTags);
+      onChange(newTags);
+    }
+  };
+
+  const removeTag = (tag: string) => {
+    const newTags = tags.filter(t => t !== tag);
+    setTags(newTags);
+    onChange(newTags);
+  };
+
+  const handleClickReset = () => {
+    setTags([]);
+    onChange([]);
+  };
+
+  const resetControl = tags.length ? (
+    <Link
+      className={styles.resetLink}
+      component="button"
+      variant="body1"
+      onClick={handleClickReset}
+    >
+      Reset
+    </Link>
+  ) : (
+    <div className={styles.resetLink} />
+  );
+
+  return (
+    <div>
+      <div className={styles.title}>
+        <FormLabel className={styles.listHeader}>{label}</FormLabel>
+        {resetControl}
+      </div>
+      <FormControl margin="dense" variant="outlined" fullWidth={true}>
+        <OutlinedInput
+          autoFocus={true}
+          className={styles.input}
+          labelWidth={0}
+          onChange={onInputChange}
+          onCompositionStart={() => (composition.current = true)}
+          onCompositionEnd={() => (composition.current = false)}
+          placeholder={placeholder}
+          type="text"
+          value={value}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !composition.current) {
+              addTag();
+            }
+          }}
+          endAdornment={
+            <InputAdornment position="end">
+              <IconButton component="span" size="small" onClick={addTag}>
+                <Add />
+              </IconButton>
+            </InputAdornment>
+          }
+        />
+        <div className={styles.tagStack}>
+          {tags.map(tag => {
+            return (
+              <Chip
+                key={tag}
+                label={tag}
+                color="default"
+                size="small"
+                onDelete={() => removeTag(tag)}
+                style={{
+                  backgroundColor: getColorFromString(tag),
+                }}
+              />
+            );
+          })}
+        </div>
+      </FormControl>
+    </div>
+  );
+};

--- a/packages/console/src/components/utils/index.ts
+++ b/packages/console/src/components/utils/index.ts
@@ -1,3 +1,22 @@
 export const removeLeadingSlash = (pathName: string | null): string => {
   return pathName?.replace(/^\//, '') || '';
 };
+
+export const getColorFromString = (str: string) => {
+  const strToDec = (string: string) => {
+    return (
+      Array.from<string>(string)
+        .map(c => c.codePointAt(0) || 0)
+        .reduce((sum, char, i) => sum + ((i + 1) * char) / 256, 0) % 1
+    );
+  };
+  return (
+    'hsl(' +
+    360 * strToDec(str) +
+    ',' +
+    (40 + 60 * strToDec(str)) +
+    '%,' +
+    (75 + 10 * strToDec(str)) +
+    '%)'
+  );
+};


### PR DESCRIPTION
# TL;DR
Issue: https://github.com/flyteorg/flyte/issues/3960
## Implement execution tags displaying
1. Normal
![image](https://github.com/flyteorg/flyteconsole/assets/59022542/d30928e3-fb7c-44de-913d-f3b99038c1a1)
2. Archived
![image](https://github.com/flyteorg/flyteconsole/assets/59022542/472ee927-ce06-4d3a-9ccb-eac4d04deb96)

## Implement table filter for execution tags 
![image](https://github.com/flyteorg/flyteconsole/assets/59022542/4d60b30e-0987-41b4-8fe7-39c9ec4eaa22)


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
1. Add "tags" column for execution table. 
2. Use VALUE_IN operation to filter "admin_tag.name"
3. Hash tag string into decimal number and present tag colors by HSL.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
