### PR TITLE
feat: change string length before collapse in json view

### DIFF
--- a/packages/console/src/components/common/ReactJsonView.tsx
+++ b/packages/console/src/components/common/ReactJsonView.tsx
@@ -99,7 +99,7 @@ export const ReactJsonViewWrapper: React.FC<ReactJsonViewProps> = props => {
         displayObjectSize={true}
         name={null}
         indentWidth={4}
-        collapseStringsAfterLength={80}
+        collapseStringsAfterLength={100}
         sortKeys={true}
         {...props}
       />


### PR DESCRIPTION
# TL;DR
Most S3 storage links are longer than 80 characters and would collapse. Changing the length to 100 will prevent the links from collapsing. 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Change the length before collapse to 100. 


## Follow-up issue
_NA_
