### PR TITLE
Display failure node in workflow graph

### DIFF
--- a/packages/console/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
+++ b/packages/console/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
@@ -492,6 +492,28 @@ const parseWorkflow = (
     };
   }
 
+  /* Build failure node and add downstream connection for edges building */
+  const failureNode = context.template.failureNode;
+  if (failureNode && failureNode.id) {
+    parseNode({
+      node: failureNode as CompiledNode,
+      root: root,
+      dynamicToMerge,
+      nodeExecutionsById,
+      staticExecutionIdsMap,
+      workflow,
+    });
+    nodeMap[failureNode.id] = {
+      dNode: root.nodes[root.nodes.length - 1],
+      compiledNode: failureNode as CompiledNode,
+    };
+    if (
+      !context.connections.downstream[startNodeId].ids.includes(failureNode.id)
+    ) {
+      context.connections.downstream[startNodeId].ids.push(failureNode.id);
+    }
+  }
+
   /* Build Edges */
   buildWorkflowEdges(root, context.connections, startNodeId, nodeMap);
   return root;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Display failure node in workflow graph, including failure workflow. 
![image](https://github.com/flyteorg/flyteconsole/assets/59022542/11d8e92c-e02a-4537-9f12-8bb2a8df9a3e)
![image](https://github.com/flyteorg/flyteconsole/assets/59022542/647bc898-2314-43af-9406-c30f20071362)

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Modified parseWorkflow function to parse failure nodes. To avoid excessive changes, use the same construction method as much as possible. Node annotations or styles could be added in the future according to needs (Might need additional property).

## Tracking Issue
_NA_

## Follow-up issue
_NA_