### PR TITLE
Feat: Allow setting advanced options on task launch like workflow launch

### DIFF
--- a/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormComponents/LaunchFormAdvancedInputs.tsx
+++ b/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormComponents/LaunchFormAdvancedInputs.tsx
@@ -15,6 +15,9 @@ import validator from '@rjsf/validator-ajv8';
 import { State } from 'xstate';
 import { LaunchAdvancedOptionsRef } from '../types';
 import {
+  TaskLaunchContext,
+  TaskLaunchEvent,
+  TaskLaunchTypestate,
   WorkflowLaunchContext,
   WorkflowLaunchEvent,
   WorkflowLaunchTypestate,
@@ -22,7 +25,9 @@ import {
 import { useStyles } from '../styles';
 
 interface LaunchAdvancedOptionsProps {
-  state: State<WorkflowLaunchContext, WorkflowLaunchEvent, any, WorkflowLaunchTypestate>;
+  state:
+    | State<WorkflowLaunchContext, WorkflowLaunchEvent, any, WorkflowLaunchTypestate>
+    | State<TaskLaunchContext, TaskLaunchEvent, any, TaskLaunchTypestate>;
 }
 
 const isValueValid = (value: any) => {
@@ -35,9 +40,7 @@ export const LaunchFormAdvancedInputs = forwardRef<
 >(
   (
     {
-      state: {
-        context: { launchPlan, ...other },
-      },
+      state: { context },
     },
     ref,
   ) => {
@@ -48,61 +51,76 @@ export const LaunchFormAdvancedInputs = forwardRef<
     const [maxParallelism, setMaxParallelism] = useState('');
     const [rawOutputDataConfig, setRawOutputDataConfig] = useState('');
 
+    // Only show max parallelism for workflow launches, not task launches
+    const isWorkflowLaunch = 'launchPlan' in context;
+
     useEffect(() => {
-      if (isValueValid(other.disableAll)) {
-        setDisableAll(other.disableAll!);
+      if (isValueValid(context.disableAll)) {
+        setDisableAll(context.disableAll!);
       }
-      if (isValueValid(other.maxParallelism)) {
-        setMaxParallelism(`${other.maxParallelism}`);
+      // maxParallelism only exists on WorkflowLaunchContext
+      if (isWorkflowLaunch && 'maxParallelism' in context && isValueValid(context.maxParallelism)) {
+        setMaxParallelism(`${context.maxParallelism}`);
       }
       if (
-        other?.rawOutputDataConfig?.outputLocationPrefix !== undefined &&
-        other.rawOutputDataConfig.outputLocationPrefix !== null
+        context?.rawOutputDataConfig?.outputLocationPrefix !== undefined &&
+        context.rawOutputDataConfig.outputLocationPrefix !== null
       ) {
-        setRawOutputDataConfig(other.rawOutputDataConfig.outputLocationPrefix);
+        setRawOutputDataConfig(context.rawOutputDataConfig.outputLocationPrefix);
       }
+      // Access launchPlan safely - it only exists in WorkflowLaunchContext
+      const launchPlan = isWorkflowLaunch ? context.launchPlan : undefined;
       const newLabels = {
-        ...(other.labels?.values || {}),
+        ...(context.labels?.values || {}),
         ...(launchPlan?.spec?.labels?.values || {}),
       };
       const newAnnotations = {
-        ...(other.annotations?.values || {}),
+        ...(context.annotations?.values || {}),
         ...(launchPlan?.spec?.annotations?.values || {}),
       };
       setLabelsParamData(newLabels);
       setAnnotationsParamData(newAnnotations);
     }, [
-      other.disableAll,
-      other.maxParallelism,
-      other.rawOutputDataConfig,
-      other.labels,
-      other.annotations,
-      launchPlan?.spec,
+      context.disableAll,
+      context.rawOutputDataConfig,
+      context.labels,
+      context.annotations,
+      context,
+      isWorkflowLaunch,
     ]);
 
     useImperativeHandle(
       ref,
       () => ({
         getValues: () => {
-          return {
+          const baseValues = {
             disableAll,
             rawOutputDataConfig: {
               outputLocationPrefix: rawOutputDataConfig,
             },
-            maxParallelism: parseInt(maxParallelism || '', 10),
             labels: {
               values: labelsParamData,
             },
             annotations: {
               values: annotationsParamData,
             },
-          } as Admin.IExecutionSpec;
+          };
+
+          // Only include maxParallelism for workflow launches
+          if (isWorkflowLaunch) {
+            return {
+              ...baseValues,
+              maxParallelism: parseInt(maxParallelism || '', 10),
+            } as Admin.IExecutionSpec;
+          }
+
+          return baseValues as Admin.IExecutionSpec;
         },
         validate: () => {
           return true;
         },
       }),
-      [disableAll, maxParallelism, rawOutputDataConfig, labelsParamData, annotationsParamData],
+      [disableAll, maxParallelism, rawOutputDataConfig, labelsParamData, annotationsParamData, isWorkflowLaunch],
     );
 
     const handleDisableAllChange = useCallback(() => {
@@ -211,16 +229,18 @@ export const LaunchFormAdvancedInputs = forwardRef<
             onChange={handleRawOutputDataConfigChange}
           />
         </section>
-        <section title="Max parallelism">
-          <TextField
-            variant="outlined"
-            label="Max parallelism"
-            fullWidth
-            margin="normal"
-            value={maxParallelism}
-            onChange={handleMaxParallelismChange}
-          />
-        </section>
+        {isWorkflowLaunch ? (
+          <section title="Max parallelism">
+            <TextField
+              variant="outlined"
+              label="Max parallelism"
+              fullWidth
+              margin="normal"
+              value={maxParallelism}
+              onChange={handleMaxParallelismChange}
+            />
+          </section>
+        ) : null}
       </>
     );
   },

--- a/packages/oss-console/src/components/Launch/LaunchForm/LaunchTaskForm.tsx
+++ b/packages/oss-console/src/components/Launch/LaunchForm/LaunchTaskForm.tsx
@@ -1,4 +1,9 @@
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
 import DialogContent from '@mui/material/DialogContent';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import * as React from 'react';
 import { getCacheKey } from '../../Cache/utils';
 import t from './strings';
@@ -9,6 +14,7 @@ import { LaunchState } from './launchMachine';
 import { LaunchRoleInput } from './LaunchRoleInput';
 import { LaunchInterruptibleInput } from './LaunchFormComponents/LaunchInterruptibleInput';
 import { LaunchOverwriteCacheInput } from './LaunchFormComponents/LaunchOverwriteCacheInput';
+import { LaunchFormAdvancedInputs } from './LaunchFormComponents/LaunchFormAdvancedInputs';
 import { SearchableSelector } from './LaunchFormComponents/SearchableSelector';
 import { useStyles } from './styles';
 import { BaseInterpretedLaunchState, BaseLaunchService, LaunchTaskFormProps } from './types';
@@ -20,6 +26,7 @@ export const LaunchTaskForm: React.FC<LaunchTaskFormProps> = (props) => {
   const {
     formInputsRef,
     roleInputRef,
+    advancedOptionsRef,
     interruptibleInputRef,
     overwriteCacheInputRef,
     state,
@@ -65,13 +72,6 @@ export const LaunchTaskForm: React.FC<LaunchTaskFormProps> = (props) => {
             />
           </section>
         ) : null}
-        {isEnterInputsState(baseState) ? (
-          <LaunchRoleInput
-            initialValue={state.context.defaultAuthRole}
-            ref={roleInputRef}
-            showErrors={state.context.showErrors}
-          />
-        ) : null}
         <LaunchFormInputs
           key={formKey}
           ref={formInputsRef}
@@ -79,14 +79,39 @@ export const LaunchTaskForm: React.FC<LaunchTaskFormProps> = (props) => {
           variant="task"
           setIsError={setIsError}
         />
-        <LaunchInterruptibleInput
-          initialValue={state.context.interruptible}
-          ref={interruptibleInputRef}
-        />
-        <LaunchOverwriteCacheInput
-          initialValue={state.context.overwriteCache}
-          ref={overwriteCacheInputRef}
-        />
+        <Accordion className={styles.noBorder}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            classes={{
+              root: styles.summaryWrapper,
+              content: styles.advancedOptions,
+            }}
+          >
+            <Typography variant="body1" fontWeight={500} paddingRight={1}>
+              Advanced options
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails classes={{ root: styles.detailsWrapper }}>
+            {isEnterInputsState(baseState) ? (
+              <LaunchRoleInput
+                initialValue={state.context.defaultAuthRole}
+                ref={roleInputRef}
+                showErrors={state.context.showErrors}
+              />
+            ) : null}
+            {isEnterInputsState(baseState) ? (
+              <LaunchFormAdvancedInputs ref={advancedOptionsRef} state={state} />
+            ) : null}
+            <LaunchInterruptibleInput
+              initialValue={state.context.interruptible}
+              ref={interruptibleInputRef}
+            />
+            <LaunchOverwriteCacheInput
+              initialValue={state.context.overwriteCache}
+              ref={overwriteCacheInputRef}
+            />
+          </AccordionDetails>
+        </Accordion>
       </DialogContent>
       <LaunchFormActions
         state={baseState}

--- a/packages/oss-console/src/components/Launch/LaunchForm/launchMachine.ts
+++ b/packages/oss-console/src/components/Launch/LaunchForm/launchMachine.ts
@@ -103,6 +103,10 @@ export interface TaskLaunchContext extends BaseLaunchContext {
   preferredTaskId?: Identifier;
   taskVersion?: Identifier;
   taskVersionOptions?: Task[];
+  disableAll?: boolean | null;
+  rawOutputDataConfig?: Admin.IRawOutputDataConfig | null;
+  labels?: Admin.ILabels | null;
+  annotations?: Admin.IAnnotations | null;
   interruptible?: Protobuf.IBoolValue | null;
   overwriteCache?: boolean | null;
 }

--- a/packages/oss-console/src/components/Launch/LaunchForm/types.ts
+++ b/packages/oss-console/src/components/Launch/LaunchForm/types.ts
@@ -80,6 +80,10 @@ export interface TaskInitialLaunchParameters extends BaseInitialLaunchParameters
   taskId?: Identifier;
   authRole?: Admin.IAuthRole;
   securityContext?: Core.ISecurityContext;
+  disableAll?: boolean | null;
+  rawOutputDataConfig?: Admin.IRawOutputDataConfig | null;
+  labels?: Admin.ILabels | null;
+  annotations?: Admin.IAnnotations | null;
   interruptible?: Protobuf.IBoolValue | null;
   overwriteCache?: boolean | null;
 }
@@ -149,6 +153,7 @@ export interface LaunchWorkflowFormState {
 }
 
 export interface LaunchTaskFormState {
+  advancedOptionsRef: React.RefObject<LaunchAdvancedOptionsRef>;
   formInputsRef: React.RefObject<LaunchFormInputsRef>;
   roleInputRef: React.RefObject<LaunchRoleInputRef>;
   interruptibleInputRef: React.RefObject<LaunchInterruptibleInputRef>;

--- a/packages/oss-console/src/components/Launch/LaunchForm/useLaunchTaskFormState.ts
+++ b/packages/oss-console/src/components/Launch/LaunchForm/useLaunchTaskFormState.ts
@@ -22,6 +22,7 @@ import {
 } from './launchMachine';
 import { validate as baseValidate } from './services';
 import {
+  LaunchAdvancedOptionsRef,
   LaunchFormInputsRef,
   LaunchInterruptibleInputRef,
   LaunchOverwriteCacheInputRef,
@@ -97,6 +98,7 @@ async function loadInputs(
 async function validate(
   formInputsRef: RefObject<LaunchFormInputsRef>,
   roleInputRef: RefObject<LaunchRoleInputRef>,
+  _advancedOptionsRef: RefObject<LaunchAdvancedOptionsRef>,
   _interruptibleInputRef: RefObject<LaunchInterruptibleInputRef>,
   _overwriteCacheInputRef: RefObject<LaunchOverwriteCacheInputRef>,
 ) {
@@ -114,6 +116,7 @@ async function submit(
   { createWorkflowExecution }: APIContextValue,
   formInputsRef: RefObject<LaunchFormInputsRef>,
   roleInputRef: RefObject<LaunchRoleInputRef>,
+  advancedOptionsRef: RefObject<LaunchAdvancedOptionsRef>,
   interruptibleInputRef: RefObject<LaunchInterruptibleInputRef>,
   overwriteCacheInputRef: RefObject<LaunchOverwriteCacheInputRef>,
   { referenceExecutionId, taskVersion }: TaskLaunchContext,
@@ -130,14 +133,20 @@ async function submit(
 
   const { securityContext } = roleInputRef?.current?.getValue?.() || {};
   const literals = formInputsRef.current.getValues();
+  const { disableAll, labels, annotations, rawOutputDataConfig } =
+    advancedOptionsRef.current?.getValues() || {};
   const interruptible = interruptibleInputRef.current?.getValue();
   const overwriteCache = overwriteCacheInputRef.current?.getValue();
   const launchPlanId = taskVersion;
   const { domain, project } = taskVersion;
 
   const response = await createWorkflowExecution({
+    annotations,
     securityContext,
+    disableAll,
+    rawOutputDataConfig,
     domain,
+    labels,
     launchPlanId,
     project,
     referenceExecutionId,
@@ -157,6 +166,7 @@ function getServices(
   apiContext: APIContextValue,
   formInputsRef: RefObject<LaunchFormInputsRef>,
   roleInputRef: RefObject<LaunchRoleInputRef>,
+  advancedOptionsRef: RefObject<LaunchAdvancedOptionsRef>,
   interruptibleInputRef: RefObject<LaunchInterruptibleInputRef>,
   overwriteCacheInputRef: RefObject<LaunchOverwriteCacheInputRef>,
 ) {
@@ -168,17 +178,19 @@ function getServices(
         apiContext,
         formInputsRef,
         roleInputRef,
+        advancedOptionsRef,
         interruptibleInputRef,
         overwriteCacheInputRef,
         launchContext,
       ),
-    validate: partial(
-      validate,
-      formInputsRef,
-      roleInputRef,
-      interruptibleInputRef,
-      overwriteCacheInputRef,
-    ),
+    validate: () =>
+      validate(
+        formInputsRef,
+        roleInputRef,
+        advancedOptionsRef,
+        interruptibleInputRef,
+        overwriteCacheInputRef,
+      ),
   };
 }
 
@@ -196,6 +208,10 @@ export function useLaunchTaskFormState({
     authRole: defaultAuthRole,
     taskId: preferredTaskId,
     values: defaultInputValues,
+    disableAll,
+    rawOutputDataConfig,
+    labels,
+    annotations,
     interruptible,
     overwriteCache,
   } = initialParameters;
@@ -203,6 +219,7 @@ export function useLaunchTaskFormState({
   const apiContext = useAPIContext();
   const formInputsRef = useRef<LaunchFormInputsRef>(null);
   const roleInputRef = useRef<LaunchRoleInputRef>(null);
+  const advancedOptionsRef = useRef<LaunchAdvancedOptionsRef>(null);
   const interruptibleInputRef = useRef<LaunchInterruptibleInputRef>(null);
   const overwriteCacheInputRef = useRef<LaunchOverwriteCacheInputRef>(null);
 
@@ -212,10 +229,11 @@ export function useLaunchTaskFormState({
         apiContext,
         formInputsRef,
         roleInputRef,
+        advancedOptionsRef,
         interruptibleInputRef,
         overwriteCacheInputRef,
       ),
-    [apiContext, formInputsRef, roleInputRef, interruptibleInputRef, overwriteCacheInputRef],
+    [apiContext, formInputsRef, roleInputRef, advancedOptionsRef, interruptibleInputRef, overwriteCacheInputRef],
   );
 
   const [state, sendEvent, service] = useMachine<
@@ -231,6 +249,10 @@ export function useLaunchTaskFormState({
       preferredTaskId,
       referenceExecutionId,
       sourceId,
+      disableAll,
+      rawOutputDataConfig,
+      labels,
+      annotations,
       interruptible,
       overwriteCache,
     },
@@ -282,6 +304,7 @@ export function useLaunchTaskFormState({
   }, [service, sendEvent]);
 
   return {
+    advancedOptionsRef,
     formInputsRef,
     roleInputRef,
     interruptibleInputRef,


### PR DESCRIPTION
# TL;DR
Currently one can set so-called "advanced options" like labels, annotations, raw output prefix, ... when launching a workflow. One cannot currently do so when launching a task.

This PR adds the same "advanced options" to the task launch menu (minus max parallelism which doesn't make sense for launching tasks).

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue