### PR TITLE
fix: use correct workflow name/version in execution breadcrumbs

### DIFF
--- a/packages/oss-console/src/components/Breadcrumbs/async/executionContext.test.ts
+++ b/packages/oss-console/src/components/Breadcrumbs/async/executionContext.test.ts
@@ -1,0 +1,78 @@
+import { ResourceType } from '../../../models/Common/types';
+import { Execution } from '../../../models/Execution/types';
+import {
+  isExecutionTaskOrWorkflow,
+  getTaskOrWorkflowName,
+  getTaskOrWorkflowVersion,
+} from './executionContext';
+
+const makeExecution = (overrides: {
+  launchPlanResourceType: ResourceType;
+  launchPlanName: string;
+  launchPlanVersion: string;
+  workflowIdName: string;
+  workflowIdVersion: string;
+}): Execution =>
+  ({
+    spec: {
+      launchPlan: {
+        resourceType: overrides.launchPlanResourceType,
+        name: overrides.launchPlanName,
+        version: overrides.launchPlanVersion,
+      },
+    },
+    closure: {
+      workflowId: {
+        name: overrides.workflowIdName,
+        version: overrides.workflowIdVersion,
+      },
+    },
+  }) as unknown as Execution;
+
+describe('executionContext helpers', () => {
+  const taskExecution = makeExecution({
+    launchPlanResourceType: ResourceType.TASK,
+    launchPlanName: 'my-task',
+    launchPlanVersion: 'task-v1',
+    workflowIdName: 'my-workflow',
+    workflowIdVersion: 'wf-v1',
+  });
+
+  const workflowExecution = makeExecution({
+    launchPlanResourceType: ResourceType.WORKFLOW,
+    launchPlanName: 'my-launch-plan',
+    launchPlanVersion: 'lp-v1',
+    workflowIdName: 'my-workflow',
+    workflowIdVersion: 'wf-v1',
+  });
+
+  describe('isExecutionTaskOrWorkflow', () => {
+    it('returns TASK when launchPlan resourceType is TASK', () => {
+      expect(isExecutionTaskOrWorkflow(taskExecution)).toBe(ResourceType.TASK);
+    });
+
+    it('returns WORKFLOW when launchPlan resourceType is WORKFLOW', () => {
+      expect(isExecutionTaskOrWorkflow(workflowExecution)).toBe(ResourceType.WORKFLOW);
+    });
+  });
+
+  describe('getTaskOrWorkflowName', () => {
+    it('returns launchPlan name for task executions', () => {
+      expect(getTaskOrWorkflowName(taskExecution)).toBe('my-task');
+    });
+
+    it('returns workflowId name for workflow executions', () => {
+      expect(getTaskOrWorkflowName(workflowExecution)).toBe('my-workflow');
+    });
+  });
+
+  describe('getTaskOrWorkflowVersion', () => {
+    it('returns launchPlan version for task executions', () => {
+      expect(getTaskOrWorkflowVersion(taskExecution)).toBe('task-v1');
+    });
+
+    it('returns workflowId version for workflow executions', () => {
+      expect(getTaskOrWorkflowVersion(workflowExecution)).toBe('wf-v1');
+    });
+  });
+});

--- a/packages/oss-console/src/components/Breadcrumbs/async/executionContext.ts
+++ b/packages/oss-console/src/components/Breadcrumbs/async/executionContext.ts
@@ -49,18 +49,24 @@ const getExecutionData = async (projectId: string, domainId: string, executionId
   return executionData;
 };
 
-const isExecutionTaskOrWorkflow = (executionData: Execution) => {
+export const isExecutionTaskOrWorkflow = (executionData: Execution) => {
   return executionData.spec.launchPlan.resourceType === ResourceType.TASK
     ? ResourceType.TASK
     : ResourceType.WORKFLOW;
 };
 
-const getTaskOrWorkflowName = (executionData: Execution): string => {
-  return executionData.spec.launchPlan.name;
+export const getTaskOrWorkflowName = (executionData: Execution): string => {
+  if (isExecutionTaskOrWorkflow(executionData) === ResourceType.TASK) {
+    return executionData.spec.launchPlan.name;
+  }
+  return executionData.closure.workflowId.name;
 };
 
-const getTaskOrWorkflowVersion = (executionData: Execution): string => {
-  return executionData.spec.launchPlan.version;
+export const getTaskOrWorkflowVersion = (executionData: Execution): string => {
+  if (isExecutionTaskOrWorkflow(executionData) === ResourceType.TASK) {
+    return executionData.spec.launchPlan.version;
+  }
+  return executionData.closure.workflowId.version;
 };
 
 const getExecutionValue = (location: Location) => {


### PR DESCRIPTION
# TL;DR
Fixes breadcrumbs showing launch plan name instead of workflow name for workflow executions.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
`getTaskOrWorkflowName` and `getTaskOrWorkflowVersion` in the breadcrumb execution context always returned the launch plan name/version, regardless of whether the execution was for a task or workflow. For workflow executions this is incorrect — the breadcrumb should display the workflow name from `closure.workflowId`.

Now both functions check the resource type via `isExecutionTaskOrWorkflow` and return `workflowId.name`/`workflowId.version` for workflows, falling back to `spec.launchPlan` for tasks.

Also exported the three helper functions and added unit tests covering both task and workflow execution paths.

## Tracking Issue

## Follow-up issue