### PR TITLE
plugin: Add SBOM to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@commitlint/cli": "^17.3.0",
     "@commitlint/config-conventional": "^17.3.0",
+    "@cyclonedx/webpack-plugin": "^4.0.1",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/exec": "^6.0.3",

--- a/website/console/webpack.config.ts
+++ b/website/console/webpack.config.ts
@@ -9,6 +9,7 @@ import HTMLWebpackPlugin, { Options as HtmlWebpackOptions } from 'html-webpack-p
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 const CopyPlugin = require('copy-webpack-plugin');
+const { CycloneDxWebpackPlugin } = require('@cyclonedx/webpack-plugin');
 const nodeExternals = require('webpack-node-externals');
 const { merge } = require('webpack-merge');
 /**
@@ -227,6 +228,10 @@ module.exports = (_env: any, argv: { mode: 'production' | 'development' }) => {
         includeAliases: ['http', 'https', 'stream', 'zlib', 'Buffer'],
       }),
       getDefinePlugin(false),
+      new CycloneDxWebpackPlugin({
+        outputLocation: './cyclonedx',
+        includeWellknown: false,
+      }),
       new HTMLWebpackPlugin(htmlWebpackOptions),
     ],
 


### PR DESCRIPTION
# TL;DR

Add the SBOM to the build, which is useful for vulnerability scanners. Reference PR, which may be helpful/interesting: https://github.com/Graylog2/graylog2-server/pull/18159 Also https://github.com/aquasecurity/trivy/discussions/6263

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [x] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Webpack-only build artifacts lose package metadata needed by vulnerability scanners. The PR uses the CycloneDX SBOM webpack plugin. See https://github.com/aquasecurity/trivy/discussions/6263

## Tracking Issue
n/a

